### PR TITLE
Enum discriminant changes

### DIFF
--- a/spec/lang/representation.md
+++ b/spec/lang/representation.md
@@ -244,13 +244,14 @@ This is to ensure that pointers to the data always contain valid values.
 /// The accessor is given an offset relative to the beginning of the encoded enum value,
 /// and it should return the abstract byte at that offset.
 /// FIXME: we have multiple quite different fail sources, it would be nice to return more error information.
-fn decode_discriminant<M: Memory>(mut accessor: impl FnMut(Offset) -> Result<AbstractByte<M::Provenance>>, discriminator: Discriminator) -> Result<Option<Int>> {
+fn decode_discriminant<M: Memory>(mut accessor: impl FnMut(Offset, IntType) -> Result<List<AbstractByte<M::Provenance>>>, discriminator: Discriminator) -> Result<Option<Int>> {
     match discriminator {
         Discriminator::Known(val) => ret(Some(val)),
         Discriminator::Invalid => ret(None),
-        Discriminator::Branch { offset, children, fallback } => {
-            let AbstractByte::Init(val, _) = accessor(offset)?
-                else { return ret(None) };
+        Discriminator::Branch { offset, value_type, children, fallback } => {
+            let bytes = accessor(offset, value_type)?;
+            let Some(Value::Int(val)) = Type::Int(value_type).decode::<M>(bytes)
+                else { return ret(None); };
             let next_discriminator = children.get(val).unwrap_or(fallback);
             decode_discriminant::<M>(accessor, next_discriminator)
         }
@@ -259,10 +260,14 @@ fn decode_discriminant<M: Memory>(mut accessor: impl FnMut(Offset) -> Result<Abs
 
 /// Writes the tag described by the tagger into the bytes accessed using the accessor.
 /// The accessor is given an offset relative to the beginning of the encoded enum value
-/// and the abstract byte to store at that offset.
-fn encode_discriminant<M: Memory>(mut accessor: impl FnMut(Offset, AbstractByte<M::Provenance>) -> Result, tagger: Map<Offset, u8>) -> Result<()> {
-    for (offset, value) in tagger.iter() {
-        accessor(offset, AbstractByte::Init(value, None))?;
+/// and the integer value and type to store at that offset.
+fn encode_discriminant<M: Memory>(
+    mut accessor: impl FnMut(Offset, IntType, List<AbstractByte<M::Provenance>>) -> Result,
+    tagger: Map<Offset, (IntType, Int)>
+) -> Result<()> {
+    for (offset, (value_type, value)) in tagger.iter() {
+        let bytes = Type::Int(value_type).encode::<M>(Value::Int(value));
+        accessor(offset, value_type, bytes)?;
     }
     ret(())
 }
@@ -272,7 +277,10 @@ impl Type {
         if bytes.len() != size.bytes() { throw!(); }
         // We can unwrap the decoded discriminant as our accessor never fails, and
         // decode_discriminant only fails if the accessor fails.
-        let disc = decode_discriminant::<M>(|idx| ret(bytes[idx.bytes()]), discriminator).unwrap()?;
+        let disc = decode_discriminant::<M>(
+            |offset, ity| ret(bytes.subslice_with_length(offset.bytes(), ity.size.bytes())),
+            discriminator
+        ).unwrap()?;
 
         // Decode into the variant.
         // Because the variant is the same size as the enum we don't need to pass a subslice.
@@ -293,7 +301,10 @@ impl Type {
         // This is fine as we don't allow encoded data and the tag to overlap.
         // We can unwrap the `Result` as our accessor never fails, and
         // encode_discriminant only fails if the accessor fails.
-        encode_discriminant::<M>(|offset, value| { bytes.set(offset.bytes(), value); ret(()) }, tagger).unwrap();
+        encode_discriminant::<M>(|offset, _value_type, value_bytes| {
+            bytes.write_subslice_at_index(offset.bytes(), value_bytes);
+            ret(())
+        }, tagger).unwrap();
         bytes
     }
 }

--- a/spec/lang/representation.md
+++ b/spec/lang/representation.md
@@ -241,15 +241,19 @@ This is to ensure that pointers to the data always contain valid values.
 
 ```rust
 /// Uses the `Discriminator` to decode the discriminant from the tag read out of the value's bytes using the accessor.
+/// Returns `Ok(None)` when reaching `Discriminator::Invalid` and when any of the reads
+/// for `Discriminator::Branch` encounters uninitialized memory.
+/// Returns `Err` only if `accessor` returns `Err`.
+///
 /// The accessor is given an offset relative to the beginning of the encoded enum value,
 /// and it should return the abstract byte at that offset.
 /// FIXME: we have multiple quite different fail sources, it would be nice to return more error information.
-fn decode_discriminant<M: Memory>(mut accessor: impl FnMut(Offset, IntType) -> Result<List<AbstractByte<M::Provenance>>>, discriminator: Discriminator) -> Result<Option<Int>> {
+fn decode_discriminant<M: Memory>(mut accessor: impl FnMut(Offset, Size) -> Result<List<AbstractByte<M::Provenance>>>, discriminator: Discriminator) -> Result<Option<Int>> {
     match discriminator {
         Discriminator::Known(val) => ret(Some(val)),
         Discriminator::Invalid => ret(None),
         Discriminator::Branch { offset, value_type, children, fallback } => {
-            let bytes = accessor(offset, value_type)?;
+            let bytes = accessor(offset, value_type.size)?;
             let Some(Value::Int(val)) = Type::Int(value_type).decode::<M>(bytes)
                 else { return ret(None); };
             let next_discriminator = children.get(val).unwrap_or(fallback);
@@ -259,15 +263,17 @@ fn decode_discriminant<M: Memory>(mut accessor: impl FnMut(Offset, IntType) -> R
 }
 
 /// Writes the tag described by the tagger into the bytes accessed using the accessor.
+/// Returns `Err` only if `accessor` returns `Err`.
+///
 /// The accessor is given an offset relative to the beginning of the encoded enum value
 /// and the integer value and type to store at that offset.
 fn encode_discriminant<M: Memory>(
-    mut accessor: impl FnMut(Offset, IntType, List<AbstractByte<M::Provenance>>) -> Result,
+    mut accessor: impl FnMut(Offset, List<AbstractByte<M::Provenance>>) -> Result,
     tagger: Map<Offset, (IntType, Int)>
 ) -> Result<()> {
     for (offset, (value_type, value)) in tagger.iter() {
         let bytes = Type::Int(value_type).encode::<M>(Value::Int(value));
-        accessor(offset, value_type, bytes)?;
+        accessor(offset, bytes)?;
     }
     ret(())
 }
@@ -277,31 +283,31 @@ impl Type {
         if bytes.len() != size.bytes() { throw!(); }
         // We can unwrap the decoded discriminant as our accessor never fails, and
         // decode_discriminant only fails if the accessor fails.
-        let disc = decode_discriminant::<M>(
-            |offset, ity| ret(bytes.subslice_with_length(offset.bytes(), ity.size.bytes())),
+        let discriminant = decode_discriminant::<M>(
+            |offset, size| ret(bytes.subslice_with_length(offset.bytes(), size.bytes())),
             discriminator
         ).unwrap()?;
 
         // Decode into the variant.
         // Because the variant is the same size as the enum we don't need to pass a subslice.
-        let Some(value) = variants[disc].ty.decode(bytes)
+        let Some(value) = variants[discriminant].ty.decode(bytes)
             else { return None };
 
-        Some(Value::Variant { idx: disc, data: value })
+        Some(Value::Variant { discriminant, data: value })
     }
 
     fn encode<M: Memory>(Type::Enum { variants, .. }: Self, val: Value<M>) -> List<AbstractByte<M::Provenance>> {
-        let Value::Variant { idx, data } = val else { panic!() };
+        let Value::Variant { discriminant, data } = val else { panic!() };
 
         // `idx` is guaranteed to be in bounds by the well-formed check in the type.
-        let Variant { ty: variant, tagger } = variants[idx];
+        let Variant { ty: variant, tagger } = variants[discriminant];
         let mut bytes = variant.encode(data.extract());
 
         // Write tag into the bytes around the data.
         // This is fine as we don't allow encoded data and the tag to overlap.
         // We can unwrap the `Result` as our accessor never fails, and
         // encode_discriminant only fails if the accessor fails.
-        encode_discriminant::<M>(|offset, _value_type, value_bytes| {
+        encode_discriminant::<M>(|offset, value_bytes| {
             bytes.write_subslice_at_index(offset.bytes(), value_bytes);
             ret(())
         }, tagger).unwrap();
@@ -396,8 +402,8 @@ impl<M: Memory> DefinedRelation for Value<M> {
                 p1.le_defined(p2),
             (Tuple(vals1), Tuple(vals2)) =>
                 vals1.le_defined(vals2),
-            (Variant { idx: idx1, data: data1 }, Variant { idx: idx2, data: data2 }) =>
-                idx1 == idx2 && data1.le_defined(data2),
+            (Variant { discriminant: discriminant1, data: data1 }, Variant { discriminant: discriminant2, data: data2 }) =>
+                discriminant1 == discriminant2 && data1.le_defined(data2),
             (Union(chunks1), Union(chunks2)) => chunks1.le_defined(chunks2),
             _ => false
         }
@@ -490,8 +496,8 @@ impl<M: Memory> AtomicMemory<M> {
                 Value::Tuple(vals.zip(fields).try_map(|(val, (_offset, ty))| self.retag_val(val, ty, fn_entry))?),
             (Value::Tuple(vals), Type::Array { elem: ty, .. }) =>
                 Value::Tuple(vals.try_map(|val| self.retag_val(val, ty, fn_entry))?),
-            (Value::Variant { idx, data }, Type::Enum { variants, .. }) =>
-                Value::Variant { idx, data: self.retag_val(data, variants[idx].ty, fn_entry)? },
+            (Value::Variant { discriminant, data }, Type::Enum { variants, .. }) =>
+                Value::Variant { discriminant, data: self.retag_val(data, variants[discriminant].ty, fn_entry)? },
             _ =>
                 panic!("this value does not have that type"),
         })

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -88,8 +88,8 @@ impl<M: Memory> Machine<M> {
 
 ```rust
 impl<M: Memory> Machine<M> {
-    fn eval_value(&mut self, ValueExpr::Variant { enum_ty, idx, data } : ValueExpr) -> NdResult<(Value<M>, Type)> {
-        ret((Value::Variant { idx, data: self.eval_value(data)?.0 }, enum_ty))
+    fn eval_value(&mut self, ValueExpr::Variant { enum_ty, discriminant, data } : ValueExpr) -> NdResult<(Value<M>, Type)> {
+        ret((Value::Variant { discriminant, data: self.eval_value(data)?.0 }, enum_ty))
     }
 }
 ```
@@ -111,10 +111,10 @@ impl<M: Memory> Machine<M> {
 
         // We don't require the variant to be valid,
         // we are only interested in the bytes that the discriminator actually touches.
-        let accessor = |idx: Offset, value_type: IntType| {
+        let accessor = |idx: Offset, size: Size| {
             let ptr = self.ptr_offset_inbounds(place.ptr, idx.bytes())?;
-            // FIXME (Timon): Do we need an alignment check on the tag values?
-            self.mem.load(ptr, value_type.size, Align::ONE, Atomicity::None)
+            // We have ensured that the place is aligned, so no alignment requirement here.
+            self.mem.load(ptr, size, Align::ONE, Atomicity::None)
         };
         let Some(discriminant) = decode_discriminant::<M>(accessor, discriminator)? else {
             throw_ub!("ValueExpr::GetDiscriminant encountered invalid discriminant.");
@@ -296,12 +296,12 @@ impl<M: Memory> Machine<M> {
         ret((Place { ptr, ..root }, field_ty))
     }
 
-    fn eval_place(&mut self, PlaceExpr::Downcast { root, variant_idx }: PlaceExpr) -> NdResult<(Place<M>, Type)> {
+    fn eval_place(&mut self, PlaceExpr::Downcast { root, discriminant }: PlaceExpr) -> NdResult<(Place<M>, Type)> {
         let (root, ty) = self.eval_place(root)?;
         // We only need to downcast the enum type into the variant data type
         // since all the enum data must have the same size with offset 0 (invariant).
         let var_ty = match ty {
-            Type::Enum { variants, .. } => variants[variant_idx].ty,
+            Type::Enum { variants, .. } => variants[discriminant].ty,
             _ => panic!("enum downcast on non-enum"),
         };
         ret((root, var_ty))

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -77,10 +77,9 @@ impl<M: Memory> Machine<M> {
 
         // Write the tag directly into memory.
         // This should be fine as we don't allow encoded data and the tag to overlap for valid enum variants.
-        let accessor = |offset: Offset, value| {
+        let accessor = |offset: Offset, value_type: IntType, bytes| {
             let ptr = self.ptr_offset_inbounds(place.ptr, offset.bytes())?;
-            // We have ensured that the place is aligned, so no alignment requirement here
-            self.mem.store(ptr, [value].into_iter().collect(), Align::ONE, Atomicity::None)
+            self.mem.store(ptr, bytes, Type::Int(value_type).align::<M::T>(), Atomicity::None)
         };
         encode_discriminant::<M>(accessor, tagger)?;
         ret(())

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -77,9 +77,10 @@ impl<M: Memory> Machine<M> {
 
         // Write the tag directly into memory.
         // This should be fine as we don't allow encoded data and the tag to overlap for valid enum variants.
-        let accessor = |offset: Offset, value_type: IntType, bytes| {
+        let accessor = |offset: Offset, bytes| {
             let ptr = self.ptr_offset_inbounds(place.ptr, offset.bytes())?;
-            self.mem.store(ptr, bytes, Type::Int(value_type).align::<M::T>(), Atomicity::None)
+            // We have ensured that the place is aligned, so no alignment requirement here
+            self.mem.store(ptr, bytes, Align::ONE, Atomicity::None)
         };
         encode_discriminant::<M>(accessor, tagger)?;
         ret(())

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -108,7 +108,8 @@ fn check_abi_compatibility(
         (Type::Enum { variants: caller_variants, discriminator: caller_discriminator, discriminant_ty: caller_discriminant_ty, size: caller_size, align: caller_align },
          Type::Enum { variants: callee_variants, discriminator: callee_discriminator, discriminant_ty: callee_discriminant_ty, size: callee_size, align: callee_align }) =>
             caller_variants.len() == callee_variants.len() &&
-            caller_variants.zip(callee_variants).all(|(caller_variant, callee_variant)|
+            caller_variants.iter().zip(callee_variants.iter()).all(|((caller_discriminant, caller_variant), (callee_discriminant, callee_variant))|
+                caller_discriminant == callee_discriminant &&
                 check_abi_compatibility(caller_variant.ty, callee_variant.ty) &&
                 caller_variant.tagger == callee_variant.tagger
             ) &&

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -34,8 +34,8 @@ pub enum ValueExpr {
 
     /// A variant of an enum type.
     Variant {
-        /// The variant index.
-        idx: Int,
+        /// The discriminant of the variant.
+        discriminant: Int,
         /// The `ValueExpr` for the variant.
         #[specr::indirection]
         data: ValueExpr,
@@ -192,8 +192,8 @@ pub enum PlaceExpr {
         /// The base enum to project to the specific variant.
         #[specr::indirection]
         root: PlaceExpr,
-        /// The variant index to project to.
-        variant_idx: Int,
+        /// The discriminant of the variant to project to.
+        discriminant: Int,
     },
 }
 ```

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -55,13 +55,13 @@ pub enum Type {
         align: Align,
     },
     Enum {
-        /// Each variant is given by a type and its tag description. All variants are thought
-        /// to "start at offset 0"; if the discriminant is encoded as an explicit tag,
-        /// then that will be put into the padding of the active variant. (This means it
-        /// is *not* safe to hand out mutable references to a variant at that type, as
-        /// then the tag might be overwritten!)
+        /// The map variants, each identified by a discriminant. Each variant is given by a type and its
+        /// tag description. All variants are thought to "start at offset 0"; if the
+        /// discriminant is encoded as an explicit tag, then that will be put into the
+        /// padding of the active variant. (This means it is *not* safe to hand out mutable
+        /// references to a variant at that type, as then the tag might be overwritten!)
         /// The Rust type `!` is encoded as an `Enum` with an empty list of variants.
-        variants: List<Variant>,
+        variants: Map<Int, Variant>,
         /// The `IntType` for the discriminant. This is used for the type of
         /// `GetDiscriminant` and `SetDiscriminant`. It is entirely independent of how
         /// the discriminant is represented in memory (the "tag").
@@ -102,8 +102,6 @@ pub enum Discriminator {
     /// Tag decoding failed, there is no valid discriminant.
     Invalid,
     /// We don't know the discriminant, so we branch on the value of a specific value.
-    /// The fallback keeps the representation more compact, as we often are only
-    /// interested in a couple of values and don't want to always have > 256 branches.
     Branch {
         offset: Offset,
         value_type: IntType,
@@ -159,7 +157,7 @@ impl Type {
             Tuple { fields, .. } => fields.all(|(_offset, ty)| ty.inhabited()),
             Array { elem, count } => count == 0 || elem.inhabited(),
             Union { .. } => true,
-            Enum { variants, .. } => variants.any(|variant| variant.ty.inhabited()),
+            Enum { variants, .. } => variants.values().any(|variant| variant.ty.inhabited()),
         }
     }
 

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -87,11 +87,11 @@ pub type Fields = List<(Offset, Type)>;
 pub struct Variant {
     /// The actual type of the variant.
     pub ty: Type,
-    /// The information on where to store which bytes to write the tag.
+    /// The information on where to store which values to write the tag.
     /// MUST NOT touch any bytes written by the actual type of the variant and vice
     /// versa. This is because we allow references/pointers to (enum) fields which
     /// should be able to dereference without having to deal with the tag.
-    pub tagger: Map<Offset, u8>,
+    pub tagger: Map<Offset, (IntType, Int)>,
 }
 
 /// The decision tree that computes the discriminant out of the tag for a specific
@@ -101,14 +101,15 @@ pub enum Discriminator {
     Known(Int),
     /// Tag decoding failed, there is no valid discriminant.
     Invalid,
-    /// We don't know the discriminant, so we branch on the value of a specific byte.
+    /// We don't know the discriminant, so we branch on the value of a specific value.
     /// The fallback keeps the representation more compact, as we often are only
-    /// interested in a couple of values and we don't want to always have 256 branches.
+    /// interested in a couple of values and don't want to always have > 256 branches.
     Branch {
         offset: Offset,
+        value_type: IntType,
         #[specr::indirection]
         fallback: Discriminator,
-        children: Map<u8, Discriminator>,
+        children: Map<Int, Discriminator>,
     },
 }
 ```

--- a/spec/lang/values.md
+++ b/spec/lang/values.md
@@ -15,7 +15,7 @@ enum Value<M: Memory> {
     Tuple(List<Value<M>>),
     /// A variant of a sum type, used for enums.
     Variant {
-        idx: Int,
+        discriminant: Int,
         #[specr::indirection]
         data: Value<M>,
     },

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -116,8 +116,9 @@ impl Type {
                 // we don't have to handle different sizes in the memory representation.
                 // Also their alignment may not be larger than the total enum alignment and
                 // all the values written by the tagger must fit into the variant.
-                // FIXME (Timon): should we require alignment checks for the values written in the taggers?
-                for variant in variants {
+                for (discriminant, variant) in variants {
+                    ensure(discriminant_ty.can_represent(discriminant))?;
+
                     variant.ty.check_wf::<T>()?;
                     ensure(size == variant.ty.size::<T>())?;
                     ensure(variant.ty.align::<T>().bytes() <= align.bytes())?;
@@ -126,12 +127,13 @@ impl Type {
                         value_type.can_represent(value) &&
                         offset + value_type.size <= size
                     ))?;
+                    // FIXME: check that the values written by the tagger do not overlap.
                 }
 
                 // check that all variants reached by the discriminator are valid,
                 // that it never performs out-of-bounds accesses and all discriminant values
                 // can be represented by the discriminant type.
-                discriminator.check_wf::<T>(size, variants.len(), discriminant_ty)?;
+                discriminator.check_wf::<T>(size, variants)?;
             }
         }
 
@@ -140,19 +142,18 @@ impl Type {
 }
 
 impl Discriminator {
-    fn check_wf<T: Target>(self, size: Size, n_variants: Int, discriminant_ty: IntType) -> Option<()> {
+    fn check_wf<T: Target>(self, size: Size, variants: Map<Int, Variant>) -> Option<()> {
         match self {
-            Discriminator::Known(variant) => ensure(variant >= Int::ZERO && variant < n_variants && discriminant_ty.can_represent(variant)),
+            Discriminator::Known(discriminant) => ensure(variants.get(discriminant).is_some()),
             Discriminator::Invalid => ret(()),
             Discriminator::Branch { offset, value_type, fallback, children } => {
-                // FIXME (Timon): Do we require a alignment check on the branching value?
-                // Ensure that the value we branch on is in bounds and that all children all valid.
+                // Ensure that the value we branch on is stored in bounds and that all children all valid.
                 value_type.check_wf()?;
                 ensure(offset + value_type.size <= size)?;
-                fallback.check_wf::<T>(size, n_variants, discriminant_ty)?;
+                fallback.check_wf::<T>(size, variants)?;
                 for (value, discriminator) in children.into_iter() {
                     ensure(value_type.can_represent(value))?;
-                    discriminator.check_wf::<T>(size, n_variants, discriminant_ty)?;
+                    discriminator.check_wf::<T>(size, variants)?;
                 }
                 ret(())
             }
@@ -237,10 +238,10 @@ impl ValueExpr {
 
                 union_ty
             }
-            Variant { idx, data, enum_ty } => {
+            Variant { discriminant, data, enum_ty } => {
                 let Type::Enum { variants, .. } = enum_ty else { throw!() };
                 enum_ty.check_wf::<T>()?;
-                let ty = variants.get(idx)?.ty;
+                let ty = variants.get(discriminant)?.ty;
 
                 let checked = data.check_wf::<T>(locals, prog)?;
                 ensure(checked == ty);
@@ -340,11 +341,11 @@ impl PlaceExpr {
                     _ => throw!(),
                 }
             }
-            Downcast { root, variant_idx } => {
+            Downcast { root, discriminant } => {
                 let root = root.check_wf::<T>(locals, prog)?;
                 match root {
                     // A valid downcast points to an existing variant.
-                    Type::Enum { variants, .. } => variants.get(variant_idx)?.ty,
+                    Type::Enum { variants, .. } => variants.get(discriminant)?.ty,
                     _ => throw!(),
                 }
             }
@@ -650,8 +651,8 @@ impl<M: Memory> Value<M> {
                     ensure(data.len() == size.bytes())?;
                 }
             }
-            (Value::Variant { idx, data }, Type::Enum { variants, .. }) => {
-                let variant = variants.get(idx)?.ty;
+            (Value::Variant { discriminant, data }, Type::Enum { variants, .. }) => {
+                let variant = variants.get(discriminant)?.ty;
                 data.check_wf(variant)?;
             }
             _ => throw!()

--- a/tooling/minitest/src/tests/enum_discriminant.rs
+++ b/tooling/minitest/src/tests/enum_discriminant.rs
@@ -1,5 +1,7 @@
 use crate::*;
 
+const U8_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size::from_bytes_const(1) };
+
 /// It is ill-formed to write an invalid discriminant.
 #[test]
 fn ill_formed_invalid_discriminant_set() {
@@ -18,8 +20,13 @@ fn ill_formed_invalid_discriminant_set() {
 fn discriminant_get_and_set_work() {
     // single-variant enum without data and the tag 4 for the only variant
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), 4)])],
-        Discriminator::Branch { offset: offset(0), fallback: GcCow::new(Discriminator::Invalid), children: [(4, Discriminator::Known(0.into()))].into_iter().collect() },
+        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))])],
+        Discriminator::Branch {
+            offset: offset(0),
+            fallback: GcCow::new(Discriminator::Invalid),
+            value_type: U8_INTTYPE,
+            children: [(4.into(), Discriminator::Known(0.into()))].into_iter().collect()
+        },
         size(1),
         align(1)
     );
@@ -46,10 +53,15 @@ fn discriminant_setting_right_value() {
     // multi-variant enum without data and the tags 4 and 2.
     let enum_ty = enum_ty::<u8>(
         &[
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), 4)]),
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), 2)]),
+            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))]),
+            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 2.into()))]),
         ],
-        Discriminator::Branch { offset: offset(0), fallback: GcCow::new(Discriminator::Invalid), children: [(4, Discriminator::Known(0.into()))].into_iter().collect() },
+        Discriminator::Branch {
+            offset: offset(0),
+            fallback: GcCow::new(Discriminator::Invalid),
+            value_type: U8_INTTYPE,
+            children: [(4.into(), Discriminator::Known(0.into()))].into_iter().collect()
+        },
         size(1),
         align(1)
     );
@@ -82,8 +94,13 @@ fn discriminant_leaves_data_alone() {
 
     // single-variant enum with layout <u8 data, u8 tag, u16 data> and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[(offset(0), u8_t), (offset(2), u16_t)], size(4), align(2)), &[(offset(1), 1)])],
-        Discriminator::Branch { offset: offset(1), fallback: GcCow::new(Discriminator::Invalid), children: [].into_iter().collect() },
+        &[enum_variant(tuple_ty(&[(offset(0), u8_t), (offset(2), u16_t)], size(4), align(2)), &[(offset(1), (U8_INTTYPE, 1.into()))])],
+        Discriminator::Branch {
+            offset: offset(1),
+            fallback: GcCow::new(Discriminator::Invalid),
+            value_type: U8_INTTYPE,
+            children: [].into_iter().collect()
+        },
         size(4), align(2)
     );
     // the only local is a union of the enum and all its field seperately
@@ -114,8 +131,13 @@ fn discriminant_leaves_data_alone() {
 fn ub_discriminant_does_not_init() {
     // single variant enum with layout (u8 data, u8 tag) and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), 1u8)])],
-        Discriminator::Branch { offset: offset(1), fallback: GcCow::new(Discriminator::Invalid), children: [(1u8, Discriminator::Known(0.into()))].into_iter().collect() },
+        &[enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), (U8_INTTYPE, 1.into()))])],
+        Discriminator::Branch {
+            offset: offset(1),
+            fallback: GcCow::new(Discriminator::Invalid),
+            value_type: U8_INTTYPE,
+            children: [(1.into(), Discriminator::Known(0.into()))].into_iter().collect()
+        },
         size(2), align(1)
     );
     let locals = [enum_ty];
@@ -137,8 +159,13 @@ fn ub_discriminant_does_not_init() {
 fn ub_cannot_read_uninit_discriminant() {
     // single variant enum with layout (u8 data, u8 tag) and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), 1u8)])],
-        Discriminator::Branch { offset: offset(1), fallback: GcCow::new(Discriminator::Invalid), children: [(1u8, Discriminator::Known(0.into()))].into_iter().collect() },
+        &[enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), (U8_INTTYPE, 1.into()))])],
+        Discriminator::Branch {
+            offset: offset(1),
+            fallback: GcCow::new(Discriminator::Invalid),
+            value_type: U8_INTTYPE,
+            children: [(1.into(), Discriminator::Known(0.into()))].into_iter().collect()
+        },
         size(2), align(1)
     );
     let locals = [enum_ty];
@@ -161,8 +188,13 @@ fn ub_cannot_read_invalid_discriminant() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
     // single variant enum without data and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), 1u8)])],
-        Discriminator::Branch { offset: offset(0), fallback: GcCow::new(Discriminator::Invalid), children: [(1u8, Discriminator::Known(0.into()))].into_iter().collect() },
+        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 1.into()))])],
+        Discriminator::Branch {
+            offset: offset(0),
+            fallback: GcCow::new(Discriminator::Invalid),
+            value_type: U8_INTTYPE,
+            children: [(1.into(), Discriminator::Known(0.into()))].into_iter().collect()
+        },
         size(1), align(1)
     );
     let locals = [union_ty(&[(offset(0), enum_ty), (offset(0), u8_t)], size(1), align(1))];
@@ -192,7 +224,7 @@ fn ub_get_discriminant_on_misaligned_enum() {
         assign(local(1), get_discriminant(deref(ptr_offset(addr_of(local(0), raw_ptr_t), const_int(1u8), InBounds::Yes), enum_t))),
     ];
     let prog = small_program(&locals, &stmts);
-    assert_ub(prog, "Getting the discriminant of a place based on a misaligned pointer");
+    assert_ub(prog, "Getting the discriminant of a place based on a misaligned pointer.");
 }
 
 /// Setting discriminant of mis-aligned enum (ptr) is UB.
@@ -218,9 +250,14 @@ fn space_optimized_enum_works() {
     let enum_ty = enum_ty::<u8>(
         &[
             enum_variant(u8_t, &[]),
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), 0u8)]),
+            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 0.into()))]),
         ],
-        Discriminator::Branch { offset: offset(0), fallback: GcCow::new(Discriminator::Known(0.into())), children: [(0u8, Discriminator::Known(1.into()))].into_iter().collect() },
+        Discriminator::Branch {
+            offset: offset(0),
+            fallback: GcCow::new(Discriminator::Known(0.into())),
+            value_type: U8_INTTYPE,
+            children: [(0.into(), Discriminator::Known(1.into()))].into_iter().collect()
+        },
         size(1), align(1)
     );
     let locals = [union_ty(&[(offset(0), enum_ty), (offset(0), u8_t)], size(1), align(1))];

--- a/tooling/minitest/src/tests/enum_discriminant.rs
+++ b/tooling/minitest/src/tests/enum_discriminant.rs
@@ -5,7 +5,7 @@ const U8_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size::
 /// It is ill-formed to write an invalid discriminant.
 #[test]
 fn ill_formed_invalid_discriminant_set() {
-    let enum_ty = enum_ty::<u8>(&[], Discriminator::Invalid, size(0), align(1));
+    let enum_ty = enum_ty::<u8>(&[], discriminator_invalid(), size(0), align(1));
     let locals = [enum_ty];
     let stmts = [
         storage_live(0),
@@ -20,13 +20,12 @@ fn ill_formed_invalid_discriminant_set() {
 fn discriminant_get_and_set_work() {
     // single-variant enum without data and the tag 4 for the only variant
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))])],
-        Discriminator::Branch {
-            offset: offset(0),
-            fallback: GcCow::new(Discriminator::Invalid),
-            value_type: U8_INTTYPE,
-            children: [(4.into(), Discriminator::Known(0.into()))].into_iter().collect()
-        },
+        &[(0, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))]))],
+        discriminator_branch::<u8>(
+            offset(0),
+            discriminator_invalid(),
+            &[(4, discriminator_known(0))]
+        ),
         size(1),
         align(1)
     );
@@ -53,15 +52,14 @@ fn discriminant_setting_right_value() {
     // multi-variant enum without data and the tags 4 and 2.
     let enum_ty = enum_ty::<u8>(
         &[
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))]),
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 2.into()))]),
+            (0, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))])),
+            (1, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 2.into()))])),
         ],
-        Discriminator::Branch {
-            offset: offset(0),
-            fallback: GcCow::new(Discriminator::Invalid),
-            value_type: U8_INTTYPE,
-            children: [(4.into(), Discriminator::Known(0.into()))].into_iter().collect()
-        },
+        discriminator_branch::<u8>(
+            offset(0),
+            discriminator_invalid(),
+            &[(4, discriminator_known(0)), (2, discriminator_known(1))]
+        ),
         size(1),
         align(1)
     );
@@ -94,13 +92,12 @@ fn discriminant_leaves_data_alone() {
 
     // single-variant enum with layout <u8 data, u8 tag, u16 data> and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[(offset(0), u8_t), (offset(2), u16_t)], size(4), align(2)), &[(offset(1), (U8_INTTYPE, 1.into()))])],
-        Discriminator::Branch {
-            offset: offset(1),
-            fallback: GcCow::new(Discriminator::Invalid),
-            value_type: U8_INTTYPE,
-            children: [].into_iter().collect()
-        },
+        &[(0, enum_variant(tuple_ty(&[(offset(0), u8_t), (offset(2), u16_t)], size(4), align(2)), &[(offset(1), (U8_INTTYPE, 1.into()))]))],
+        discriminator_branch::<u8>(
+            offset(1),
+            discriminator_invalid(),
+            &[(1, discriminator_known(0))]
+        ),
         size(4), align(2)
     );
     // the only local is a union of the enum and all its field seperately
@@ -131,13 +128,12 @@ fn discriminant_leaves_data_alone() {
 fn ub_discriminant_does_not_init() {
     // single variant enum with layout (u8 data, u8 tag) and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), (U8_INTTYPE, 1.into()))])],
-        Discriminator::Branch {
-            offset: offset(1),
-            fallback: GcCow::new(Discriminator::Invalid),
-            value_type: U8_INTTYPE,
-            children: [(1.into(), Discriminator::Known(0.into()))].into_iter().collect()
-        },
+        &[(0, enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), (U8_INTTYPE, 1.into()))]))],
+        discriminator_branch::<u8>(
+            offset(1),
+            discriminator_invalid(),
+            &[(1, discriminator_known(0))]
+        ),
         size(2), align(1)
     );
     let locals = [enum_ty];
@@ -159,13 +155,12 @@ fn ub_discriminant_does_not_init() {
 fn ub_cannot_read_uninit_discriminant() {
     // single variant enum with layout (u8 data, u8 tag) and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), (U8_INTTYPE, 1.into()))])],
-        Discriminator::Branch {
-            offset: offset(1),
-            fallback: GcCow::new(Discriminator::Invalid),
-            value_type: U8_INTTYPE,
-            children: [(1.into(), Discriminator::Known(0.into()))].into_iter().collect()
-        },
+        &[(0, enum_variant(tuple_ty(&[(offset(0), int_ty(Signedness::Unsigned, size(1)))], size(2), align(1)), &[(offset(1), (U8_INTTYPE, 1.into()))]))],
+        discriminator_branch::<u8>(
+            offset(1),
+            discriminator_invalid(),
+            &[(1, discriminator_known(0))]
+        ),
         size(2), align(1)
     );
     let locals = [enum_ty];
@@ -188,13 +183,12 @@ fn ub_cannot_read_invalid_discriminant() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
     // single variant enum without data and tag 1
     let enum_ty = enum_ty::<u8>(
-        &[enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 1.into()))])],
-        Discriminator::Branch {
-            offset: offset(0),
-            fallback: GcCow::new(Discriminator::Invalid),
-            value_type: U8_INTTYPE,
-            children: [(1.into(), Discriminator::Known(0.into()))].into_iter().collect()
-        },
+        &[(0, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 1.into()))]))],
+        discriminator_branch::<u8>(
+            offset(0),
+            discriminator_invalid(),
+            &[(1, discriminator_known(0))]
+        ),
         size(1), align(1)
     );
     let locals = [union_ty(&[(offset(0), enum_ty), (offset(0), u8_t)], size(1), align(1))];
@@ -214,7 +208,7 @@ fn ub_cannot_read_invalid_discriminant() {
 /// Reading discriminant from mis-aligned enum (ptr) is UB.
 #[test]
 fn ub_get_discriminant_on_misaligned_enum() {
-    let enum_t = enum_ty::<u8>(&[enum_variant(<u16>::get_type(), &[])], Discriminator::Known(0.into()), size(2), align(2));
+    let enum_t = enum_ty::<u8>(&[(0, enum_variant(<u16>::get_type(), &[]))], discriminator_known(0), size(2), align(2));
     let raw_ptr_t = <*const [u16;2]>::get_type();
     let locals = [<[u16;2]>::get_type(), <u8>::get_type()];
     let stmts = [
@@ -230,7 +224,7 @@ fn ub_get_discriminant_on_misaligned_enum() {
 /// Setting discriminant of mis-aligned enum (ptr) is UB.
 #[test]
 fn ub_set_discriminant_on_misaligned_enum() {
-    let enum_t = enum_ty::<u8>(&[enum_variant(<u16>::get_type(), &[])], Discriminator::Known(0.into()), size(2), align(2));
+    let enum_t = enum_ty::<u8>(&[(0, enum_variant(<u16>::get_type(), &[]))], discriminator_known(0), size(2), align(2));
     let raw_ptr_t = <*const [u16;2]>::get_type();
     let locals = [<[u16;2]>::get_type()];
     let stmts = [
@@ -249,15 +243,14 @@ fn space_optimized_enum_works() {
     // a space-optimized version of `Option<NonZeroU8>` based on an actual u8
     let enum_ty = enum_ty::<u8>(
         &[
-            enum_variant(u8_t, &[]),
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 0.into()))]),
+            (0, enum_variant(u8_t, &[])),
+            (1, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 0.into()))])),
         ],
-        Discriminator::Branch {
-            offset: offset(0),
-            fallback: GcCow::new(Discriminator::Known(0.into())),
-            value_type: U8_INTTYPE,
-            children: [(0.into(), Discriminator::Known(1.into()))].into_iter().collect()
-        },
+        discriminator_branch::<u8>(
+            offset(0),
+            discriminator_known(0),
+            &[(0, discriminator_known(1))]
+        ),
         size(1), align(1)
     );
     let locals = [union_ty(&[(offset(0), enum_ty), (offset(0), u8_t)], size(1), align(1))];

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -6,7 +6,7 @@ const U8_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size::
 #[test]
 fn out_of_bounds_downcast() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let enum_ty = enum_ty::<u8>(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[(0, enum_variant(u8_t, &[]))], discriminator_known(0), size(1), align(1));
     let locals = &[enum_ty, u8_t];
     let stmts = &[
         storage_live(0),
@@ -21,7 +21,7 @@ fn out_of_bounds_downcast() {
 #[test]
 fn valid_downcast() {
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let enum_ty = enum_ty::<u8>(&[enum_variant(u8_t, &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[(0.into(), enum_variant(u8_t, &[]))], discriminator_known(0), size(1), align(1));
     let locals = &[enum_ty, u8_t];
     let stmts = &[
         storage_live(0),
@@ -42,13 +42,12 @@ fn downcasts_give_different_place() {
     let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 0.into()))]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
     let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 1.into()))]);
-    let discriminator = Discriminator::Branch {
-        offset: offset(2),
-        fallback: GcCow::new(Discriminator::Invalid),
-        value_type: U8_INTTYPE,
-        children: [(0.into(), Discriminator::Known(0.into())), (1.into(), Discriminator::Known(1.into()))].into_iter().collect()
-    };
-    let enum_ty = enum_ty::<u8>(&[variant1, variant2], discriminator, size(4), align(2));
+    let discriminator = discriminator_branch::<u8>(
+        offset(2),
+        discriminator_invalid(),
+        &[(0, discriminator_known(0)), (1, discriminator_known(1))]
+    );
+    let enum_ty = enum_ty::<u8>(&[(0.into(), variant1), (1.into(), variant2)], discriminator, size(4), align(2));
 
     let locals = &[enum_ty, u16_t];
     let stmts = &[
@@ -69,13 +68,12 @@ fn downcasts_give_different_place2() {
     let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 0.into()))]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
     let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 1.into()))]);
-    let discriminator = Discriminator::Branch {
-        offset: offset(2),
-        fallback: GcCow::new(Discriminator::Invalid),
-        value_type: U8_INTTYPE,
-        children: [(0.into(), Discriminator::Known(0.into())), (1.into(), Discriminator::Known(1.into()))].into_iter().collect()
-    };
-    let enum_ty = enum_ty::<u8>(&[variant1, variant2], discriminator, size(4), align(2));
+    let discriminator = discriminator_branch::<u8>(
+        offset(2),
+        discriminator_invalid(),
+        &[(0, discriminator_known(0)), (1, discriminator_known(1))]
+    );
+    let enum_ty = enum_ty::<u8>(&[(0.into(), variant1), (1.into(), variant2)], discriminator, size(4), align(2));
 
     let locals = &[enum_ty, u8_t];
     let stmts = &[

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -1,5 +1,7 @@
 use crate::*;
 
+const U8_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size::from_bytes_const(1) };
+
 /// Ill-formed: Downcasting to an out-of-bounds variant.
 #[test]
 fn out_of_bounds_downcast() {
@@ -37,13 +39,14 @@ fn valid_downcast() {
 fn downcasts_give_different_place() {
     // setup enum where the first two bytes are data (u8 / u16) and the third byte is the tag.
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), 0u8)]);
+    let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 0.into()))]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
-    let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), 1u8)]);
+    let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 1.into()))]);
     let discriminator = Discriminator::Branch {
         offset: offset(2),
         fallback: GcCow::new(Discriminator::Invalid),
-        children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
+        value_type: U8_INTTYPE,
+        children: [(0.into(), Discriminator::Known(0.into())), (1.into(), Discriminator::Known(1.into()))].into_iter().collect()
     };
     let enum_ty = enum_ty::<u8>(&[variant1, variant2], discriminator, size(4), align(2));
 
@@ -63,13 +66,14 @@ fn downcasts_give_different_place() {
 fn downcasts_give_different_place2() {
     // setup enum where the first two bytes are data (u8 / u16) and the third byte is the tag.
     let u8_t = int_ty(Signedness::Unsigned, size(1));
-    let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), 0)]);
+    let variant1 = enum_variant(tuple_ty(&[(offset(1), u8_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 0.into()))]);
     let u16_t = int_ty(Signedness::Unsigned, size(2));
-    let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), 1)]);
+    let variant2 = enum_variant(tuple_ty(&[(offset(0), u16_t)], size(4), align(2)), &[(offset(2), (U8_INTTYPE, 1.into()))]);
     let discriminator = Discriminator::Branch {
         offset: offset(2),
         fallback: GcCow::new(Discriminator::Invalid),
-        children: [(0, Discriminator::Known(0.into())), (1, Discriminator::Known(1.into()))].into_iter().collect()
+        value_type: U8_INTTYPE,
+        children: [(0.into(), Discriminator::Known(0.into())), (1.into(), Discriminator::Known(1.into()))].into_iter().collect()
     };
     let enum_ty = enum_ty::<u8>(&[variant1, variant2], discriminator, size(4), align(2));
 

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -5,7 +5,7 @@ const U8_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size::
 /// Ill-formed: the only variant has size 0, but the enum is size 1
 #[test]
 fn ill_sized_enum_variant() {
-    let enum_ty = enum_ty::<u8>(&[enum_variant(<()>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[(0, enum_variant(<()>::get_type(), &[]))], discriminator_known(0), size(1), align(1));
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -16,9 +16,9 @@ fn ill_sized_enum_variant() {
 #[test]
 fn inconsistently_sized_enum_variants() {
     let enum_ty = enum_ty::<u8>(&[
-            enum_variant(<()>::get_type(), &[(offset(1), (U8_INTTYPE, 2.into()))]),  // size 0
-            enum_variant(<bool>::get_type(), &[]),              // size 1
-        ], Discriminator::Invalid, size(1), align(1));       // size 1
+            (0, enum_variant(<()>::get_type(), &[(offset(1), (U8_INTTYPE, 2.into()))])),  // size 0
+            (1, enum_variant(<bool>::get_type(), &[])),                                   // size 1
+        ], discriminator_invalid(), size(1), align(1));                                   // size 1
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -28,7 +28,46 @@ fn inconsistently_sized_enum_variants() {
 /// Ill-formed: no variants but discriminator returns variant 1
 #[test]
 fn ill_formed_discriminator() {
-    let enum_ty = enum_ty::<u8>(&[], Discriminator::Known(1.into()), size(0), align(1));
+    let enum_ty = enum_ty::<u8>(&[], discriminator_known(1), size(0), align(1));
+    let locals = &[enum_ty];
+    let stmts = &[];
+    let prog = small_program(locals, stmts);
+    assert_ill_formed(prog);
+}
+
+/// Ill-formed: discriminator branch has a case of -1 which is an invalid value for u8. 
+#[test]
+fn ill_formed_discriminator_branch() {
+    // enum based on Option<NonZeroU8>.
+    let enum_ty = enum_ty::<u8>(&[
+            (0, enum_variant(<u8>::get_type(), &[])),
+            (1, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 0.into()))])),
+        ],
+        Discriminator::Branch {
+            offset: offset(0),
+            value_type: U8_INTTYPE,
+            fallback: GcCow::new(discriminator_known(0)),
+            children: [(Int::from(-1), discriminator_known(1))].into_iter().collect() // ill-formed here
+        },
+        size(1),
+        align(1)
+    );
+    let locals = &[enum_ty];
+    let stmts = &[];
+    let prog = small_program(locals, stmts);
+    assert_ill_formed(prog);
+}
+
+/// Ill-formed: discriminant is of type u8 but variant has discriminant -1.
+#[test]
+fn ill_formed_discriminant_value() {
+    let enum_ty = Type::Enum {
+        variants: [(Int::from(-1), enum_variant(<u8>::get_type(), &[]))].into_iter().collect(),
+        discriminant_ty: U8_INTTYPE,
+        discriminator: discriminator_known(-1),
+        size: size(1),
+        align: align(1),
+    };
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
@@ -41,17 +80,16 @@ fn simple_two_variant_works() {
     let bool_var_ty = enum_variant(Type::Bool, &[]);
     let empty_var_data_ty = tuple_ty(&[], size(1), align(1)); // unit with size 1
     let empty_var_ty = enum_variant(empty_var_data_ty, &[(offset(0), (U8_INTTYPE, 2.into()))]);
-    let discriminator = Discriminator::Branch {
-        offset: offset(0),
-        fallback: GcCow::new(Discriminator::Invalid),
-        value_type: U8_INTTYPE,
-        children: [
-            (0.into(), Discriminator::Known(0.into())),
-            (1.into(), Discriminator::Known(0.into())),
-            (2.into(), Discriminator::Known(1.into())),
-        ].into_iter().collect()
-    };
-    let enum_ty = enum_ty::<u8>(&[bool_var_ty, empty_var_ty], discriminator, size(1), align(1));
+    let discriminator = discriminator_branch::<u8>(
+        offset(0),
+        discriminator_invalid(),
+        &[
+            (0, discriminator_known(0)),
+            (1, discriminator_known(0)),
+            (2, discriminator_known(1)),
+        ]
+    );
+    let enum_ty = enum_ty::<u8>(&[(0, bool_var_ty), (1, empty_var_ty)], discriminator, size(1), align(1));
     
     let locals = &[enum_ty];
     let statements = &[
@@ -70,20 +108,20 @@ fn simple_two_variant_works() {
 /// It is the discriminant computation that fails, as we start off with Discriminator::Invalid.
 #[test]
 fn loading_uninhabited_enum_is_ub() {
-    let enum_ty = enum_ty::<u8>(&[], Discriminator::Invalid, size(0), align(1));
+    let enum_ty = enum_ty::<u8>(&[], discriminator_invalid(), size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),
         assign(local(0), load(local(0))), // UB here.
     ];
     let prog = small_program(locals, stmts);
-    assert_ub(prog, "load at type Enum { variants: List([]), discriminant_ty: IntType { signed: Unsigned, size: Size(1 bytes) }, discriminator: Invalid, size: Size(0 bytes), align: Align(1 bytes) } but the data in memory violates the validity invariant");
+    assert_ub(prog, "load at type Enum { variants: Map({}), discriminant_ty: IntType { signed: Unsigned, size: Size(1 bytes) }, discriminator: Invalid, size: Size(0 bytes), align: Align(1 bytes) } but the data in memory violates the validity invariant");
 }
 
 /// Ill-formed: trying to build a variant value of an uninhabited enum
 #[test]
 fn ill_formed_variant_constant() {
-    let enum_ty = enum_ty::<u8>(&[], Discriminator::Invalid, size(0), align(1));
+    let enum_ty = enum_ty::<u8>(&[], discriminator_invalid(), size(0), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),
@@ -96,7 +134,7 @@ fn ill_formed_variant_constant() {
 /// Ill-formed: The data of the variant value does not match the type
 #[test]
 fn ill_formed_variant_constant_data() {
-    let enum_ty = enum_ty::<u8>(&[enum_variant(<u8>::get_type(), &[])], Discriminator::Known(0.into()), size(1), align(1));
+    let enum_ty = enum_ty::<u8>(&[(0, enum_variant(<u8>::get_type(), &[]))], discriminator_known(0), size(1), align(1));
     let locals = &[enum_ty];
     let stmts = &[
         storage_live(0),
@@ -110,7 +148,7 @@ fn ill_formed_variant_constant_data() {
 /// Ill-formed: Ensures that the enum alignment is at least as big as all the variant alignments.
 #[test]
 fn ill_formed_enum_must_have_maximal_alignment_of_inner() {
-    let enum_ty = enum_ty::<u8>(&[enum_variant(<u16>::get_type(), &[])], Discriminator::Known(0.into()), size(2), align(1));
+    let enum_ty = enum_ty::<u8>(&[(0, enum_variant(<u16>::get_type(), &[]))], discriminator_known(0), size(2), align(1));
     let locals = [enum_ty];
     let stmts = [];
     let prog = small_program(&locals, &stmts);
@@ -123,14 +161,13 @@ const U32_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size:
 #[test]
 fn larger_sized_tag_works() {
     let variant_0_tuple_ty = tuple_ty(&[(offset(0), <u32>::get_type())], size(8), align(4));
-    let enum_ty = enum_ty::<u8>(
-        &[enum_variant(variant_0_tuple_ty, &[(offset(4), (U32_INTTYPE, 1048576.into()))])],
-        Discriminator::Branch {
-            offset: offset(4),
-            value_type: U32_INTTYPE,
-            fallback: GcCow::new(Discriminator::Invalid),
-            children: [(1048576.into(), Discriminator::Known(0.into()))].into_iter().collect()
-        },
+    let enum_ty = enum_ty::<u32>(
+        &[(1048576, enum_variant(variant_0_tuple_ty, &[(offset(4), (U32_INTTYPE, 1048576.into()))]))],
+        discriminator_branch::<u32>(
+            offset(4),
+            discriminator_invalid(),
+            &[(1048576, discriminator_known(1048576))]
+        ),
         size(8),
         align(4)
     );
@@ -138,7 +175,7 @@ fn larger_sized_tag_works() {
     let locals = &[enum_ty];
     let statements = &[
         storage_live(0),
-        assign(local(0), variant(0, tuple(&[const_int(2774879812u32)], variant_0_tuple_ty), enum_ty)),
+        assign(local(0), variant(1048576, tuple(&[const_int(2774879812u32)], variant_0_tuple_ty), enum_ty)),
         assign(local(0), load(local(0))),
         storage_dead(0)
     ];
@@ -150,14 +187,13 @@ fn larger_sized_tag_works() {
 #[test]
 fn larger_tag_has_no_alignment() {
     let variant_0_tuple_ty = tuple_ty(&[(offset(0), <u32>::get_type())], size(12), align(4));
-    let enum_ty = enum_ty::<u8>(
-        &[enum_variant(variant_0_tuple_ty, &[(offset(6), (U32_INTTYPE, 1048576.into()))])],
-        Discriminator::Branch {
-            offset: offset(6),
-            value_type: U32_INTTYPE,
-            fallback: GcCow::new(Discriminator::Invalid),
-            children: [(1048576.into(), Discriminator::Known(0.into()))].into_iter().collect()
-        },
+    let enum_ty = enum_ty::<u32>(
+        &[(1048576, enum_variant(variant_0_tuple_ty, &[(offset(6), (U32_INTTYPE, 1048576.into()))]))],
+        discriminator_branch::<u32>(
+            offset(6),
+            discriminator_invalid(),
+            &[(1048576, discriminator_known(1048576))]
+        ),
         size(12),
         align(4)
     );
@@ -165,7 +201,34 @@ fn larger_tag_has_no_alignment() {
     let locals = &[enum_ty];
     let statements = &[
         storage_live(0),
-        assign(local(0), variant(0, tuple(&[const_int(2774879812u32)], variant_0_tuple_ty), enum_ty)),
+        assign(local(0), variant(1048576, tuple(&[const_int(2774879812u32)], variant_0_tuple_ty), enum_ty)),
+        assign(local(0), load(local(0))),
+        storage_dead(0)
+    ];
+    let prog = small_program(locals, statements);
+    assert_stop(prog)
+}
+
+/// Works: tests that negative discriminants are valid.
+#[test]
+fn negative_discriminants_work() {
+    let i16_it = IntType { size: size(2), signed: Signedness::Signed };
+    let variant_0_tuple_ty = tuple_ty(&[(offset(0), <u32>::get_type())], size(8), align(4));
+    let enum_ty = enum_ty::<i16>(
+        &[(i16::MAX, enum_variant(variant_0_tuple_ty, &[(offset(4), (i16_it, (-12989).into()))]))],
+        discriminator_branch::<i16>(
+            offset(4),
+            discriminator_invalid(),
+            &[(-12989, discriminator_known(i16::MAX))]
+        ),
+        size(8),
+        align(4)
+    );
+
+    let locals = &[enum_ty];
+    let statements = &[
+        storage_live(0),
+        assign(local(0), variant(i16::MAX, tuple(&[const_int(2774879812u32)], variant_0_tuple_ty), enum_ty)),
         assign(local(0), load(local(0))),
         storage_dead(0)
     ];

--- a/tooling/minitest/src/tests/switch.rs
+++ b/tooling/minitest/src/tests/switch.rs
@@ -79,18 +79,14 @@ const U8_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size::
 fn switch_enum_works() {
     let enum_ty = enum_ty::<u8>(
         &[
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))]),
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 2.into()))]),
+            (0, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))])),
+            (1, enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 2.into()))])),
         ],
-        Discriminator::Branch {
-            offset: offset(0),
-            fallback: GcCow::new(Discriminator::Invalid),
-            value_type: U8_INTTYPE,
-            children: [
-                (2.into(), Discriminator::Known(1.into())),
-                (4.into(), Discriminator::Known(0.into())),
-            ].into_iter().collect()
-        },
+        discriminator_branch::<u8>(
+            offset(0),
+            discriminator_invalid(),
+            &[(2, discriminator_known(1)), (4, discriminator_known(0))]
+        ),
         size(1),
         align(1)
     );

--- a/tooling/minitest/src/tests/switch.rs
+++ b/tooling/minitest/src/tests/switch.rs
@@ -72,20 +72,23 @@ fn switch_int_works() {
     assert_stop(program);
 }
 
+const U8_INTTYPE: IntType = IntType { signed: Signedness::Unsigned, size: Size::from_bytes_const(1) };
+
 /// tests that switching on a enum discriminant is possible
 #[test]
 fn switch_enum_works() {
     let enum_ty = enum_ty::<u8>(
         &[
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), 4)]),
-            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), 2)]),
+            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 4.into()))]),
+            enum_variant(tuple_ty(&[], size(1), align(1)), &[(offset(0), (U8_INTTYPE, 2.into()))]),
         ],
         Discriminator::Branch {
             offset: offset(0),
             fallback: GcCow::new(Discriminator::Invalid),
+            value_type: U8_INTTYPE,
             children: [
-                (2, Discriminator::Known(1.into())),
-                (4, Discriminator::Known(0.into())),
+                (2.into(), Discriminator::Known(1.into())),
+                (4.into(), Discriminator::Known(0.into())),
             ].into_iter().collect()
         },
         size(1),

--- a/tooling/minitest/src/tests/zst.rs
+++ b/tooling/minitest/src/tests/zst.rs
@@ -69,7 +69,7 @@ fn zst_tuple2() {
 #[test]
 fn zst_enum() {
     let empty_var_ty = enum_variant(<()>::get_type(), &[]);
-    let locals = &[enum_ty::<u8>(&[empty_var_ty], Discriminator::Known(Int::from(0)), size(0), Align::ONE)];
+    let locals = &[enum_ty::<u8>(&[(0, empty_var_ty)], discriminator_known(0), size(0), Align::ONE)];
     let stmts = &[
         storage_live(0),
         assign(local(0), load(local(0))),

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -27,8 +27,8 @@ pub fn array(args: &[ValueExpr], elem_ty: Type) -> ValueExpr {
     ValueExpr::Tuple(args.iter().cloned().collect(), ty)
 }
 
-pub fn variant(idx: impl Into<Int>, data: ValueExpr, enum_ty: Type) -> ValueExpr {
-    ValueExpr::Variant { idx: idx.into(), data: GcCow::new(data), enum_ty}
+pub fn variant(discriminant: impl Into<Int>, data: ValueExpr, enum_ty: Type) -> ValueExpr {
+    ValueExpr::Variant { discriminant: discriminant.into(), data: GcCow::new(data), enum_ty}
 }
 
 pub fn get_discriminant(place: PlaceExpr) -> ValueExpr {
@@ -231,10 +231,10 @@ pub fn index(root: PlaceExpr, index: ValueExpr) -> PlaceExpr {
 }
 
 /// An enum downcast into the variant at the specified index.
-pub fn downcast(root: PlaceExpr, variant_idx: impl Into<Int>) -> PlaceExpr {
+pub fn downcast(root: PlaceExpr, discriminant: impl Into<Int>) -> PlaceExpr {
     PlaceExpr::Downcast {
         root: GcCow::new(root),
-        variant_idx: variant_idx.into(),
+        discriminant: discriminant.into(),
     }
 }
 

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -63,7 +63,7 @@ pub fn array_ty(elem: Type, count: impl Into<Int>) -> Type {
     }
 }
 
-pub fn enum_variant(ty: Type, tagger: &[(Offset, u8)]) -> Variant {
+pub fn enum_variant(ty: Type, tagger: &[(Offset, (IntType, Int))]) -> Variant {
     Variant {
         ty,
         tagger: tagger.iter().copied().collect()

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -53,11 +53,11 @@ pub(super) fn fmt_place_expr(p: PlaceExpr, comptypes: &mut Vec<CompType>) -> Fmt
             // This can be considered atomic due to the same reasoning as for PlaceExpr::Field, see above.
             FmtExpr::Atomic(format!("{root}[{index}]"))
         }
-        PlaceExpr::Downcast { root, variant_idx } => {
+        PlaceExpr::Downcast { root, discriminant } => {
             let root = fmt_place_expr(root.extract(), comptypes).to_atomic_string();
             // This is not atomic as `local(1) as variant 3.0` illustrates. (Field 0 of downcast)
             // We can't do it nicely like in the Rust MIR ({root} as {variant name}) since we have no variant names.
-            FmtExpr::NonAtomic(format!("{root} as variant {variant_idx}"))
+            FmtExpr::NonAtomic(format!("{root} as variant {discriminant}"))
         }
     }
 }
@@ -112,13 +112,13 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             FmtExpr::NonAtomic(format!("{union_ty} {{ field{field}: {expr} }}"))
         }
         ValueExpr::Variant {
-            idx,
+            discriminant,
             data,
             enum_ty,
         } => {
             let enum_ty = fmt_type(enum_ty, comptypes).to_string();
             let expr = fmt_value_expr(data.extract(), comptypes).to_string();
-            FmtExpr::NonAtomic(format!("{enum_ty} {{ variant{idx}: {expr} }}"))
+            FmtExpr::NonAtomic(format!("{enum_ty} {{ variant{discriminant}: {expr} }}"))
         }
         ValueExpr::GetDiscriminant {
             place

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -145,9 +145,9 @@ fn fmt_comptype(i: CompTypeIndex, t: CompType, comptypes: &mut Vec<CompType>) ->
             s += &fmt_comptype_chunks(chunks);
         },
         Type::Enum { variants, .. } => {
-            variants.iter().enumerate().for_each(|(idx, v)| {
+            variants.iter().for_each(|(discriminant, v)| {
                 let typ = fmt_type(v.ty, comptypes).to_string();
-                s += &format!("  Variant {idx}: {typ}");
+                s += &format!("  Variant {discriminant}: {typ}");
             });
         },
         _ => panic!("not a supported composite type!"),


### PR DESCRIPTION
Various changes around how MiniRust handles the discriminant.

- The `Discrimininator` now operates on arbitrary integer types, not only bytes.
- Replaces a list holding the variants in a map from discriminant to variant, completely removing the concept of a variant index in MiniRust. The minimizer will have to translate where rustc uses the variant index but I have checked all places known to me that this is possible.
- Adds a miniutil build interface for the Discriminator, removing a lot of explicit `Int` conversions in the test cases while also ensuring that we do not use invalid integers accidentally.
- Adds test cases for some situations that weren't tested previously.