### PR TITLE
Various alignment-check fixes (mainly around enums)

### DIFF
--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -46,7 +46,7 @@ pub enum ValueExpr {
     /// Read the discriminant of an enum type.
     /// As we don't need to know the validity of the inner data
     /// we don't fully load the variant value.
-    Discriminant {
+    GetDiscriminant {
         /// The place where the enum is located.
         #[specr::indirection]
         place: PlaceExpr,

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -103,3 +103,13 @@ fn ill_formed_variant_constant_data() {
     assert_ill_formed(prog);
 }
 
+
+/// Ill-formed: Ensures that the enum alignment is at least as big as all the variant alignments.
+#[test]
+fn ill_formed_enum_must_have_maximal_alignment_of_inner() {
+    let enum_ty = enum_ty::<u8>(&[enum_variant(<u16>::get_type(), &[])], Discriminator::Known(0.into()), size(2), align(1));
+    let locals = [enum_ty];
+    let stmts = [];
+    let prog = small_program(&locals, &stmts);
+    assert_ill_formed(prog);
+}

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -32,7 +32,7 @@ pub fn variant(idx: impl Into<Int>, data: ValueExpr, enum_ty: Type) -> ValueExpr
 }
 
 pub fn get_discriminant(place: PlaceExpr) -> ValueExpr {
-    ValueExpr::Discriminant { place: GcCow::new(place) }
+    ValueExpr::GetDiscriminant { place: GcCow::new(place) }
 }
 
 // Returns () or [].

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -120,7 +120,7 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             let expr = fmt_value_expr(data.extract(), comptypes).to_string();
             FmtExpr::NonAtomic(format!("{enum_ty} {{ variant{idx}: {expr} }}"))
         }
-        ValueExpr::Discriminant {
+        ValueExpr::GetDiscriminant {
             place
         } => {
             let place = fmt_place_expr(place.extract(), comptypes).to_string();


### PR DESCRIPTION
- Add check that size is multiple of alignment
- Add check that the total enum alignment fits all variants
- Add check that the enum targeted by getDiscriminant is aligned
- Add tests for enum-related alignment stuff