### PR TITLE
Enum variant as ValueExpr

### DIFF
--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -49,10 +49,6 @@ impl<M: Memory> Machine<M> {
                     provenance: None,
                 })
             }
-            Constant::Variant { idx, data } => {
-                let data = self.eval_constant(data)?;
-                Value::Variant { idx, data }
-            },
         })
     }
 
@@ -84,6 +80,16 @@ impl<M: Memory> Machine<M> {
         let (val, _) = self.eval_value(expr)?;
         data.write_subslice_at_index(offset.bytes(), expr_ty.encode::<M>(val));
         ret((union_ty.decode(data).unwrap(), union_ty))
+    }
+}
+```
+
+### Enums
+
+```rust
+impl<M: Memory> Machine<M> {
+    fn eval_value(&mut self, ValueExpr::Variant { enum_ty, idx, data } : ValueExpr) -> NdResult<(Value<M>, Type)> {
+        ret((Value::Variant { idx, data: self.eval_value(data)?.0 }, enum_ty))
     }
 }
 ```

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -32,6 +32,17 @@ pub enum ValueExpr {
         union_ty: Type,
     },
 
+    /// A variant of an enum type.
+    Variant {
+        /// The variant index.
+        idx: Int,
+        /// The `ValueExpr` for the variant.
+        #[specr::indirection]
+        data: ValueExpr,
+        /// The enum type, needs to be `Type::Enum``.
+        enum_ty: Type,
+    },
+
     /// Load a value from memory.
     Load {
         /// The place to load from.
@@ -75,13 +86,6 @@ pub enum Constant {
     FnPointer(FnName),
     /// A constant pointer, not pointing into any allocation.
     InvalidPointer(Address),
-    /// A variant of a sum type, used for enums.
-    // TODO Variant shouldn't be a Constant, but rather a ValueExpr.
-    Variant {
-        idx: Int,
-        #[specr::indirection]
-        data: Constant,
-    },
 }
 
 pub enum UnOpInt {

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -79,7 +79,6 @@ fn fmt_constant(c: Constant) -> FmtExpr {
                 FmtExpr::Atomic(format!("invalid_ptr({addr})"))
             }
         }
-        Constant::Variant { .. } => panic!("enums are unsupported!"),
     }
 }
 
@@ -105,6 +104,15 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             let union_ty = fmt_type(union_ty, comptypes).to_string();
             let expr = fmt_value_expr(expr.extract(), comptypes).to_string();
             FmtExpr::NonAtomic(format!("{union_ty} {{ field{field}: {expr} }}"))
