### PR TITLE
Offset type alias

### DIFF
--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -341,7 +341,7 @@ pub struct Global {
     /// Cross-references pointing to other global allocations,
     /// together with an offset, expressing where this allocation should put the pointer.
     /// Note that the pointers created due to relocations overwrite the data given by `bytes`.
-    pub relocations: List<(Size, Relocation)>,
+    pub relocations: List<(Offset, Relocation)>,
     /// The alignment with which this global shall be allocated.
     pub align: Align,
 }
@@ -351,6 +351,6 @@ pub struct Relocation {
     /// The name of the global allocation we are pointing into.
     pub name: GlobalName,
     /// The offset within that allocation.
-    pub offset: Size,
+    pub offset: Offset,
 }
 ```

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -47,7 +47,7 @@ pub enum Type {
         /// preserved, and data between chunks is lost (like padding in a struct).
         /// This is necessary to model the behavior of some `repr(C)` unions, see
         /// <https://github.com/rust-lang/unsafe-code-guidelines/issues/156> for details.
-        chunks: List<(Size, Size)>, // (offset, length) for each chunk.
+        chunks: List<(Offset, Size)>,
         /// The total size of the union, can indicate padding after the last chunk.
         size: Size,
         /// Total alignment of the union. Due to `repr(packed)` and `repr(align)`,
@@ -79,7 +79,7 @@ pub struct IntType {
     pub size: Size,
 }
 
-pub type Fields = List<(Size, Type)>; // (offset, type) pair for each field
+pub type Fields = List<(Offset, Type)>;
 
 /// We leave the details of enum tags to the future.
 /// (We might want to extend the "variants" field of `Enum` to also have a

--- a/spec/mem/basic.md
+++ b/spec/mem/basic.md
@@ -204,7 +204,7 @@ impl<T: Target> BasicMemory<T> {
             throw_ub!("out-of-bounds memory access");
         }
         // All is good!
-        ret(Some((id, Size::from_bytes(offset_in_alloc).unwrap())))
+        ret(Some((id, Offset::from_bytes(offset_in_alloc).unwrap())))
     }
 }
 

--- a/spec/prelude/main.md
+++ b/spec/prelude/main.md
@@ -9,6 +9,9 @@ pub use libspecr::prelude::*;
 /// Make the two main modules available.
 pub use crate::{lang, mem};
 
+/// When a non-negative integer is used as an offset into an allocation or type
+/// rather than to describe the size of an object or type, use this type instead
+/// of `Size` for extra clarity.
 pub type Offset = Size;
 
 /// All operations are fallible, so they return `Result`.  If they fail, that

--- a/spec/prelude/main.md
+++ b/spec/prelude/main.md
@@ -9,6 +9,8 @@ pub use libspecr::prelude::*;
 /// Make the two main modules available.
 pub use crate::{lang, mem};
 
+pub type Offset = Size;
+
 /// All operations are fallible, so they return `Result`.  If they fail, that
 /// means the program caused UB or put the machine to a halt.
 pub type Result<T=()> = std::result::Result<T, TerminationInfo>;

--- a/tooling/minimize/src/chunks.rs
+++ b/tooling/minimize/src/chunks.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// Calculates the Chunks for a union type.
 /// This works roughly as described here:
 /// https://github.com/rust-lang/unsafe-code-guidelines/issues/354#issuecomment-1297545313
-pub fn calc_chunks(fields: Fields, size: Size) -> List<(Size, Size)> {
+pub fn calc_chunks(fields: Fields, size: Size) -> List<(Offset, Size)> {
     let s = size.bytes().try_to_usize().unwrap();
     let mut markers = vec![false; s];
     for (offset, ty) in fields {
@@ -24,7 +24,7 @@ pub fn calc_chunks(fields: Fields, size: Size) -> List<(Size, Size)> {
                 current_chunk_start = Some(i);
             }
             (false, Some(s)) => {
-                let start = Size::from_bytes(*s).unwrap();
+                let start = Offset::from_bytes(*s).unwrap();
                 let length = Size::from_bytes(i - *s).unwrap();
                 chunks.push((start, length));
                 current_chunk_start = None;

--- a/tooling/minimize/src/constant.rs
+++ b/tooling/minimize/src/constant.rs
@@ -66,7 +66,7 @@ fn translate_const_uneval<'cx, 'tcx>(
         .eval_to_allocation_raw(rs::ParamEnv::empty().and(cid))
         .unwrap();
     let name = translate_alloc_id(alloc.alloc_id, fcx);
-    let offset = Size::ZERO;
+    let offset = Offset::ZERO;
 
     let rel = Relocation { name, offset };
     relocation_to_value_expr(rel, ty, fcx)

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -38,7 +38,7 @@ pub fn raw_ptr_ty() -> Type {
     Type::Ptr(PtrType::Raw)
 }
 
-pub fn tuple_ty(f: &[(Size, Type)], size: Size, align: Align) -> Type {
+pub fn tuple_ty(f: &[(Offset, Type)], size: Size, align: Align) -> Type {
     Type::Tuple {
         fields: f.iter().copied().collect(),
         size,
@@ -46,7 +46,7 @@ pub fn tuple_ty(f: &[(Size, Type)], size: Size, align: Align) -> Type {
     }
 }
 
-pub fn union_ty(f: &[(Size, Type)], size: Size, align: Align) -> Type {
+pub fn union_ty(f: &[(Offset, Type)], size: Size, align: Align) -> Type {
     let chunks = list![(Size::ZERO, size)];
     Type::Union {
         fields: f.iter().copied().collect(),

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -166,7 +166,7 @@ fn fmt_comptype_fields(fields: Fields, comptypes: &mut Vec<CompType>) -> String 
     s
 }
 
-fn fmt_comptype_chunks(chunks: List<(Size, Size)>) -> String {
+fn fmt_comptype_chunks(chunks: List<(Offset, Size)>) -> String {
     let mut s = String::new();
     for (offset, size) in chunks {
         let offset = offset.bytes();


### PR DESCRIPTION
Introduces an offset type alias so we don't have a list of fields that is of type `List<(Size, Size)>` but `List<(Offset, Size)>`.

Changed all instances of `Size` to `Offset` in the MiniRust spec, miniutil and minimizer where applicable.