### PR TITLE
Enum memory representation and well-formedness

### DIFF
--- a/spec/lang/representation.md
+++ b/spec/lang/representation.md
@@ -243,7 +243,7 @@ fn compute_discriminant<M: Memory>(bytes: List<AbstractByte<M::Provenance>>, dis
         Discriminator::Known(val) => Some(val),
         Discriminator::Invalid => None,
         Discriminator::Unknown { offset, children, fallback } => {
-            let AbstractByte::Init(val, _) = bytes[offset]
+            let AbstractByte::Init(val, _) = bytes[offset.bytes()]
                 else { return None };
             let next_discriminator = children.get(val).unwrap_or(fallback);
             compute_discriminant::<M>(bytes, next_discriminator)
@@ -274,7 +274,7 @@ impl Type {
         // write tag afterwards into the encoded bytes. This is fine as we don't allow
         // encoded data and the tag to overlap at the moment.
         for (offset, value) in tagger.iter() {
-            bytes.set(offset, AbstractByte::Init(value, None));
+            bytes.set(offset.bytes(), AbstractByte::Init(value, None));
         }
         bytes
     }

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -105,13 +105,14 @@ fn check_abi_compatibility(
             caller_chunks == callee_chunks &&
             caller_size == callee_size &&
             caller_align == callee_align,
-        (Type::Enum { variants: caller_variants, tag_encoding: caller_encoding, size: caller_size, align: caller_align },
-         Type::Enum { variants: callee_variants, tag_encoding: callee_encoding, size: callee_size, align: callee_align }) =>
+        (Type::Enum { variants: caller_variants, discriminator: caller_discriminator, size: caller_size, align: caller_align },
+         Type::Enum { variants: callee_variants, discriminator: callee_discriminator, size: callee_size, align: callee_align }) =>
             caller_variants.len() == callee_variants.len() &&
-            caller_variants.zip(callee_variants).all(|(caller_field, callee_field)|
-                check_abi_compatibility(caller_field, callee_field)
+            caller_variants.zip(callee_variants).all(|(caller_variant, callee_variant)|
+                check_abi_compatibility(caller_variant.ty, callee_variant.ty) &&
+                caller_variant.tagger == callee_variant.tagger
             ) &&
-            caller_encoding == callee_encoding &&
+            caller_discriminator == callee_discriminator &&
             caller_size == callee_size &&
             caller_align == callee_align,
         // Different kind of type, definitely incompatible.

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -84,7 +84,18 @@ pub type Fields = List<(Offset, Type)>;
 /// We leave the details of enum tags to the future.
 /// (We might want to extend the "variants" field of `Enum` to also have a
 /// discriminant for each variant. We will see.)
-pub enum TagEncoding { /* ... */ }
+pub struct TagEncoding {
+    discriminator: Discriminator,
+    tagger: List<Map<Int, u8>>, // TODO: move to Variant struct
+}
+
+pub enum Discriminator {
+    Known(Int),
+    Unknown { // Branch
+        offset: Int,
+        children: Map<u8, Discriminator>,
+    },
+}
 ```
 
 Note that references have no lifetime, since the lifetime is irrelevant for their representation in memory!

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -98,8 +98,8 @@ pub enum Discriminator {
     /// Tag decoding failed, there is no valid discriminant.
     Invalid,
     /// We don't know the discriminant, so we branch on the value of a specific byte.
-    /// The fallback is for readability, as we often are only interested in a couple
-    /// of values.
+    /// The fallback keeps the representation more compact, as we often are only
+    /// interested in a couple of values and we don't want to always have 256 branches.
     Unknown {
         offset: Offset,
         #[specr::indirection]

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -87,8 +87,7 @@ pub struct Variant {
     /// MUST NOT touch any bytes written by the actual type of the variant and vice
     /// versa. This is because we allow references/pointers to (enum) fields which
     /// should be able to dereference without having to deal with the tag.
-    /// FIXME(essickmango): Int should be `Offset`
-    pub tagger: Map<Int, u8>,
+    pub tagger: Map<Offset, u8>,
 }
 
 /// The decision tree that computes the discriminant out of the tag for a specific
@@ -101,9 +100,8 @@ pub enum Discriminator {
     /// We don't know the discriminant, so we branch on the value of a specific byte.
     /// The fallback is for readability, as we often are only interested in a couple
     /// of values.
-    /// FIXME(essickmango): change offset to `Offset`
     Unknown {
-        offset: Int,
+        offset: Offset,
         #[specr::indirection]
         fallback: Discriminator,
         children: Map<u8, Discriminator>,

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -132,7 +132,7 @@ impl Discriminator {
             Discriminator::Known(variant) => ensure(variant >= Int::ZERO && variant < n_variants),
             Discriminator::Invalid => ret(()),
             Discriminator::Unknown { offset, fallback, children } => {
-                ensure(offset < size.bytes())?;
+                ensure(offset < size)?;
                 fallback.check_wf::<T>(size, n_variants)?;
                 for discriminator in children.values() {
                     discriminator.check_wf::<T>(size, n_variants)?;

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -117,7 +117,7 @@ impl Type {
                 }
 
                 // check that all variants reached by the discriminator are valid and
-                // that it never accesses out-of-bounds area.
+                // that it never performs out-of-bounds accesses.
                 discriminator.check_wf::<T>(size, variants.len())?;
             }
         }

--- a/tooling/minitest/src/tests/atomic.rs
+++ b/tooling/minitest/src/tests/atomic.rs
@@ -64,7 +64,7 @@ fn atomic_store_arg_type_pow() {
     let locals = [<[u8; 3]>::get_type()];
 
     let ptr_ty = raw_ptr_ty();
-    let arr = const_array(&[
+    let arr = array(&[
         const_int::<u8>(0),
         const_int::<u8>(1),
         const_int::<u8>(69),
@@ -92,7 +92,7 @@ fn atomic_store_arg_type_size() {
     let locals = [<[u64; 2]>::get_type()];
 
     let ptr_ty = raw_ptr_ty();
-    let arr = const_array(&[
+    let arr = array(&[
         const_int::<u64>(0),
         const_int::<u64>(1),
     ], <u64>::get_type());
@@ -189,7 +189,7 @@ fn atomic_load_arg_type() {
         storage_live(0),
         Terminator::CallIntrinsic {
             intrinsic: Intrinsic::AtomicLoad,
-            arguments: list!(const_unit()),
+            arguments: list!(unit()),
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1)))
         }

--- a/tooling/minitest/src/tests/atomic_fetch.rs
+++ b/tooling/minitest/src/tests/atomic_fetch.rs
@@ -104,7 +104,7 @@ fn atomic_fetch_ret_ty() {
 
     let ptr_ty = raw_ptr_ty();
 
-    let const_arr = const_array(&[const_int::<u8>(0); 3], <u8>::get_type());
+    let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type());
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/call.rs
+++ b/tooling/minitest/src/tests/call.rs
@@ -15,7 +15,7 @@ fn call_success() {
         storage_live(0),
         Terminator::Call {
             callee: fn_ptr(1),
-            arguments: list![by_value(const_unit())],
+            arguments: list![by_value(unit())],
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1))),
         }
@@ -36,7 +36,7 @@ fn call_non_exist() {
         storage_live(0),
         Terminator::Call {
             callee: fn_ptr(1),
-            arguments: list![by_value(const_unit())],
+            arguments: list![by_value(unit())],
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1))),
         }
@@ -99,7 +99,7 @@ fn call_ret_abi() {
         storage_live(0),
         Terminator::Call {
             callee: fn_ptr(1),
-            arguments: list![by_value(const_unit())],
+            arguments: list![by_value(unit())],
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1))),
         }

--- a/tooling/minitest/src/tests/compare_exchange.rs
+++ b/tooling/minitest/src/tests/compare_exchange.rs
@@ -95,7 +95,7 @@ fn compare_exchange_ret_type() {
 
     let ptr_ty = raw_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
-    let const_arr = const_array(&[const_int::<u8>(0); 3], <u8>::get_type() );
+    let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type() );
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -1,0 +1,105 @@
+use crate::*;
+
+/// Ill-formed: the only variant has size 0, but the enum is size 1
+#[test]
+fn ill_sized_enum_variant() {
+    let enum_ty = enum_ty(&[enum_variant(<()>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let locals = &[enum_ty];
+    let stmts = &[];
+    let prog = small_program(locals, stmts);
+    assert_ill_formed(prog);
+}
+
+/// Ill-formed: the two variants have different sizes
+#[test]
+fn inconsistently_sized_enum_variants() {
+    let enum_ty = enum_ty(&[
+            enum_variant(<()>::get_type(), &[(size(1), 2)]), // size 0
+            enum_variant(<bool>::get_type(), &[]),           // size 1
+        ], Discriminator::Invalid, size(1), align(1));       // size 1
+    let locals = &[enum_ty];
+    let stmts = &[];
+    let prog = small_program(locals, stmts);
+    assert_ill_formed(prog);
+}
+
+/// Ill-formed: no variants but discriminator returns variant 1
+#[test]
+fn ill_formed_discriminator() {
+    let enum_ty = enum_ty(&[], Discriminator::Known(1.into()), size(0), align(1));
+    let locals = &[enum_ty];
+    let stmts = &[];
+    let prog = small_program(locals, stmts);
+    assert_ill_formed(prog);
+}
+
+/// Works: simple roundtrip for both variants of an enum like Option<bool>
+#[test]
+fn simple_two_variant_works() {
+    let bool_var_ty = enum_variant(Type::Bool, &[]);
+    let empty_var_data_ty = tuple_ty(&[], size(1), align(1)); // unit with size 1
+    let empty_var_ty = enum_variant(empty_var_data_ty, &[(size(0), 2)]);
+    let discriminator = Discriminator::Unknown {
+        offset: size(0),
+        fallback: GcCow::new(Discriminator::Invalid),
+        children: [
+            (0, Discriminator::Known(0.into())),
+            (1, Discriminator::Known(0.into())),
+            (2, Discriminator::Known(1.into())),
+        ].into_iter().collect()
+    };
+    let enum_ty = enum_ty(&[bool_var_ty, empty_var_ty], discriminator, size(1), align(1));
+    
+    let locals = &[enum_ty];
+    let statements = &[
+        storage_live(0),
+        assign(local(0), variant(1, tuple(&[], empty_var_data_ty), enum_ty)),
+        assign(local(0), load(local(0))),
+        assign(local(0), variant(0, const_bool(false), enum_ty)),
+        assign(local(0), load(local(0))),
+        storage_dead(0)
+    ];
+    let prog = small_program(locals, statements);
+    assert_stop(prog)
+}
+
+/// UB: Loading an uninhabited enum is UB as such a value is impossible to produce
+/// It is the discriminant computation that fails, as we start off with Discriminator::Invalid.
+#[test]
+fn loading_uninhabited_enum_is_ub() {
+    let enum_ty = enum_ty(&[], Discriminator::Invalid, size(0), align(1));
+    let locals = &[enum_ty];
+    let stmts = &[
+        storage_live(0),
+        assign(local(0), load(local(0))), // UB here.
+    ];
+    let prog = small_program(locals, stmts);
+    assert_ub(prog, "load at type Enum { variants: List([]), discriminator: Invalid, size: Size(0 bytes), align: Align(1 bytes) } but the data in memory violates the validity invariant");
+}
+
+/// Ill-formed: trying to build a variant value of an uninhabited enum
+#[test]
+fn ill_formed_variant_constant() {
+    let enum_ty = enum_ty(&[], Discriminator::Invalid, size(0), align(1));
+    let locals = &[enum_ty];
+    let stmts = &[
+        storage_live(0),
+        assign(local(0), variant(0, unit(), enum_ty)), // ill-formed here
+    ];
+    let prog = small_program(locals, stmts);
+    assert_ill_formed(prog);
+}
+
+/// Ill-formed: The data of the variant value does not match the type
+#[test]
+fn ill_formed_variant_constant_data() {
+    let enum_ty = enum_ty(&[enum_variant(<u8>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let locals = &[enum_ty];
+    let stmts = &[
+        storage_live(0),
+        assign(local(0), variant(1, unit(), enum_ty)), // ill-formed here
+    ];
+    let prog = small_program(locals, stmts);
+    assert_ill_formed(prog);
+}
+

--- a/tooling/minitest/src/tests/invalid_offset.rs
+++ b/tooling/minitest/src/tests/invalid_offset.rs
@@ -15,7 +15,7 @@ fn invalid_offset() {
         storage_live(0),
         storage_live(1),
         assign(local(0),
-            const_array(&[
+            array(&[
                 const_int::<i32>(42),
                 const_int::<i32>(24),
             ], <i32>::get_type()),

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod concurrency;
 mod data_race;
 mod dereferenceable;
 mod div_zero;
+mod enum_representation;
 mod heap_intrinsics;
 mod ill_formed;
 mod invalid_offset;

--- a/tooling/minitest/src/tests/print.rs
+++ b/tooling/minitest/src/tests/print.rs
@@ -20,7 +20,7 @@ fn print_fail() {
     let locals = [];
 
     let b0 = block!(
-        print(const_unit(), 1), // tuples cannot be printed
+        print(unit(), 1), // tuples cannot be printed
     );
     let b1 = block!(exit());
 

--- a/tooling/minitest/src/tests/zst.rs
+++ b/tooling/minitest/src/tests/zst.rs
@@ -65,3 +65,16 @@ fn zst_tuple2() {
     dump_program(p);
     assert_stop(p);
 }
+
+#[test]
+fn zst_enum() {
+    let empty_var_ty = enum_variant(<()>::get_type(), &[]);
+    let locals = &[enum_ty(&[empty_var_ty], Discriminator::Known(Int::from(0)), size(0), Align::ONE)];
+    let stmts = &[
+        storage_live(0),
+        assign(local(0), load(local(0))),
+    ];
+    let p = small_program(locals, stmts);
+    dump_program(p);
+    assert_stop(p);
+}

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -27,6 +27,10 @@ pub fn const_array(args: &[ValueExpr], elem_ty: Type) -> ValueExpr {
     ValueExpr::Tuple(args.iter().cloned().collect(), ty)
 }
 
+pub fn const_variant(idx: impl Into<Int>, data: ValueExpr, enum_ty: Type) -> ValueExpr {
+    ValueExpr::Variant { idx: idx.into(), data: GcCow::new(data), enum_ty}
+}
+
 // Returns () or [].
 pub fn const_unit() -> ValueExpr {
     ValueExpr::Tuple(Default::default(), <()>::get_type())

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -14,7 +14,7 @@ pub fn const_bool(b: bool) -> ValueExpr {
     ValueExpr::Constant(Constant::Bool(b), Type::Bool)
 }
 
-pub fn const_tuple(args: &[ValueExpr], ty: Type) -> ValueExpr {
+pub fn tuple(args: &[ValueExpr], ty: Type) -> ValueExpr {
     let Type::Tuple { fields, .. } = ty else {
         panic!("const_tuple received non-tuple type!");
     };
@@ -22,17 +22,17 @@ pub fn const_tuple(args: &[ValueExpr], ty: Type) -> ValueExpr {
     ValueExpr::Tuple(args.iter().cloned().collect(), ty)
 }
 
-pub fn const_array(args: &[ValueExpr], elem_ty: Type) -> ValueExpr {
+pub fn array(args: &[ValueExpr], elem_ty: Type) -> ValueExpr {
     let ty = array_ty(elem_ty, args.len());
     ValueExpr::Tuple(args.iter().cloned().collect(), ty)
 }
 
-pub fn const_variant(idx: impl Into<Int>, data: ValueExpr, enum_ty: Type) -> ValueExpr {
+pub fn variant(idx: impl Into<Int>, data: ValueExpr, enum_ty: Type) -> ValueExpr {
     ValueExpr::Variant { idx: idx.into(), data: GcCow::new(data), enum_ty}
 }
 
 // Returns () or [].
-pub fn const_unit() -> ValueExpr {
+pub fn unit() -> ValueExpr {
     ValueExpr::Tuple(Default::default(), <()>::get_type())
 }
 

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -62,3 +62,19 @@ pub fn array_ty(elem: Type, count: impl Into<Int>) -> Type {
         count: count.into(),
     }
 }
+
+pub fn enum_variant(ty: Type, tagger: &[(Offset, u8)]) -> Variant {
+    Variant {
+        ty,
+        tagger: tagger.iter().copied().collect()
+    }
+}
+
+pub fn enum_ty(variants: &[Variant], discriminator: Discriminator, size: Size, align: Align) -> Type {
+    Type::Enum {
+        variants: variants.iter().copied().collect(),
+        discriminator,
+        size,
+        align,
+    }
+}

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -146,7 +146,7 @@ fn fmt_comptype(i: CompTypeIndex, t: CompType, comptypes: &mut Vec<CompType>) ->
         },
         Type::Enum { variants, .. } => {
             variants.iter().enumerate().for_each(|(idx, v)| {
-                let typ = fmt_type(v, comptypes).to_string();
+                let typ = fmt_type(v.ty, comptypes).to_string();
                 s += &format!("  Variant {idx}: {typ}");
             });
         },


### PR DESCRIPTION
Implements the enum memory representation and discriminant using a decision tree for decoding and tagger for encoding.

Also adds some well-formedness. Both an invalid discriminant and values of uninhabited enums are not allowed (see https://doc.rust-lang.org/reference/behavior-considered-undefined.html).