+        }
+        ValueExpr::Variant {
+            idx,
+            data,
+            enum_ty,
+        } => {
+            let enum_ty = fmt_type(enum_ty, comptypes).to_string();
+            let expr = fmt_value_expr(data.extract(), comptypes).to_string();
+            FmtExpr::NonAtomic(format!("{enum_ty} {{ variant{idx}: {expr} }}"))
         }
         ValueExpr::Load {
             source,

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -87,13 +87,6 @@ fn get_comptype_index(ty: CompType, comptypes: &mut Vec<CompType>) -> CompTypeIn
         None => {
             let n = comptypes.len();
             comptypes.push(ty);
-
-            if let Type::Enum { variants, .. } = ty.0 {
-                variants.iter().for_each(|v| {
-                    get_comptype_index(CompType(v), comptypes);
-                });
-            }
-
             n
         }
     };

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -121,7 +121,7 @@ pub(super) fn fmt_comptypes(mut comptypes: Vec<CompType>) -> String {
 
 fn fmt_comptype(i: CompTypeIndex, t: CompType, comptypes: &mut Vec<CompType>) -> String {
     let (keyword, size, align) = match t.0 {
-        Type::Tuple { fields, size, align } => ("tuple", size, align),
+        Type::Tuple { fields: _, size, align } => ("tuple", size, align),
         Type::Union {
             size,
             align,

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -5,7 +5,7 @@ pub(super) fn fmt_type(t: Type, comptypes: &mut Vec<CompType>) -> FmtExpr {
         Type::Int(int_ty) => FmtExpr::Atomic(fmt_int_type(int_ty)),
         Type::Ptr(ptr_ty) => fmt_ptr_type(ptr_ty),
         Type::Bool => FmtExpr::Atomic(format!("bool")),
-        Type::Tuple { .. } | Type::Union { .. } => {
+        Type::Tuple { .. } | Type::Union { .. } | Type::Enum { .. } => {
             let comp_ty = CompType(t);
             let comptype_index = get_comptype_index(comp_ty, comptypes);
             FmtExpr::Atomic(fmt_comptype_index(comptype_index))
@@ -14,7 +14,6 @@ pub(super) fn fmt_type(t: Type, comptypes: &mut Vec<CompType>) -> FmtExpr {
             let elem = fmt_type(elem.extract(), comptypes).to_string();
             FmtExpr::Atomic(format!("[{elem}; {count}]"))
         }
-        Type::Enum { .. } => panic!("enums are unsupported!"),
     }
 }
 
@@ -69,7 +68,7 @@ fn fmt_layout(layout: Layout) -> String {
 // composite types
 /////////////////////
 
-// A "composite" type is a union or tuple (enums aren't yet supported).
+// A "composite" type is a union or tuple.
 // Composite types will be printed separately above the functions, as inlining them would be hard to read.
 // During formatting, the list of composite types we encounter will be stored in `comptypes`.
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -88,6 +87,13 @@ fn get_comptype_index(ty: CompType, comptypes: &mut Vec<CompType>) -> CompTypeIn
         None => {
             let n = comptypes.len();
             comptypes.push(ty);
+
+            if let Type::Enum { variants, .. } = ty.0 {
+                variants.iter().for_each(|v| {
+                    get_comptype_index(CompType(v), comptypes);
+                });
+            }
+
             n
         }
     };
@@ -121,32 +127,58 @@ pub(super) fn fmt_comptypes(mut comptypes: Vec<CompType>) -> String {
 }
 
 fn fmt_comptype(i: CompTypeIndex, t: CompType, comptypes: &mut Vec<CompType>) -> String {
-    let (keyword, fields, opt_chunks, size, align) = match t.0 {
-        Type::Tuple { fields, size, align } => ("tuple", fields, None, size, align),
+    let (keyword, size, align) = match t.0 {
+        Type::Tuple { fields, size, align } => ("tuple", size, align),
         Type::Union {
-            chunks,
-            fields,
             size,
             align,
-        } => ("union", fields, Some(chunks), size, align),
+            ..
+        } => ("union", size, align),
+        Type::Enum {
+            size,
+            align,
+            ..
+        } => ("enum", size, align),
         _ => panic!("not a supported composite type!"),
     };
     let ct = fmt_comptype_index(i).to_string();
     let size = size.bytes();
     let align = align.bytes();
     let mut s = format!("{keyword} {ct} ({size} bytes, aligned {align} bytes) {{\n");
+    match t.0 {
+        Type::Tuple { fields, .. } => s += &fmt_comptype_fields(fields, comptypes),
+        Type::Union { fields, chunks, .. } => {
+            s += &fmt_comptype_fields(fields, comptypes);
+            s += &fmt_comptype_chunks(chunks);
+        },
+        Type::Enum { variants, .. } => {
+            variants.iter().enumerate().for_each(|(idx, v)| {
+                let typ = fmt_type(v, comptypes).to_string();
+                s += &format!("  Variant {idx}: {typ}");
+            });
+        },
+        _ => panic!("not a supported composite type!"),
+    };
+    s += "}\n\n";
+    s
+}
+
+fn fmt_comptype_fields(fields: Fields, comptypes: &mut Vec<CompType>) -> String {
+    let mut s = String::new();
     for (offset, f) in fields {
         let offset = offset.bytes();
         let ty = fmt_type(f, comptypes).to_string();
         s += &format!("  at byte {offset}: {ty},\n");
     }
-    if let Some(chunks) = opt_chunks {
-        for (offset, size) in chunks {
-            let offset = offset.bytes();
-            let size = size.bytes();
-            s += &format!("  chunk(at={offset}, size={size}),\n");
-        }
+    s
+}
+
+fn fmt_comptype_chunks(chunks: List<(Size, Size)>) -> String {
+    let mut s = String::new();
+    for (offset, size) in chunks {
+        let offset = offset.bytes();
+        let size = size.bytes();
+        s += &format!("  chunk(at={offset}, size={size}),\n");
     }
-    s += "}\n\n";
     s
 }


### PR DESCRIPTION
Moves enum variant expressions from Constant to ValueExpr in order to allow other sources than constants for the fields (including now tuples). Also adds miniutil formatting for enums because it broke with the move and I could fix it (but not test it).