### PR TITLE
Enum discriminant

### DIFF
--- a/spec/lang/representation.md
+++ b/spec/lang/representation.md
@@ -240,7 +240,7 @@ fn decode_discriminant<M: Memory>(accessor: &mut dyn FnMut(Int) -> Result<Abstra
     match discriminator {
         Discriminator::Known(val) => ret(Some(val)),
         Discriminator::Invalid => ret(None),
-        Discriminator::Unknown { offset, children, fallback } => {
+        Discriminator::Branch { offset, children, fallback } => {
             let AbstractByte::Init(val, _) = accessor(offset.bytes())?
                 else { return ret(None) };
             let next_discriminator = children.get(val).unwrap_or(fallback);

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -102,7 +102,7 @@ impl<M: Memory> Machine<M> {
     fn eval_value(&mut self, ValueExpr::Discriminant { place } : ValueExpr) -> NdResult<(Value<M>, Type)> {
         // Get the place of the enum and its information.
         let (place, ty) = self.eval_place(place)?;
-        let Type::Enum { size, align, discriminator, .. } = ty else {
+        let Type::Enum { size, align, discriminator, discriminant_ty, .. } = ty else {
             throw_ill_formed!();
         };
 
@@ -112,9 +112,8 @@ impl<M: Memory> Machine<M> {
         let Some(discriminant) = decode_discriminant::<M>(bytes, discriminator) else {
             throw_ub!("`get_discriminant` encountered invalid discriminant.");
         };
-        // TODOT: What actually should the discriminant be? Do we save the discriminant type in the enum?
-        //        Is it the smallest possible?
-        ret((Value::Int(discriminant), Type::Int(IntType { signed: Signedness::Unsigned, size: Size::from_bytes(4).unwrap() })))
+
+        ret((Value::Int(discriminant), Type::Int(discriminant_ty)))
     }
 }
 ```

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -108,12 +108,12 @@ impl<M: Memory> Machine<M> {
 
         // We don't require the variant to be valid,
         // we are only interested in the bytes that the discriminator actually touches.
-        let mut accessor = |idx| {
+        let accessor = |idx| {
             let ptr = self.ptr_offset_inbounds(place.ptr, idx)?;
             let byte = self.mem.load(ptr, Size::from_bytes(1).unwrap(), Align::ONE, Atomicity::None)?;
             ret(byte[Int::ZERO])
         };
-        let Some(discriminant) = decode_discriminant::<M>(&mut accessor, discriminator)? else {
+        let Some(discriminant) = decode_discriminant::<M>(accessor, discriminator)? else {
             throw_ub!("Discriminant expression encountered invalid discriminant.");
         };
 

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -108,8 +108,10 @@ impl<M: Memory> Machine<M> {
 
         // We don't require the variant to be valid,
         // we are only interested in the bytes that the discriminator actually touches.
-        let accessor = |idx| {
-            let ptr = self.ptr_offset_inbounds(place.ptr, idx)?;
+        let accessor = |idx: Offset| {
+            let ptr = self.ptr_offset_inbounds(place.ptr, idx.bytes())?;
+            // FIXME: is this the right alignment? rustc has alignment requirements for
+            // discriminant reads, we need to check for that UB somewhere.
             let byte = self.mem.load(ptr, Size::from_bytes(1).unwrap(), Align::ONE, Atomicity::None)?;
             ret(byte[Int::ZERO])
         };

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -103,7 +103,7 @@ impl<M: Memory> Machine<M> {
         // Get the place of the enum and its information.
         let (place, ty) = self.eval_place(place)?;
         let Type::Enum { discriminator, discriminant_ty, .. } = ty else {
-            panic!();
+            panic!("ValueExpr::Discriminant requires enum type");
         };
 
         // We don't require the variant to be valid,

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -77,11 +77,11 @@ impl<M: Memory> Machine<M> {
 
         // Write the tag directly into memory.
         // This should be fine as we don't allow encoded data and the tag to overlap for valid enum variants.
-        let mut accessor = |offset, value| {
+        let accessor = |offset, value| {
             let ptr = self.ptr_offset_inbounds(place.ptr, offset)?;
             self.mem.store(ptr, [value].into_iter().collect(), Align::ONE, Atomicity::None)
         };
-        encode_discriminant::<M>(&mut accessor, tagger)?;
+        encode_discriminant::<M>(accessor, tagger)?;
         ret(())
     }
 }

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -66,7 +66,7 @@ impl<M: Memory> Machine<M> {
             panic!("Setting the discriminant type of a non-enum contradicts well-formedness.");
         };
         if !place.aligned {
-            throw_ub!("Setting the discriminant based on a misaligned pointer");
+            throw_ub!("Setting the discriminant of a place based on a misaligned pointer");
         }
 
         let tagger = match variants.get(value) {
@@ -79,6 +79,7 @@ impl<M: Memory> Machine<M> {
         // This should be fine as we don't allow encoded data and the tag to overlap for valid enum variants.
         let accessor = |offset, value| {
             let ptr = self.ptr_offset_inbounds(place.ptr, offset)?;
+            // We have ensured that the place is aligned, so no alignment requirement here
             self.mem.store(ptr, [value].into_iter().collect(), Align::ONE, Atomicity::None)
         };
         encode_discriminant::<M>(accessor, tagger)?;

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -77,8 +77,8 @@ impl<M: Memory> Machine<M> {
 
         // Write the tag directly into memory.
         // This should be fine as we don't allow encoded data and the tag to overlap for valid enum variants.
-        let accessor = |offset, value| {
-            let ptr = self.ptr_offset_inbounds(place.ptr, offset)?;
+        let accessor = |offset: Offset, value| {
+            let ptr = self.ptr_offset_inbounds(place.ptr, offset.bytes())?;
             // We have ensured that the place is aligned, so no alignment requirement here
             self.mem.store(ptr, [value].into_iter().collect(), Align::ONE, Atomicity::None)
         };

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -105,14 +105,15 @@ fn check_abi_compatibility(
             caller_chunks == callee_chunks &&
             caller_size == callee_size &&
             caller_align == callee_align,
-        (Type::Enum { variants: caller_variants, discriminator: caller_discriminator, size: caller_size, align: caller_align },
-         Type::Enum { variants: callee_variants, discriminator: callee_discriminator, size: callee_size, align: callee_align }) =>
+        (Type::Enum { variants: caller_variants, discriminator: caller_discriminator, discriminant_ty: caller_discriminant_ty, size: caller_size, align: caller_align },
+         Type::Enum { variants: callee_variants, discriminator: callee_discriminator, discriminant_ty: callee_discriminant_ty, size: callee_size, align: callee_align }) =>
             caller_variants.len() == callee_variants.len() &&
             caller_variants.zip(callee_variants).all(|(caller_variant, callee_variant)|
                 check_abi_compatibility(caller_variant.ty, callee_variant.ty) &&
                 caller_variant.tagger == callee_variant.tagger
             ) &&
             caller_discriminator == callee_discriminator &&
+            caller_discriminant_ty == callee_discriminant_ty &&
             caller_size == callee_size &&
             caller_align == callee_align,
         // Different kind of type, definitely incompatible.

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -210,6 +210,11 @@ pub enum Statement {
     Expose {
         value: ValueExpr,
     },
+    /// Set the discriminant of the variant at `destination` to `value`.
+    SetDiscriminant {
+        destination: PlaceExpr,
+        value: ValueExpr,
+    },
     /// Ensure that `place` contains a valid value of its type (else UB).
     /// Also perform retagging and ensure safe pointers are dereferenceable.
     ///

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -213,7 +213,7 @@ pub enum Statement {
     /// Set the discriminant of the variant at `destination` to `value`.
     SetDiscriminant {
         destination: PlaceExpr,
-        value: ValueExpr,
+        value: Int,
     },
     /// Ensure that `place` contains a valid value of its type (else UB).
     /// Also perform retagging and ensure safe pointers are dereferenceable.

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -39,8 +39,17 @@ pub enum ValueExpr {
         /// The `ValueExpr` for the variant.
         #[specr::indirection]
         data: ValueExpr,
-        /// The enum type, needs to be `Type::Enum``.
+        /// The enum type, needs to be `Type::Enum`.
         enum_ty: Type,
+    },
+
+    /// Read the discriminant of an enum type.
+    /// As we don't need to know the validity of the inner data
+    /// we don't fully load the variant value.
+    Discriminant {
+        /// The place where the enum is located.
+        #[specr::indirection]
+        place: PlaceExpr,
     },
 
     /// Load a value from memory.

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -108,7 +108,7 @@ pub enum Discriminator {
     /// We don't know the discriminant, so we branch on the value of a specific byte.
     /// The fallback keeps the representation more compact, as we often are only
     /// interested in a couple of values and we don't want to always have 256 branches.
-    Unknown {
+    Branch {
         offset: Offset,
         #[specr::indirection]
         fallback: Discriminator,

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -80,6 +80,12 @@ pub struct IntType {
     pub size: Size,
 }
 
+impl IntType {
+    pub fn can_represent(&self, i: Int) -> bool {
+        i.in_bounds(self.signed, self.size)
+    }
+}
+
 pub type Fields = List<(Offset, Type)>;
 
 pub struct Variant {

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -64,6 +64,8 @@ pub enum Type {
         variants: List<Variant>,
         /// This contains the decision tree to decode the variant at runtime.
         discriminator: Discriminator,
+        /// The `IntType` to represent the discriminant.
+        discriminant_ty: IntType,
         /// The total size of the enum can indicate trailing padding.
         /// Must be large enough to contain all variants.
         size: Size,

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -229,6 +229,13 @@ impl ValueExpr {
                 ensure(checked == ty);
                 enum_ty
             }
+            Discriminant { place } => {
+                let Some(Type::Enum { .. }) = place.check_wf::<T>(locals, prog) else {
+                    throw!();
+                };
+                // TODOT: find right type (see eval_value)
+                Type::Int(IntType { signed: Signedness::Unsigned, size: Size::from_bytes(4).unwrap() })
+            }
             Load { source } => {
                 source.check_wf::<T>(locals, prog)?
             }

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -132,7 +132,7 @@ impl Discriminator {
         match self {
             Discriminator::Known(variant) => ensure(variant >= Int::ZERO && variant < n_variants && discriminant_ty.can_represent(variant)),
             Discriminator::Invalid => ret(()),
-            Discriminator::Unknown { offset, fallback, children } => {
+            Discriminator::Branch { offset, fallback, children } => {
                 ensure(offset < size)?;
                 fallback.check_wf::<T>(size, n_variants, discriminant_ty)?;
                 for discriminator in children.values() {

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -370,6 +370,15 @@ impl Statement {
                 ensure(matches!(v, Type::Ptr(_)));
                 live_locals
             }
+            SetDiscriminant { destination, value } => {
+                let Type::Enum { .. } = destination.check_wf::<T>(live_locals, prog)? else {
+                    throw!();
+                };
+                let val_ty = value.check_wf::<T>(live_locals, prog)?;
+                // TODOT: ensure int size matches when we defined its size.
+                ensure(matches!(val_ty, Type::Int(_)));
+                live_locals
+            }
             Validate { place, fn_entry: _ } => {
                 place.check_wf::<T>(live_locals, prog)?;
                 live_locals

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -116,10 +116,10 @@ impl Type {
                     ensure(size == variant.ty.size::<T>())?;
                 }
 
-                // check that all variants reached by the discriminator are valid and
-                // that it never performs out-of-bounds accesses.
-                discriminator.check_wf::<T>(size, variants.len())?;
-                ensure(libspecr::Int::ONE << discriminant_ty.size.bits() >= variants.len())?;
+                // check that all variants reached by the discriminator are valid,
+                // that it never performs out-of-bounds accesses and all discriminant values
+                // can be represented by the discriminant type.
+                discriminator.check_wf::<T>(size, variants.len(), discriminant_ty)?;
             }
         }
 
@@ -128,15 +128,15 @@ impl Type {
 }
 
 impl Discriminator {
-    fn check_wf<T: Target>(self, size: Size, n_variants: Int) -> Option<()> {
+    fn check_wf<T: Target>(self, size: Size, n_variants: Int, discriminant_ty: IntType) -> Option<()> {
         match self {
-            Discriminator::Known(variant) => ensure(variant >= Int::ZERO && variant < n_variants),
+            Discriminator::Known(variant) => ensure(variant >= Int::ZERO && variant < n_variants && discriminant_ty.can_represent(variant)),
             Discriminator::Invalid => ret(()),
             Discriminator::Unknown { offset, fallback, children } => {
                 ensure(offset < size)?;
-                fallback.check_wf::<T>(size, n_variants)?;
+                fallback.check_wf::<T>(size, n_variants, discriminant_ty)?;
                 for discriminator in children.values() {
-                    discriminator.check_wf::<T>(size, n_variants)?;
+                    discriminator.check_wf::<T>(size, n_variants, discriminant_ty)?;
                 }
                 ret(())
             }
@@ -156,7 +156,7 @@ impl Constant {
         // TODO: add more.
         match (self, ty) {
             (Constant::Int(i), Type::Int(int_type)) => {
-                ensure(i.in_bounds(int_type.signed, int_type.size))?;
+                ensure(int_type.can_represent(i))?;
             }
             (Constant::Bool(_), Type::Bool) => (),
             (Constant::GlobalPointer(relocation), Type::Ptr(_)) => {
@@ -371,12 +371,17 @@ impl Statement {
                 live_locals
             }
             SetDiscriminant { destination, value } => {
-                let Type::Enum { discriminant_ty, .. } = destination.check_wf::<T>(live_locals, prog)? else {
+                let Type::Enum { variants, .. } = destination.check_wf::<T>(live_locals, prog)? else {
                     throw!();
                 };
-                let val_ty = value.check_wf::<T>(live_locals, prog)?;
-                // Ensure the type we set the discriminant to matches the type of the discriminant.
-                ensure(val_ty == Type::Int(discriminant_ty));
+                // We don't ensure that we can actually represent the discriminant.
+                // The well-formedness checks for the type just ensure that every discriminant
+                // reached by the discriminator is valid, however there we don't require that every
+                // variant is represented. Setting such an unrepresented discriminant would probably
+                // result in an invalid value as either the discriminator returns
+                // `Discriminator::Invalid` or another variant.
+                // This is fine as SetDiscriminant does not guarantee that the enum is a valid value.
+                variants.get(value)?;
                 live_locals
             }
             Validate { place, fn_entry: _ } => {
@@ -585,7 +590,7 @@ impl<M: Memory> Value<M> {
     fn check_wf(self, ty: Type) -> Option<()> {
         match (self, ty) {
             (Value::Int(i), Type::Int(ity)) => {
-                ensure(i.in_bounds(ity.signed, ity.size))?;
+                ensure(ity.can_represent(i))?;
             }
             (Value::Bool(_), Type::Bool) => {},
             (Value::Ptr(ptr), Type::Ptr(ptr_ty)) => {

--- a/tooling/minitest/src/tests/enum_discriminant.rs
+++ b/tooling/minitest/src/tests/enum_discriminant.rs
@@ -1,6 +1,19 @@
 use crate::*;
 
 #[test]
+/// It is ill-formed to write an invalid discriminant.
+fn ill_formed_invalid_discriminant_set() {
+    let enum_ty = enum_ty(&[], Discriminator::Invalid, 1, size(0), align(1));
+    let locals = [enum_ty];
+    let stmts = [
+        storage_live(0),
+        set_discriminant(local(0), 0), // ill-formed here
+    ];
+    let program = small_program(&locals, &stmts);
+    assert_ill_formed(program);
+}
+
+#[test]
 fn discriminant_get_and_set_work() {
     // single-variant enum without data and the tag 4 for the only variant
     let enum_ty = enum_ty(
@@ -95,4 +108,74 @@ fn discriminant_leaves_data_alone() {
     let function = function(Ret::No, 0, &locals, &blocks);
     let program = program(&[function]);
     assert_stop(program);
+}
+
+#[test]
+/// Tests that set_discriminant does not init the data byte.
+fn ub_discriminant_does_not_init() {
+    // single variant enum with layout (u8 data, u8 tag) and tag 1
+    let enum_ty = enum_ty(
+        &[enum_variant(tuple_ty(&[(size(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(size(1), 1u8)])],
+        Discriminator::Branch { offset: size(1), fallback: GcCow::new(Discriminator::Invalid), children: [(1u8, Discriminator::Known(0.into()))].into_iter().collect() },
+        1, size(2), align(1)
+    );
+    let locals = [enum_ty];
+    let blocks = [
+        block!(
+            storage_live(0),
+            set_discriminant(local(0), 0),
+            if_(eq(load(field(downcast(local(0), 0), 0)), get_discriminant(local(0))), 1, 2) // ub here as the field isn't initialized
+        ),
+        block!(exit()),
+        block!(unreachable()),
+    ];
+    let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
+    assert_ub(program, "load at type Int(IntType { signed: Unsigned, size: Size(1 bytes) }) but the data in memory violates the validity invariant");
+}
+
+#[test]
+/// Tests that reading from a discriminant that wasn't initialized is UB.
+fn ub_cannot_read_uninit_discriminant() {
+    // single variant enum with layout (u8 data, u8 tag) and tag 1
+    let enum_ty = enum_ty(
+        &[enum_variant(tuple_ty(&[(size(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(size(1), 1u8)])],
+        Discriminator::Branch { offset: size(1), fallback: GcCow::new(Discriminator::Invalid), children: [(1u8, Discriminator::Known(0.into()))].into_iter().collect() },
+        1, size(2), align(1)
+    );
+    let locals = [enum_ty];
+    let blocks = [
+        block!(
+            storage_live(0),
+            assign(field(downcast(local(0), 0), 0), const_int(12u8)),
+            if_(eq(load(field(downcast(local(0), 0), 0)), get_discriminant(local(0))), 1, 2) // ub here as the discriminant isn't initialized
+        ),
+        block!(exit()),
+        block!(unreachable()),
+    ];
+    let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
+    assert_ub(program, "Discriminant expression encountered invalid discriminant.");
+}
+
+#[test]
+/// Tests that reading from an invalid discriminant is UB.
+fn ub_cannot_read_invalid_discriminant() {
+    let u8_t = int_ty(Signedness::Unsigned, size(1));
+    // single variant enum without data and tag 1
+    let enum_ty = enum_ty(
+        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(size(0), 1u8)])],
+        Discriminator::Branch { offset: size(0), fallback: GcCow::new(Discriminator::Invalid), children: [(1u8, Discriminator::Known(0.into()))].into_iter().collect() },
+        1, size(1), align(1)
+    );
+    let locals = [union_ty(&[(size(0), enum_ty), (size(0), u8_t)], size(1), align(1))];
+    let blocks = [
+        block!(
+            storage_live(0),
+            assign(field(local(0), 1), const_int(12u8)),
+            if_(eq(const_int(12u8), get_discriminant(field(local(0), 0))), 1, 2) // ub here as the discriminant isn't valid
+        ),
+        block!(exit()),
+        block!(unreachable()),
+    ];
+    let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
+    assert_ub(program, "Discriminant expression encountered invalid discriminant.");
 }

--- a/tooling/minitest/src/tests/enum_discriminant.rs
+++ b/tooling/minitest/src/tests/enum_discriminant.rs
@@ -1,0 +1,98 @@
+use crate::*;
+
+#[test]
+fn discriminant_get_and_set_work() {
+    // single-variant enum without data and the tag 4 for the only variant
+    let enum_ty = enum_ty(
+        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(size(0), 4)])],
+        Discriminator::Branch { offset: size(0), fallback: GcCow::new(Discriminator::Invalid), children: [(4, Discriminator::Known(0.into()))].into_iter().collect() },
+        1,
+        size(1),
+        align(1)
+    );
+    let locals = [enum_ty];
+
+    // check that discriminant matches whats written, go to unreachable if not
+    let blocks = [
+        block!(
+            storage_live(0),
+            set_discriminant(local(0), 0),
+            if_(eq(get_discriminant(local(0)), const_int(0u8)), 1, 2)
+        ),
+        block!(exit()),
+        block!(unreachable()),
+    ];
+    let function = function(Ret::No, 0, &locals, &blocks);
+    let program = program(&[function]);
+    assert_stop(program);
+}
+
+
+#[test]
+fn discriminant_setting_right_value() {
+    // multi-variant enum without data and the tags 4 and 2.
+    let enum_ty = enum_ty(
+        &[
+            enum_variant(tuple_ty(&[], size(1), align(1)), &[(size(0), 4)]),
+            enum_variant(tuple_ty(&[], size(1), align(1)), &[(size(0), 2)]),
+        ],
+        Discriminator::Branch { offset: size(0), fallback: GcCow::new(Discriminator::Invalid), children: [(4, Discriminator::Known(0.into()))].into_iter().collect() },
+        1,
+        size(1),
+        align(1)
+    );
+    let locals = [union_ty(&[(size(0), enum_ty), (size(0), int_ty(Signedness::Unsigned, size(1)))], size(1), align(1))];
+
+    // check that discriminant matches whats written, go to unreachable if not
+    let blocks = [
+        block!(
+            storage_live(0),
+            set_discriminant(field(local(0), 0), 0),
+            if_(eq(load(field(local(0), 1)), const_int(4u8)), 1, 3)
+        ),
+        block!(
+            set_discriminant(field(local(0), 0), 1),
+            if_(eq(load(field(local(0), 1)), const_int(2u8)), 2, 3)
+        ),
+        block!(exit()),
+        block!(unreachable()),
+    ];
+    let function = function(Ret::No, 0, &locals, &blocks);
+    let program = program(&[function]);
+    assert_stop(program);
+}
+
+#[test]
+/// Tests the integrity of the enum data after set_discriminant.
+fn discriminant_leaves_data_alone() {
+    let u8_t = int_ty(Signedness::Unsigned, size(1));
+    let u16_t = int_ty(Signedness::Unsigned, size(2));
+
+    // single-variant enum with layout <u8 data, u8 tag, u16 data> and tag 1
+    let enum_ty = enum_ty(
+        &[enum_variant(tuple_ty(&[(size(0), u8_t), (size(2), u16_t)], size(4), align(2)), &[(size(1), 1)])],
+        Discriminator::Branch { offset: size(1), fallback: GcCow::new(Discriminator::Invalid), children: [].into_iter().collect() },
+        1, size(4), align(2)
+    );
+    // the only local is a union of the enum and all its field seperately
+    let locals = [union_ty(&[(size(0), enum_ty), (size(0), u8_t), (size(1), u8_t), (size(2), u16_t)], size(4), align(2))];
+
+    let blocks = [
+        block!(
+            // setup enum
+            storage_live(0),
+            assign(field(downcast(field(local(0), 0), 0), 0), const_int(12u8)),
+            assign(field(downcast(field(local(0), 0), 0), 1), const_int(9834u16)),
+            set_discriminant(field(local(0), 0), 0),
+            // now let the checks begin
+            if_(eq(load(field(local(0), 1)), const_int(12u8)), 1, 4)
+        ),
+        block!(if_(eq(load(field(local(0), 2)), const_int(1u8)), 2, 4)),
+        block!(if_(eq(load(field(local(0), 3)), const_int(9834u16)), 3, 4)),
+        block!(exit()),
+        block!(unreachable())
+    ];
+    let function = function(Ret::No, 0, &locals, &blocks);
+    let program = program(&[function]);
+    assert_stop(program);
+}

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -4,7 +4,7 @@ use crate::*;
 #[test]
 fn out_of_bounds_downcast() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let enum_ty = enum_ty(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
     let locals = &[enum_ty, u8_t];
     let stmts = &[
         storage_live(0),
@@ -19,7 +19,7 @@ fn out_of_bounds_downcast() {
 #[test]
 fn valid_downcast() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let enum_ty = enum_ty(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
     let locals = &[enum_ty, u8_t];
     let stmts = &[
         storage_live(0),
@@ -45,7 +45,7 @@ fn downcasts_give_different_place() {
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
     };
-    let enum_ty = enum_ty(&[variant1, variant2], discriminator, size(4), align(2));
+    let enum_ty = enum_ty(&[variant1, variant2], discriminator, 1, size(4), align(2));
 
     let locals = &[enum_ty, u16_t];
     let stmts = &[
@@ -71,7 +71,7 @@ fn downcasts_give_different_place2() {
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
     };
-    let enum_ty = enum_ty(&[variant1, variant2], discriminator, size(4), align(2));
+    let enum_ty = enum_ty(&[variant1, variant2], discriminator, 1, size(4), align(2));
 
     let locals = &[enum_ty, u8_t];
     let stmts = &[

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -37,11 +37,11 @@ fn valid_downcast() {
 fn downcasts_give_different_place() {
     // setup enum where the first two bytes are data (u8 / u16) and the third byte is the tag.
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let variant1 = enum_variant(tuple_ty(&[(size(1), u8_t)], size(4), align(2)), &[(size(2), 0u8)]);
+    let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), 0u8)]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
-    let variant2 = enum_variant(tuple_ty(&[(size(0), u16_t)], size(4), align(2)), &[(size(2), 1u8)]);
+    let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), 1u8)]);
     let discriminator = Discriminator::Branch {
-        offset: size(2),
+        offset: offset(2),
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
     };
@@ -63,11 +63,11 @@ fn downcasts_give_different_place() {
 fn downcasts_give_different_place2() {
     // setup enum where the first two bytes are data (u8 / u16) and the third byte is the tag.
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let variant1 = enum_variant(tuple_ty(&[(size(1), u8_t)], size(4), align(2)), &[(size(2), 0)]);
+    let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), 0)]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
-    let variant2 = enum_variant(tuple_ty(&[(size(0), u16_t)], size(4), align(2)), &[(size(2), 1)]);
+    let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), 1)]);
     let discriminator = Discriminator::Branch {
-        offset: size(2),
+        offset: offset(2),
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
     };

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -4,7 +4,7 @@ use crate::*;
 #[test]
 fn out_of_bounds_downcast() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let enum_ty = enum_ty(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), size(1), align(1));
     let locals = &[enum_ty, u8_t];
     let stmts = &[
         storage_live(0),
@@ -19,7 +19,7 @@ fn out_of_bounds_downcast() {
 #[test]
 fn valid_downcast() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let enum_ty = enum_ty(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), size(1), align(1));
     let locals = &[enum_ty, u8_t];
     let stmts = &[
         storage_live(0),
@@ -45,7 +45,7 @@ fn downcasts_give_different_place() {
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
     };
-    let enum_ty = enum_ty(&[variant1, variant2], discriminator, 1, size(4), align(2));
+    let enum_ty = enum_ty::<u8>(&[variant1, variant2], discriminator, size(4), align(2));
 
     let locals = &[enum_ty, u16_t];
     let stmts = &[
@@ -71,7 +71,7 @@ fn downcasts_give_different_place2() {
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
     };
-    let enum_ty = enum_ty(&[variant1, variant2], discriminator, 1, size(4), align(2));
+    let enum_ty = enum_ty::<u8>(&[variant1, variant2], discriminator, size(4), align(2));
 
     let locals = &[enum_ty, u8_t];
     let stmts = &[

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -40,7 +40,7 @@ fn downcasts_give_different_place() {
     let variant1 = enum_variant(tuple_ty(&[(size(1), u8_t)], size(4), align(2)), &[(size(2), 0u8)]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
     let variant2 = enum_variant(tuple_ty(&[(size(0), u16_t)], size(4), align(2)), &[(size(2), 1u8)]);
-    let discriminator = Discriminator::Unknown {
+    let discriminator = Discriminator::Branch {
         offset: size(2),
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
@@ -66,7 +66,7 @@ fn downcasts_give_different_place2() {
     let variant1 = enum_variant(tuple_ty(&[(size(1), u8_t)], size(4), align(2)), &[(size(2), 0)]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
     let variant2 = enum_variant(tuple_ty(&[(size(0), u16_t)], size(4), align(2)), &[(size(2), 1)]);
-    let discriminator = Discriminator::Unknown {
+    let discriminator = Discriminator::Branch {
         offset: size(2),
         fallback: GcCow::new(Discriminator::Invalid),
         children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -14,8 +14,8 @@ fn ill_sized_enum_variant() {
 #[test]
 fn inconsistently_sized_enum_variants() {
     let enum_ty = enum_ty(&[
-            enum_variant(<()>::get_type(), &[(size(1), 2)]), // size 0
-            enum_variant(<bool>::get_type(), &[]),           // size 1
+            enum_variant(<()>::get_type(), &[(offset(1), 2)]),  // size 0
+            enum_variant(<bool>::get_type(), &[]),              // size 1
         ], Discriminator::Invalid, 1, size(1), align(1));       // size 1
     let locals = &[enum_ty];
     let stmts = &[];
@@ -38,9 +38,9 @@ fn ill_formed_discriminator() {
 fn simple_two_variant_works() {
     let bool_var_ty = enum_variant(Type::Bool, &[]);
     let empty_var_data_ty = tuple_ty(&[], size(1), align(1)); // unit with size 1
-    let empty_var_ty = enum_variant(empty_var_data_ty, &[(size(0), 2)]);
+    let empty_var_ty = enum_variant(empty_var_data_ty, &[(offset(0), 2)]);
     let discriminator = Discriminator::Branch {
-        offset: size(0),
+        offset: offset(0),
         fallback: GcCow::new(Discriminator::Invalid),
         children: [
             (0, Discriminator::Known(0.into())),

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// Ill-formed: the only variant has size 0, but the enum is size 1
 #[test]
 fn ill_sized_enum_variant() {
-    let enum_ty = enum_ty(&[enum_variant(<()>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty(&[enum_variant(<()>::get_type(), &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -16,7 +16,7 @@ fn inconsistently_sized_enum_variants() {
     let enum_ty = enum_ty(&[
             enum_variant(<()>::get_type(), &[(size(1), 2)]), // size 0
             enum_variant(<bool>::get_type(), &[]),           // size 1
-        ], Discriminator::Invalid, size(1), align(1));       // size 1
+        ], Discriminator::Invalid, 1, size(1), align(1));       // size 1
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -26,7 +26,7 @@ fn inconsistently_sized_enum_variants() {
 /// Ill-formed: no variants but discriminator returns variant 1
 #[test]
 fn ill_formed_discriminator() {
-    let enum_ty = enum_ty(&[], Discriminator::Known(1.into()), size(0), align(1));
+    let enum_ty = enum_ty(&[], Discriminator::Known(1.into()), 1, size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -48,7 +48,7 @@ fn simple_two_variant_works() {
             (2, Discriminator::Known(1.into())),
         ].into_iter().collect()
     };
-    let enum_ty = enum_ty(&[bool_var_ty, empty_var_ty], discriminator, size(1), align(1));
+    let enum_ty = enum_ty(&[bool_var_ty, empty_var_ty], discriminator, 1, size(1), align(1));
     
     let locals = &[enum_ty];
     let statements = &[
@@ -67,20 +67,20 @@ fn simple_two_variant_works() {
 /// It is the discriminant computation that fails, as we start off with Discriminator::Invalid.
 #[test]
 fn loading_uninhabited_enum_is_ub() {
-    let enum_ty = enum_ty(&[], Discriminator::Invalid, size(0), align(1));
+    let enum_ty = enum_ty(&[], Discriminator::Invalid, 1, size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),
         assign(local(0), load(local(0))), // UB here.
     ];
     let prog = small_program(locals, stmts);
-    assert_ub(prog, "load at type Enum { variants: List([]), discriminator: Invalid, size: Size(0 bytes), align: Align(1 bytes) } but the data in memory violates the validity invariant");
+    assert_ub(prog, "load at type Enum { variants: List([]), discriminator: Invalid, discriminant_ty: IntType { signed: Unsigned, size: Size(1 bytes) }, size: Size(0 bytes), align: Align(1 bytes) } but the data in memory violates the validity invariant");
 }
 
 /// Ill-formed: trying to build a variant value of an uninhabited enum
 #[test]
 fn ill_formed_variant_constant() {
-    let enum_ty = enum_ty(&[], Discriminator::Invalid, size(0), align(1));
+    let enum_ty = enum_ty(&[], Discriminator::Invalid, 1, size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),
@@ -93,7 +93,7 @@ fn ill_formed_variant_constant() {
 /// Ill-formed: The data of the variant value does not match the type
 #[test]
 fn ill_formed_variant_constant_data() {
-    let enum_ty = enum_ty(&[enum_variant(<u8>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty(&[enum_variant(<u8>::get_type(), &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -39,7 +39,7 @@ fn simple_two_variant_works() {
     let bool_var_ty = enum_variant(Type::Bool, &[]);
     let empty_var_data_ty = tuple_ty(&[], size(1), align(1)); // unit with size 1
     let empty_var_ty = enum_variant(empty_var_data_ty, &[(size(0), 2)]);
-    let discriminator = Discriminator::Unknown {
+    let discriminator = Discriminator::Branch {
         offset: size(0),
         fallback: GcCow::new(Discriminator::Invalid),
         children: [

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// Ill-formed: the only variant has size 0, but the enum is size 1
 #[test]
 fn ill_sized_enum_variant() {
-    let enum_ty = enum_ty(&[enum_variant(<()>::get_type(), &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[enum_variant(<()>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -13,10 +13,10 @@ fn ill_sized_enum_variant() {
 /// Ill-formed: the two variants have different sizes
 #[test]
 fn inconsistently_sized_enum_variants() {
-    let enum_ty = enum_ty(&[
+    let enum_ty = enum_ty::<u8>(&[
             enum_variant(<()>::get_type(), &[(offset(1), 2)]),  // size 0
             enum_variant(<bool>::get_type(), &[]),              // size 1
-        ], Discriminator::Invalid, 1, size(1), align(1));       // size 1
+        ], Discriminator::Invalid, size(1), align(1));       // size 1
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -26,7 +26,7 @@ fn inconsistently_sized_enum_variants() {
 /// Ill-formed: no variants but discriminator returns variant 1
 #[test]
 fn ill_formed_discriminator() {
-    let enum_ty = enum_ty(&[], Discriminator::Known(1.into()), 1, size(0), align(1));
+    let enum_ty = enum_ty::<u8>(&[], Discriminator::Known(1.into()), size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -48,7 +48,7 @@ fn simple_two_variant_works() {
             (2, Discriminator::Known(1.into())),
         ].into_iter().collect()
     };
-    let enum_ty = enum_ty(&[bool_var_ty, empty_var_ty], discriminator, 1, size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[bool_var_ty, empty_var_ty], discriminator, size(1), align(1));
     
     let locals = &[enum_ty];
     let statements = &[
@@ -67,7 +67,7 @@ fn simple_two_variant_works() {
 /// It is the discriminant computation that fails, as we start off with Discriminator::Invalid.
 #[test]
 fn loading_uninhabited_enum_is_ub() {
-    let enum_ty = enum_ty(&[], Discriminator::Invalid, 1, size(0), align(1));
+    let enum_ty = enum_ty::<u8>(&[], Discriminator::Invalid, size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),
@@ -80,7 +80,7 @@ fn loading_uninhabited_enum_is_ub() {
 /// Ill-formed: trying to build a variant value of an uninhabited enum
 #[test]
 fn ill_formed_variant_constant() {
-    let enum_ty = enum_ty(&[], Discriminator::Invalid, 1, size(0), align(1));
+    let enum_ty = enum_ty::<u8>(&[], Discriminator::Invalid, size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),
@@ -93,7 +93,7 @@ fn ill_formed_variant_constant() {
 /// Ill-formed: The data of the variant value does not match the type
 #[test]
 fn ill_formed_variant_constant_data() {
-    let enum_ty = enum_ty(&[enum_variant(<u8>::get_type(), &[])], Discriminator::Known(0.into()), 1, size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[enum_variant(<u8>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod concurrency;
 mod data_race;
 mod dereferenceable;
 mod div_zero;
+mod enum_discriminant;
 mod enum_downcast;
 mod enum_representation;
 mod heap_intrinsics;

--- a/tooling/minitest/src/tests/zst.rs
+++ b/tooling/minitest/src/tests/zst.rs
@@ -69,7 +69,7 @@ fn zst_tuple2() {
 #[test]
 fn zst_enum() {
     let empty_var_ty = enum_variant(<()>::get_type(), &[]);
-    let locals = &[enum_ty(&[empty_var_ty], Discriminator::Known(Int::from(0)), 1, size(0), Align::ONE)];
+    let locals = &[enum_ty::<u8>(&[empty_var_ty], Discriminator::Known(Int::from(0)), size(0), Align::ONE)];
     let stmts = &[
         storage_live(0),
         assign(local(0), load(local(0))),

--- a/tooling/minitest/src/tests/zst.rs
+++ b/tooling/minitest/src/tests/zst.rs
@@ -69,7 +69,7 @@ fn zst_tuple2() {
 #[test]
 fn zst_enum() {
     let empty_var_ty = enum_variant(<()>::get_type(), &[]);
-    let locals = &[enum_ty(&[empty_var_ty], Discriminator::Known(Int::from(0)), size(0), Align::ONE)];
+    let locals = &[enum_ty(&[empty_var_ty], Discriminator::Known(Int::from(0)), 1, size(0), Align::ONE)];
     let stmts = &[
         storage_live(0),
         assign(local(0), load(local(0))),

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -31,6 +31,10 @@ pub fn variant(idx: impl Into<Int>, data: ValueExpr, enum_ty: Type) -> ValueExpr
     ValueExpr::Variant { idx: idx.into(), data: GcCow::new(data), enum_ty}
 }
 
+pub fn get_discriminant(place: PlaceExpr) -> ValueExpr {
+    ValueExpr::Discriminant { place: GcCow::new(place) }
+}
+
 // Returns () or [].
 pub fn unit() -> ValueExpr {
     ValueExpr::Tuple(Default::default(), <()>::get_type())

--- a/tooling/miniutil/src/build/mod.rs
+++ b/tooling/miniutil/src/build/mod.rs
@@ -45,6 +45,10 @@ pub fn size(bytes: impl Into<Int>) -> Size {
     Size::from_bytes(bytes).unwrap()
 }
 
+pub fn offset(bytes: impl Into<Int>) -> Offset {
+    size(bytes)
+}
+
 // The first function in `fns` is the start function of the program.
 pub fn program_with_globals(fns: &[Function], globals: &[Global]) -> Program {
     let functions: Map<FnName, Function> = fns

--- a/tooling/miniutil/src/build/statement.rs
+++ b/tooling/miniutil/src/build/statement.rs
@@ -11,6 +11,10 @@ pub fn expose(value: ValueExpr) -> Statement {
     Statement::Expose { value }
 }
 
+pub fn set_discriminant(destination: PlaceExpr, value: impl Into<Int>) -> Statement {
+    Statement::SetDiscriminant { destination, value: value.into() }
+}
+
 pub fn validate(place: PlaceExpr, fn_entry: bool) -> Statement {
     Statement::Validate { place, fn_entry }
 }

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -70,10 +70,11 @@ pub fn enum_variant(ty: Type, tagger: &[(Offset, u8)]) -> Variant {
     }
 }
 
-pub fn enum_ty(variants: &[Variant], discriminator: Discriminator, size: Size, align: Align) -> Type {
+pub fn enum_ty(variants: &[Variant], discriminator: Discriminator, discriminant_bytes: impl Into<Int>, size: Size, align: Align) -> Type {
     Type::Enum {
         variants: variants.iter().copied().collect(),
         discriminator,
+        discriminant_ty: IntType { signed: Signedness::Unsigned, size: Size::from_bytes(discriminant_bytes).unwrap() },
         size,
         align,
     }

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -70,11 +70,14 @@ pub fn enum_variant(ty: Type, tagger: &[(Offset, u8)]) -> Variant {
     }
 }
 
-pub fn enum_ty(variants: &[Variant], discriminator: Discriminator, discriminant_bytes: impl Into<Int>, size: Size, align: Align) -> Type {
+pub fn enum_ty<DiscriminantTy: TypeConv>(variants: &[Variant], discriminator: Discriminator, size: Size, align: Align) -> Type {
+    let Type::Int(discriminant_ty) = DiscriminantTy::get_type() else {
+        panic!("Discriminant Type needs to be an integer type.");
+    };
     Type::Enum {
         variants: variants.iter().copied().collect(),
         discriminator,
-        discriminant_ty: IntType { signed: Signedness::Unsigned, size: Size::from_bytes(discriminant_bytes).unwrap() },
+        discriminant_ty,
         size,
         align,
     }

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -120,6 +120,12 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             let expr = fmt_value_expr(data.extract(), comptypes).to_string();
             FmtExpr::NonAtomic(format!("{enum_ty} {{ variant{idx}: {expr} }}"))
         }
+        ValueExpr::Discriminant {
+            place
+        } => {
+            let place = fmt_place_expr(place.extract(), comptypes).to_string();
+            FmtExpr::Atomic(format!("discriminant({place})"))
+        }
         ValueExpr::Load {
             source,
         } => {

--- a/tooling/miniutil/src/fmt/function.rs
+++ b/tooling/miniutil/src/fmt/function.rs
@@ -109,8 +109,7 @@ fn fmt_statement(st: Statement, comptypes: &mut Vec<CompType>) -> String {
             value
         } => {
             let left = fmt_place_expr(destination, comptypes).to_string();
-            let right = fmt_value_expr(value, comptypes).to_string();
-            format!("    discriminant({left}) = {right};")
+            format!("    discriminant({left}) = {value};")
         }
         Statement::Validate { place, fn_entry } => {
             let place = fmt_place_expr(place, comptypes).to_string();

--- a/tooling/miniutil/src/fmt/function.rs
+++ b/tooling/miniutil/src/fmt/function.rs
@@ -104,6 +104,14 @@ fn fmt_statement(st: Statement, comptypes: &mut Vec<CompType>) -> String {
             let val = fmt_value_expr(value, comptypes).to_string();
             format!("    expose({val});")
         }
+        Statement::SetDiscriminant {
+            destination,
+            value
+        } => {
+            let left = fmt_place_expr(destination, comptypes).to_string();
+            let right = fmt_value_expr(value, comptypes).to_string();
+            format!("    discriminant({left}) = {right};")
+        }
         Statement::Validate { place, fn_entry } => {
             let place = fmt_place_expr(place, comptypes).to_string();
             format!("    validate({place}, {fn_entry});")


### PR DESCRIPTION
Implements the MiniRust interface for enum discriminants, namely get_discriminant (ValueExpr::Discriminant) and set_discriminant (Statement::SetDiscriminant).

Adds tests for the discriminant interface.