### PR TITLE
minimize: turn functions using `FnCtxt` into methods

### DIFF
--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -3,114 +3,181 @@ use crate::*;
 // Some Rust features are not supported, and are ignored by `minimize`.
 // Those can be found by grepping "IGNORED".
 
-pub fn translate_bb<'cx, 'tcx>(
-    bb: &rs::BasicBlockData<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> BasicBlock {
-    let mut statements = List::new();
-    for stmt in bb.statements.iter() {
-        // unsupported statements will be IGNORED.
-        if let Some(stmts) = translate_stmt(stmt, fcx) {
-            for stmt in stmts {
-                statements.push(stmt);
+impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
+    pub fn translate_bb(&mut self, bb: &rs::BasicBlockData<'tcx>) -> BasicBlock {
+        let mut statements = List::new();
+        for stmt in bb.statements.iter() {
+            // unsupported statements will be IGNORED.
+            if let Some(stmts) = self.translate_stmt(stmt) {
+                for stmt in stmts {
+                    statements.push(stmt);
+                }
+            }
+        }
+        BasicBlock { statements, terminator: self.translate_terminator(bb.terminator()) }
+    }
+
+    fn translate_stmt(&mut self, stmt: &rs::Statement<'tcx>) -> Option<Vec<Statement>> {
+        Some(match &stmt.kind {
+            rs::StatementKind::Assign(box (place, rval)) => {
+                let destination = self.translate_place(place);
+                let (mut stmts, source) = self.translate_rvalue(rval)?; // assign of unsupported rvalues are IGNORED.
+
+                // this puts the extra statements before the evaluation of `destination`!
+                stmts.push(Statement::Assign { destination, source });
+                stmts
+            }
+            rs::StatementKind::StorageLive(local) => {
+                vec![Statement::StorageLive(self.local_name_map[&local])]
+            }
+            rs::StatementKind::StorageDead(local) => {
+                vec![Statement::StorageDead(self.local_name_map[&local])]
+            }
+            rs::StatementKind::Retag(kind, place) => {
+                let place = self.translate_place(place);
+                let fn_entry = matches!(kind, rs::RetagKind::FnEntry);
+                vec![Statement::Validate { place, fn_entry }]
+            }
+            rs::StatementKind::Deinit(place) => {
+                let place = self.translate_place(place);
+                vec![Statement::Deinit { place }]
+            }
+            rs::StatementKind::SetDiscriminant { place, variant_index } => {
+                let place_ty =
+                    rs::Place::ty_from(place.local, place.projection, &self.body, self.cx.tcx).ty;
+                let discriminant = self.discriminant_for_variant(place_ty, *variant_index);
+                vec![Statement::SetDiscriminant {
+                    destination: self.translate_place(place),
+                    value: discriminant,
+                }]
+            }
+            // FIXME: add assume intrinsic statement to MiniRust.
+            rs::StatementKind::Intrinsic(box rs::NonDivergingIntrinsic::Assume(_)) => vec![],
+            x => {
+                dbg!(x);
+                todo!()
+            }
+        })
+    }
+
+    fn translate_terminator(&mut self, terminator: &rs::Terminator<'tcx>) -> Terminator {
+        match &terminator.kind {
+            rs::TerminatorKind::Return => Terminator::Return,
+            rs::TerminatorKind::Goto { target } => Terminator::Goto(self.bb_name_map[&target]),
+            rs::TerminatorKind::Call { func, target, destination, args, .. } =>
+                self.translate_call(func, args, destination, target),
+            rs::TerminatorKind::SwitchInt { discr, targets } => {
+                let ty = self.translate_ty(discr.ty(&self.body, self.cx.tcx));
+
+                let discr_op = self.translate_operand(discr);
+                let (value, int_ty) = match ty {
+                    Type::Bool => {
+                        // If the value is a boolean we need to cast it to an integer first as MiniRust switch only operates on ints.
+                        let Type::Int(u8_inttype) = <u8>::get_type() else { unreachable!() };
+                        (
+                            ValueExpr::UnOp {
+                                operator: UnOp::Bool(UnOpBool::IntCast(u8_inttype)),
+                                operand: GcCow::new(discr_op),
+                            },
+                            u8_inttype,
+                        )
+                    }
+                    Type::Int(ity) => (discr_op, ity),
+                    // FIXME: add support for switching on `char`
+                    _ => panic!("SwitchInt terminator currently only supports int and bool."),
+                };
+
+                let cases = targets
+                    .iter()
+                    .map(|(value, target)| {
+                        (int_from_bits(value, int_ty), self.bb_name_map[&target])
+                    })
+                    .collect();
+
+                let fallback_block = targets.otherwise();
+                let fallback = self.bb_name_map[&fallback_block];
+
+                Terminator::Switch { value, cases, fallback }
+            }
+            rs::TerminatorKind::Unreachable => Terminator::Unreachable,
+            // those are IGNORED currently.
+            rs::TerminatorKind::Drop { target, .. } | rs::TerminatorKind::Assert { target, .. } =>
+                Terminator::Goto(self.bb_name_map[&target]),
+            x => {
+                unimplemented!("terminator not supported: {x:?}")
             }
         }
     }
-    BasicBlock { statements, terminator: translate_terminator(bb.terminator(), fcx) }
-}
 
-fn translate_stmt<'cx, 'tcx>(
-    stmt: &rs::Statement<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> Option<Vec<Statement>> {
-    Some(match &stmt.kind {
-        rs::StatementKind::Assign(box (place, rval)) => {
-            let destination = translate_place(place, fcx);
-            let (mut stmts, source) = translate_rvalue(rval, fcx)?; // assign of unsupported rvalues are IGNORED.
+    fn translate_call(
+        &mut self,
+        func: &rs::Operand<'tcx>,
+        args: &[rs::Spanned<rs::Operand<'tcx>>],
+        destination: &rs::Place<'tcx>,
+        target: &Option<rs::BasicBlock>,
+    ) -> Terminator {
+        // For now we only support calling specific functions, not function pointers.
+        let rs::Operand::Constant(box f1) = func else { panic!() };
+        let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
+        let &rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
+        let instance =
+            rs::Instance::resolve(self.cx.tcx, rs::ParamEnv::reveal_all(), f, substs_ref)
+                .unwrap()
+                .unwrap();
 
-            // this puts the extra statements before the evaluation of `destination`!
-            stmts.push(Statement::Assign { destination, source });
-            stmts
-        }
-        rs::StatementKind::StorageLive(local) => {
-            vec![Statement::StorageLive(fcx.local_name_map[&local])]
-        }
-        rs::StatementKind::StorageDead(local) => {
-            vec![Statement::StorageDead(fcx.local_name_map[&local])]
-        }
-        rs::StatementKind::Retag(kind, place) => {
-            let place = translate_place(place, fcx);
-            let fn_entry = matches!(kind, rs::RetagKind::FnEntry);
-            vec![Statement::Validate { place, fn_entry }]
-        }
-        rs::StatementKind::Deinit(place) => {
-            let place = translate_place(place, fcx);
-            vec![Statement::Deinit { place }]
-        }
-        rs::StatementKind::SetDiscriminant { place, variant_index } => {
-            let place_ty =
-                rs::Place::ty_from(place.local, place.projection, &fcx.body, fcx.cx.tcx).ty;
-            let discriminant = fcx.discriminant_for_variant(place_ty, *variant_index);
-            vec![Statement::SetDiscriminant {
-                destination: translate_place(place, fcx),
-                value: discriminant,
-            }]
-        }
-        // FIXME: add assume intrinsic statement to MiniRust.
-        rs::StatementKind::Intrinsic(box rs::NonDivergingIntrinsic::Assume(_)) => vec![],
-        x => {
-            dbg!(x);
-            todo!()
-        }
-    })
-}
-
-fn translate_terminator<'cx, 'tcx>(
-    terminator: &rs::Terminator<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> Terminator {
-    match &terminator.kind {
-        rs::TerminatorKind::Return => Terminator::Return,
-        rs::TerminatorKind::Goto { target } => Terminator::Goto(fcx.bb_name_map[&target]),
-        rs::TerminatorKind::Call { func, target, destination, args, .. } =>
-            translate_call(fcx, func, args, destination, target),
-        rs::TerminatorKind::SwitchInt { discr, targets } => {
-            let ty = fcx.translate_ty(discr.ty(&fcx.body, fcx.cx.tcx));
-
-            let discr_op = translate_operand(discr, fcx);
-            let (value, int_ty) = match ty {
-                Type::Bool => {
-                    // If the value is a boolean we need to cast it to an integer first as MiniRust switch only operates on ints.
-                    let Type::Int(u8_inttype) = <u8>::get_type() else { unreachable!() };
-                    (
-                        ValueExpr::UnOp {
-                            operator: UnOp::Bool(UnOpBool::IntCast(u8_inttype)),
-                            operand: GcCow::new(discr_op),
-                        },
-                        u8_inttype,
-                    )
-                }
-                Type::Int(ity) => (discr_op, ity),
-                // FIXME: add support for switching on `char`
-                _ => panic!("SwitchInt terminator currently only supports int and bool."),
+        if self.cx.tcx.crate_name(f.krate).as_str() == "intrinsics" {
+            let intrinsic = match self.cx.tcx.item_name(f).as_str() {
+                "print" => Intrinsic::PrintStdout,
+                "eprint" => Intrinsic::PrintStderr,
+                "exit" => Intrinsic::Exit,
+                "allocate" => Intrinsic::Allocate,
+                "deallocate" => Intrinsic::Deallocate,
+                "spawn" => Intrinsic::Spawn,
+                "join" => Intrinsic::Join,
+                "create_lock" => Intrinsic::Lock(LockIntrinsic::Create),
+                "acquire" => Intrinsic::Lock(LockIntrinsic::Acquire),
+                "release" => Intrinsic::Lock(LockIntrinsic::Release),
+                "atomic_store" => Intrinsic::AtomicStore,
+                "atomic_load" => Intrinsic::AtomicLoad,
+                "compare_exchange" => Intrinsic::AtomicCompareExchange,
+                "atomic_fetch_add" => Intrinsic::AtomicFetchAndOp(BinOpInt::Add),
+                "atomic_fetch_sub" => Intrinsic::AtomicFetchAndOp(BinOpInt::Sub),
+                name => panic!("unsupported intrinsic `{}`", name),
             };
+            Terminator::CallIntrinsic {
+                intrinsic,
+                arguments: args.iter().map(|x| self.translate_operand(&x.node)).collect(),
+                ret: self.translate_place(&destination),
+                next_block: target.as_ref().map(|t| self.bb_name_map[t]),
+            }
+        } else if is_panic_fn(&instance.to_string()) {
+            // We can't translate this call, it takes a string. So as a special hack we just make this `Unreachable`.
+            Terminator::Unreachable
+        } else {
+            let abi = self
+                .cx
+                .tcx
+                .fn_abi_of_instance(rs::ParamEnv::reveal_all().and((instance, rs::List::empty())))
+                .unwrap();
+            let conv = translate_calling_convention(abi.conv);
 
-            let cases = targets
+            let args: List<_> = args
                 .iter()
-                .map(|(value, target)| (int_from_bits(value, int_ty), fcx.bb_name_map[&target]))
+                .map(|op| {
+                    match &op.node {
+                        rs::Operand::Move(place) =>
+                            ArgumentExpr::InPlace(self.translate_place(place)),
+                        op => ArgumentExpr::ByValue(self.translate_operand(op)),
+                    }
+                })
                 .collect();
 
-            let fallback_block = targets.otherwise();
-            let fallback = fcx.bb_name_map[&fallback_block];
-
-            Terminator::Switch { value, cases, fallback }
-        }
-        rs::TerminatorKind::Unreachable => Terminator::Unreachable,
-        // those are IGNORED currently.
-        rs::TerminatorKind::Drop { target, .. } | rs::TerminatorKind::Assert { target, .. } =>
-            Terminator::Goto(fcx.bb_name_map[&target]),
-        x => {
-            unimplemented!("terminator not supported: {x:?}")
+            Terminator::Call {
+                callee: build::fn_ptr_conv(self.cx.get_fn_name(instance).0.get_internal(), conv),
+                arguments: args,
+                ret: self.translate_place(&destination),
+                next_block: target.as_ref().map(|t| self.bb_name_map[t]),
+            }
         }
     }
 }
@@ -118,74 +185,4 @@ fn translate_terminator<'cx, 'tcx>(
 // HACK to skip translating some functions we can't handle yet.
 fn is_panic_fn(name: &str) -> bool {
     name == "core::panicking::panic" || name == "core::panicking::panic_nounwind"
-}
-
-fn translate_call<'cx, 'tcx>(
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-    func: &rs::Operand<'tcx>,
-    args: &[rs::Spanned<rs::Operand<'tcx>>],
-    destination: &rs::Place<'tcx>,
-    target: &Option<rs::BasicBlock>,
-) -> Terminator {
-    // For now we only support calling specific functions, not function pointers.
-    let rs::Operand::Constant(box f1) = func else { panic!() };
-    let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
-    let &rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
-    let instance = rs::Instance::resolve(fcx.cx.tcx, rs::ParamEnv::reveal_all(), f, substs_ref)
-        .unwrap()
-        .unwrap();
-
-    if fcx.cx.tcx.crate_name(f.krate).as_str() == "intrinsics" {
-        let intrinsic = match fcx.cx.tcx.item_name(f).as_str() {
-            "print" => Intrinsic::PrintStdout,
-            "eprint" => Intrinsic::PrintStderr,
-            "exit" => Intrinsic::Exit,
-            "allocate" => Intrinsic::Allocate,
-            "deallocate" => Intrinsic::Deallocate,
-            "spawn" => Intrinsic::Spawn,
-            "join" => Intrinsic::Join,
-            "create_lock" => Intrinsic::Lock(LockIntrinsic::Create),
-            "acquire" => Intrinsic::Lock(LockIntrinsic::Acquire),
-            "release" => Intrinsic::Lock(LockIntrinsic::Release),
-            "atomic_store" => Intrinsic::AtomicStore,
-            "atomic_load" => Intrinsic::AtomicLoad,
-            "compare_exchange" => Intrinsic::AtomicCompareExchange,
-            "atomic_fetch_add" => Intrinsic::AtomicFetchAndOp(BinOpInt::Add),
-            "atomic_fetch_sub" => Intrinsic::AtomicFetchAndOp(BinOpInt::Sub),
-            name => panic!("unsupported intrinsic `{}`", name),
-        };
-        Terminator::CallIntrinsic {
-            intrinsic,
-            arguments: args.iter().map(|x| translate_operand(&x.node, fcx)).collect(),
-            ret: translate_place(&destination, fcx),
-            next_block: target.as_ref().map(|t| fcx.bb_name_map[t]),
-        }
-    } else if is_panic_fn(&instance.to_string()) {
-        // We can't translate this call, it takes a string. So as a special hack we just make this `Unreachable`.
-        Terminator::Unreachable
-    } else {
-        let abi = fcx
-            .cx
-            .tcx
-            .fn_abi_of_instance(rs::ParamEnv::reveal_all().and((instance, rs::List::empty())))
-            .unwrap();
-        let conv = translate_calling_convention(abi.conv);
-
-        let args: List<_> = args
-            .iter()
-            .map(|op| {
-                match &op.node {
-                    rs::Operand::Move(place) => ArgumentExpr::InPlace(translate_place(place, fcx)),
-                    op => ArgumentExpr::ByValue(translate_operand(op, fcx)),
-                }
-            })
-            .collect();
-
-        Terminator::Call {
-            callee: build::fn_ptr_conv(fcx.cx.get_fn_name(instance).0.get_internal(), conv),
-            arguments: args,
-            ret: translate_place(&destination, fcx),
-            next_block: target.as_ref().map(|t| fcx.bb_name_map[t]),
-        }
-    }
 }

--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -44,7 +44,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             }
             rs::StatementKind::SetDiscriminant { place, variant_index } => {
                 let place_ty =
-                    rs::Place::ty_from(place.local, place.projection, &self.body, self.cx.tcx).ty;
+                    rs::Place::ty_from(place.local, place.projection, &self.body, self.tcx).ty;
                 let discriminant = self.discriminant_for_variant(place_ty, *variant_index);
                 vec![Statement::SetDiscriminant {
                     destination: self.translate_place(place),
@@ -67,7 +67,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             rs::TerminatorKind::Call { func, target, destination, args, .. } =>
                 self.translate_call(func, args, destination, target),
             rs::TerminatorKind::SwitchInt { discr, targets } => {
-                let ty = self.translate_ty(discr.ty(&self.body, self.cx.tcx));
+                let ty = self.translate_ty(discr.ty(&self.body, self.tcx));
 
                 let discr_op = self.translate_operand(discr);
                 let (value, int_ty) = match ty {
@@ -121,12 +121,12 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
         let &rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
         let instance =
-            rs::Instance::resolve(self.cx.tcx, rs::ParamEnv::reveal_all(), f, substs_ref)
+            rs::Instance::resolve(self.tcx, rs::ParamEnv::reveal_all(), f, substs_ref)
                 .unwrap()
                 .unwrap();
 
-        if self.cx.tcx.crate_name(f.krate).as_str() == "intrinsics" {
-            let intrinsic = match self.cx.tcx.item_name(f).as_str() {
+        if self.tcx.crate_name(f.krate).as_str() == "intrinsics" {
+            let intrinsic = match self.tcx.item_name(f).as_str() {
                 "print" => Intrinsic::PrintStdout,
                 "eprint" => Intrinsic::PrintStderr,
                 "exit" => Intrinsic::Exit,

--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -120,10 +120,9 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         let rs::Operand::Constant(box f1) = func else { panic!() };
         let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
         let &rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
-        let instance =
-            rs::Instance::resolve(self.tcx, rs::ParamEnv::reveal_all(), f, substs_ref)
-                .unwrap()
-                .unwrap();
+        let instance = rs::Instance::resolve(self.tcx, rs::ParamEnv::reveal_all(), f, substs_ref)
+            .unwrap()
+            .unwrap();
 
         if self.tcx.crate_name(f.krate).as_str() == "intrinsics" {
             let intrinsic = match self.tcx.item_name(f).as_str() {

--- a/tooling/minimize/src/constant.rs
+++ b/tooling/minimize/src/constant.rs
@@ -49,8 +49,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             panic!("can't resolve unevaluated const!")
         };
         let cid = rs::GlobalId { instance, promoted: uneval.promoted };
-        let alloc =
-            self.tcx.eval_to_allocation_raw(rs::ParamEnv::reveal_all().and(cid)).unwrap();
+        let alloc = self.tcx.eval_to_allocation_raw(rs::ParamEnv::reveal_all().and(cid)).unwrap();
         let name = self.translate_alloc_id(alloc.alloc_id);
         let offset = Offset::ZERO;
 

--- a/tooling/minimize/src/constant.rs
+++ b/tooling/minimize/src/constant.rs
@@ -1,161 +1,153 @@
 use crate::*;
 
-pub fn translate_const<'cx, 'tcx>(
-    c: &rs::mir::Const<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> ValueExpr {
-    match c {
-        rs::mir::Const::Ty(_) => panic!("not supported!"),
-        rs::mir::Const::Unevaluated(uneval, ty) => translate_const_uneval(uneval, *ty, fcx),
-        rs::mir::Const::Val(val, ty) => translate_const_val(val, *ty, fcx),
-    }
-}
-
-fn translate_const_val<'cx, 'tcx>(
-    val: &rs::ConstValue<'tcx>,
-    ty: rs::Ty<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> ValueExpr {
-    let ty = fcx.translate_ty(ty);
-
-    let constant = match ty {
-        Type::Int(int_ty) => {
-            let val = val.try_to_scalar_int().unwrap();
-            let int: Int = match int_ty.signed {
-                Signed => val.try_to_int(val.size()).unwrap().into(),
-                Unsigned => val.try_to_uint(val.size()).unwrap().into(),
-            };
-            Constant::Int(int)
-        }
-        Type::Bool => Constant::Bool(val.try_to_bool().unwrap()),
-        Type::Tuple { fields, .. } if fields.is_empty() => {
-            return ValueExpr::Tuple(List::new(), ty);
-        }
-        // A `static`
-        Type::Ptr(_) => {
-            let (alloc_id, offset) =
-                val.try_to_scalar().unwrap().to_pointer(&fcx.cx.tcx).unwrap().into_parts();
-            let alloc_id = alloc_id.expect("no alloc id?").alloc_id();
-            let rel = translate_relocation(alloc_id, offset, fcx);
-            Constant::GlobalPointer(rel)
-        }
-        ty => panic!("unsupported type for `ConstVal`: {:?}", ty),
-    };
-    ValueExpr::Constant(constant, ty)
-}
-
-fn translate_const_uneval<'cx, 'tcx>(
-    uneval: &rs::UnevaluatedConst<'tcx>,
-    ty: rs::Ty<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> ValueExpr {
-    let Ok(Some(instance)) =
-        rs::Instance::resolve(fcx.cx.tcx, rs::ParamEnv::reveal_all(), uneval.def, uneval.args)
-    else {
-        panic!("can't resolve unevaluated const!")
-    };
-    let cid = rs::GlobalId { instance, promoted: uneval.promoted };
-    let alloc = fcx.cx.tcx.eval_to_allocation_raw(rs::ParamEnv::reveal_all().and(cid)).unwrap();
-    let name = translate_alloc_id(alloc.alloc_id, fcx);
-    let offset = Offset::ZERO;
-
-    let rel = Relocation { name, offset };
-    relocation_to_value_expr(rel, ty, fcx)
-}
-
-fn relocation_to_value_expr<'cx, 'tcx>(
-    rel: Relocation,
-    ty: rs::Ty<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> ValueExpr {
-    let expr = Constant::GlobalPointer(rel);
-
-    let ty = fcx.translate_ty(ty);
-    let ptr_ty = Type::Ptr(PtrType::Raw);
-
-    let expr = ValueExpr::Constant(expr, ptr_ty);
-    let expr = PlaceExpr::Deref { operand: GcCow::new(expr), ty };
-    ValueExpr::Load { source: GcCow::new(expr) }
-}
-
-fn translate_relocation<'cx, 'tcx>(
-    alloc_id: rs::AllocId,
-    offset: rs::Size,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> Relocation {
-    let name = translate_alloc_id(alloc_id, fcx);
-    let offset = translate_size(offset);
-    Relocation { name, offset }
-}
-
-// calls `translate_const_allocation` with the allocation of alloc_id,
-// and adds the alloc_id and its newly-created global to alloc_map.
-fn translate_alloc_id<'cx, 'tcx>(alloc_id: rs::AllocId, fcx: &mut FnCtxt<'cx, 'tcx>) -> GlobalName {
-    if let Some(x) = fcx.cx.alloc_map.get(&alloc_id) {
-        return *x;
-    }
-
-    let name = fresh_global_name(fcx);
-    fcx.cx.alloc_map.insert(alloc_id, name);
-
-    let alloc = match fcx.cx.tcx.global_alloc(alloc_id) {
-        rs::GlobalAlloc::Memory(alloc) => alloc,
-        rs::GlobalAlloc::Static(def_id) => fcx.cx.tcx.eval_static_initializer(def_id).unwrap(),
-        _ => panic!("unsupported!"),
-    };
-    translate_const_allocation(alloc, fcx, name);
-    name
-}
-
-// adds a Global representing this ConstAllocation, and returns the corresponding GlobalName.
-fn translate_const_allocation<'cx, 'tcx>(
-    allocation: rs::ConstAllocation<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-    name: GlobalName,
-) {
-    let allocation = allocation.inner();
-    let size = allocation.size();
-    let mut bytes: Vec<Option<u8>> = allocation
-        .inspect_with_uninit_and_ptr_outside_interpreter(0..size.bytes_usize())
-        .iter()
-        .copied()
-        .map(Some)
-        .collect();
-    for (i, b) in bytes.iter_mut().enumerate() {
-        if !allocation.init_mask().get(rs::Size::from_bytes(i)) {
-            *b = None;
+impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
+    pub fn translate_const(&mut self, c: &rs::mir::Const<'tcx>) -> ValueExpr {
+        match c {
+            rs::mir::Const::Ty(_) => panic!("not supported!"),
+            rs::mir::Const::Unevaluated(uneval, ty) => self.translate_const_uneval(uneval, *ty),
+            rs::mir::Const::Val(val, ty) => self.translate_const_val(val, *ty),
         }
     }
-    let relocations = allocation
-        .provenance()
-        .ptrs()
-        .iter()
-        .map(|&(offset, alloc_id)| {
-            // "Note that the bytes of a pointer represent the offset of the pointer.", see https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/struct.Allocation.html
-            // Hence we have to decode them.
-            let inner_offset_bytes: &[Option<u8>] = &bytes[offset.bytes() as usize..]
-                [..DefaultTarget::PTR_SIZE.bytes().try_to_usize().unwrap()];
-            let inner_offset_bytes: List<u8> =
-                inner_offset_bytes.iter().map(|x| x.unwrap()).collect();
-            let inner_offset: Int = DefaultTarget::ENDIANNESS.decode(Unsigned, inner_offset_bytes);
-            let inner_offset = rs::Size::from_bytes(inner_offset.try_to_usize().unwrap());
-            let relo = translate_relocation(alloc_id.alloc_id(), inner_offset, fcx);
 
-            let offset = translate_size(offset);
-            (offset, relo)
-        })
-        .collect();
-    let align = translate_align(allocation.align);
-    let global = Global { bytes: bytes.into_iter().collect(), relocations, align };
+    fn translate_const_val(&mut self, val: &rs::ConstValue<'tcx>, ty: rs::Ty<'tcx>) -> ValueExpr {
+        let ty = self.translate_ty(ty);
 
-    fcx.cx.globals.insert(name, global);
-}
+        let constant = match ty {
+            Type::Int(int_ty) => {
+                let val = val.try_to_scalar_int().unwrap();
+                let int: Int = match int_ty.signed {
+                    Signed => val.try_to_int(val.size()).unwrap().into(),
+                    Unsigned => val.try_to_uint(val.size()).unwrap().into(),
+                };
+                Constant::Int(int)
+            }
+            Type::Bool => Constant::Bool(val.try_to_bool().unwrap()),
+            Type::Tuple { fields, .. } if fields.is_empty() => {
+                return ValueExpr::Tuple(List::new(), ty);
+            }
+            // A `static`
+            Type::Ptr(_) => {
+                let (alloc_id, offset) =
+                    val.try_to_scalar().unwrap().to_pointer(&self.cx.tcx).unwrap().into_parts();
+                let alloc_id = alloc_id.expect("no alloc id?").alloc_id();
+                let rel = self.translate_relocation(alloc_id, offset);
+                Constant::GlobalPointer(rel)
+            }
+            ty => panic!("unsupported type for `ConstVal`: {:?}", ty),
+        };
+        ValueExpr::Constant(constant, ty)
+    }
 
-fn fresh_global_name<'cx, 'tcx>(fcx: &mut FnCtxt<'cx, 'tcx>) -> GlobalName {
-    let name = GlobalName(Name::from_internal(fcx.cx.globals.iter().count() as _)); // TODO use .len() here, if supported
-    // the default_global is added so that calling `fresh_global_name` twice returns different names.
-    let default_global =
-        Global { bytes: Default::default(), relocations: Default::default(), align: Align::ONE };
-    fcx.cx.globals.insert(name, default_global);
-    name
+    fn translate_const_uneval(
+        &mut self,
+        uneval: &rs::UnevaluatedConst<'tcx>,
+        ty: rs::Ty<'tcx>,
+    ) -> ValueExpr {
+        let Ok(Some(instance)) =
+            rs::Instance::resolve(self.cx.tcx, rs::ParamEnv::reveal_all(), uneval.def, uneval.args)
+        else {
+            panic!("can't resolve unevaluated const!")
+        };
+        let cid = rs::GlobalId { instance, promoted: uneval.promoted };
+        let alloc =
+            self.cx.tcx.eval_to_allocation_raw(rs::ParamEnv::reveal_all().and(cid)).unwrap();
+        let name = self.translate_alloc_id(alloc.alloc_id);
+        let offset = Offset::ZERO;
+
+        let rel = Relocation { name, offset };
+        self.relocation_to_value_expr(rel, ty)
+    }
+
+    fn relocation_to_value_expr(&mut self, rel: Relocation, ty: rs::Ty<'tcx>) -> ValueExpr {
+        let expr = Constant::GlobalPointer(rel);
+
+        let ty = self.translate_ty(ty);
+        let ptr_ty = Type::Ptr(PtrType::Raw);
+
+        let expr = ValueExpr::Constant(expr, ptr_ty);
+        let expr = PlaceExpr::Deref { operand: GcCow::new(expr), ty };
+        ValueExpr::Load { source: GcCow::new(expr) }
+    }
+
+    fn translate_relocation(&mut self, alloc_id: rs::AllocId, offset: rs::Size) -> Relocation {
+        let name = self.translate_alloc_id(alloc_id);
+        let offset = translate_size(offset);
+        Relocation { name, offset }
+    }
+
+    // calls `translate_const_allocation` with the allocation of alloc_id,
+    // and adds the alloc_id and its newly-created global to alloc_map.
+    fn translate_alloc_id(&mut self, alloc_id: rs::AllocId) -> GlobalName {
+        if let Some(x) = self.cx.alloc_map.get(&alloc_id) {
+            return *x;
+        }
+
+        let name = self.fresh_global_name();
+        self.cx.alloc_map.insert(alloc_id, name);
+
+        let alloc = match self.cx.tcx.global_alloc(alloc_id) {
+            rs::GlobalAlloc::Memory(alloc) => alloc,
+            rs::GlobalAlloc::Static(def_id) => self.cx.tcx.eval_static_initializer(def_id).unwrap(),
+            _ => panic!("unsupported!"),
+        };
+        self.translate_const_allocation(alloc, name);
+        name
+    }
+
+    // adds a Global representing this ConstAllocation, and returns the corresponding GlobalName.
+    fn translate_const_allocation(
+        &mut self,
+        allocation: rs::ConstAllocation<'tcx>,
+        name: GlobalName,
+    ) {
+        let allocation = allocation.inner();
+        let size = allocation.size();
+        let mut bytes: Vec<Option<u8>> = allocation
+            .inspect_with_uninit_and_ptr_outside_interpreter(0..size.bytes_usize())
+            .iter()
+            .copied()
+            .map(Some)
+            .collect();
+        for (i, b) in bytes.iter_mut().enumerate() {
+            if !allocation.init_mask().get(rs::Size::from_bytes(i)) {
+                *b = None;
+            }
+        }
+        let relocations = allocation
+            .provenance()
+            .ptrs()
+            .iter()
+            .map(|&(offset, alloc_id)| {
+                // "Note that the bytes of a pointer represent the offset of the pointer.", see https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/struct.Allocation.html
+                // Hence we have to decode them.
+                let inner_offset_bytes: &[Option<u8>] = &bytes[offset.bytes() as usize..]
+                    [..DefaultTarget::PTR_SIZE.bytes().try_to_usize().unwrap()];
+                let inner_offset_bytes: List<u8> =
+                    inner_offset_bytes.iter().map(|x| x.unwrap()).collect();
+                let inner_offset: Int =
+                    DefaultTarget::ENDIANNESS.decode(Unsigned, inner_offset_bytes);
+                let inner_offset = rs::Size::from_bytes(inner_offset.try_to_usize().unwrap());
+                let relo = self.translate_relocation(alloc_id.alloc_id(), inner_offset);
+
+                let offset = translate_size(offset);
+                (offset, relo)
+            })
+            .collect();
+        let align = translate_align(allocation.align);
+        let global = Global { bytes: bytes.into_iter().collect(), relocations, align };
+
+        self.cx.globals.insert(name, global);
+    }
+
+    fn fresh_global_name(&mut self) -> GlobalName {
+        let name = GlobalName(Name::from_internal(self.cx.globals.iter().count() as _)); // TODO use .len() here, if supported
+        // the default_global is added so that calling `fresh_global_name` twice returns different names.
+        let default_global = Global {
+            bytes: Default::default(),
+            relocations: Default::default(),
+            align: Align::ONE,
+        };
+        self.cx.globals.insert(name, default_global);
+        name
+    }
 }

--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -46,13 +46,10 @@ mod ty;
 use ty::*;
 
 mod bb;
-use bb::*;
 
 mod rvalue;
-use rvalue::*;
 
 mod constant;
-use constant::*;
 
 mod get;
 use get::get_mini;

--- a/tooling/minimize/src/program.rs
+++ b/tooling/minimize/src/program.rs
@@ -213,7 +213,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         for (id, bb_name) in self.bb_name_map.clone() {
             // TODO fix clone
             let bb_data = &self.body.basic_blocks[id].clone(); // TODO fix clone
-            let bb = translate_bb(bb_data, &mut self);
+            let bb = self.translate_bb(bb_data);
             self.blocks.insert(bb_name, bb);
         }
         self.blocks.insert(init_bb, init_blk);

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -207,8 +207,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     }
                 }
                 rs::Rvalue::Repeat(op, c) => {
-                    let c =
-                        c.try_eval_target_usize(self.tcx, rs::ParamEnv::reveal_all()).unwrap();
+                    let c = c.try_eval_target_usize(self.tcx, rs::ParamEnv::reveal_all()).unwrap();
                     let c = Int::from(c);
 
                     let elem_ty = self.translate_ty(op.ty(&self.body, self.tcx));
@@ -227,14 +226,10 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     let rs::Operand::Constant(box f1) = func else { panic!() };
                     let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
                     let rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
-                    let instance = rs::Instance::resolve(
-                        self.tcx,
-                        rs::ParamEnv::reveal_all(),
-                        *f,
-                        substs_ref,
-                    )
-                    .unwrap()
-                    .unwrap();
+                    let instance =
+                        rs::Instance::resolve(self.tcx, rs::ParamEnv::reveal_all(), *f, substs_ref)
+                            .unwrap()
+                            .unwrap();
 
                     build::fn_ptr(self.cx.get_fn_name(instance).0.get_internal())
                 }

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -1,307 +1,312 @@
 use crate::*;
 
-/// Translate an rvalue -- could generate a bunch of helper statements.
-pub fn translate_rvalue<'cx, 'tcx>(
-    rv: &rs::Rvalue<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> Option<(Vec<Statement>, ValueExpr)> {
-    Some((
-        vec![],
-        match rv {
-            rs::Rvalue::Use(operand) => translate_operand(operand, fcx),
-            rs::Rvalue::CheckedBinaryOp(bin_op, box (l, r))
-            | rs::Rvalue::BinaryOp(bin_op, box (l, r)) => {
-                let lty = l.ty(&fcx.body, fcx.cx.tcx);
-                let rty = r.ty(&fcx.body, fcx.cx.tcx);
+impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
+    /// Translate an rvalue -- could generate a bunch of helper statements.
+    pub fn translate_rvalue(
+        &mut self,
+        rv: &rs::Rvalue<'tcx>,
+    ) -> Option<(Vec<Statement>, ValueExpr)> {
+        Some((
+            vec![],
+            match rv {
+                rs::Rvalue::Use(operand) => self.translate_operand(operand),
+                rs::Rvalue::CheckedBinaryOp(bin_op, box (l, r))
+                | rs::Rvalue::BinaryOp(bin_op, box (l, r)) => {
+                    let lty = l.ty(&self.body, self.cx.tcx);
+                    let rty = r.ty(&self.body, self.cx.tcx);
 
-                assert_eq!(lty, rty);
+                    assert_eq!(lty, rty);
 
-                let l = translate_operand(l, fcx);
-                let r = translate_operand(r, fcx);
+                    let l = self.translate_operand(l);
+                    let r = self.translate_operand(r);
 
-                let l = GcCow::new(l);
-                let r = GcCow::new(r);
+                    let l = GcCow::new(l);
+                    let r = GcCow::new(r);
 
-                use rs::BinOp::*;
-                let op = if *bin_op == Offset {
-                    BinOp::PtrOffset { inbounds: true }
-                } else {
-                    // everything else right-now is a int op!
+                    use rs::BinOp::*;
+                    let op = if *bin_op == Offset {
+                        BinOp::PtrOffset { inbounds: true }
+                    } else {
+                        // everything else right-now is a int op!
 
-                    let op = |x| {
-                        let Type::Int(int_ty) = fcx.translate_ty(lty) else {
-                            panic!("arithmetic operation with non-int type unsupported!");
+                        let op = |x| {
+                            let Type::Int(int_ty) = self.translate_ty(lty) else {
+                                panic!("arithmetic operation with non-int type unsupported!");
+                            };
+
+                            BinOp::Int(x, int_ty)
                         };
+                        let rel = |x| BinOp::IntRel(x);
 
-                        BinOp::Int(x, int_ty)
+                        match bin_op {
+                            Add => op(BinOpInt::Add),
+                            Sub => op(BinOpInt::Sub),
+                            Mul => op(BinOpInt::Mul),
+                            Div => op(BinOpInt::Div),
+                            Rem => op(BinOpInt::Rem),
+
+                            Lt => rel(IntRel::Lt),
+                            Le => rel(IntRel::Le),
+                            Gt => rel(IntRel::Gt),
+                            Ge => rel(IntRel::Ge),
+                            Eq => rel(IntRel::Eq),
+                            Ne => rel(IntRel::Ne),
+
+                            BitAnd => return None,
+                            x => {
+                                dbg!(x);
+                                todo!("unsupported BinOp")
+                            }
+                        }
                     };
-                    let rel = |x| BinOp::IntRel(x);
 
-                    match bin_op {
-                        Add => op(BinOpInt::Add),
-                        Sub => op(BinOpInt::Sub),
-                        Mul => op(BinOpInt::Mul),
-                        Div => op(BinOpInt::Div),
-                        Rem => op(BinOpInt::Rem),
-
-                        Lt => rel(IntRel::Lt),
-                        Le => rel(IntRel::Le),
-                        Gt => rel(IntRel::Gt),
-                        Ge => rel(IntRel::Ge),
-                        Eq => rel(IntRel::Eq),
-                        Ne => rel(IntRel::Ne),
-
-                        BitAnd => return None,
-                        x => {
-                            dbg!(x);
-                            todo!("unsupported BinOp")
-                        }
-                    }
-                };
-
-                ValueExpr::BinOp { operator: op, left: l, right: r }
-            }
-            rs::Rvalue::UnaryOp(unop, operand) =>
-                match unop {
-                    rs::UnOp::Neg => {
-                        let ty = operand.ty(&fcx.body, fcx.cx.tcx);
-                        let ty = fcx.translate_ty(ty);
-                        let Type::Int(int_ty) = ty else {
-                            panic!("Neg operation with non-int type!");
-                        };
-
-                        let operand = translate_operand(operand, fcx);
-
-                        ValueExpr::UnOp {
-                            operator: UnOp::Int(UnOpInt::Neg, int_ty),
-                            operand: GcCow::new(operand),
-                        }
-                    }
-                    rs::UnOp::Not => {
-                        let ty = operand.ty(&fcx.body, fcx.cx.tcx);
-                        let ty = fcx.translate_ty(ty);
-                        let Type::Bool = ty else {
-                            panic!("Not operation with non-boolean type!");
-                        };
-
-                        let operand = translate_operand(operand, fcx);
-
-                        ValueExpr::UnOp {
-                            operator: UnOp::Bool(UnOpBool::Not),
-                            operand: GcCow::new(operand),
-                        }
-                    }
-                },
-            rs::Rvalue::Ref(_, bkind, place) => {
-                let ty = place.ty(&fcx.body, fcx.cx.tcx).ty;
-                let pointee = fcx.layout_of(ty);
-
-                let place = translate_place(place, fcx);
-                let target = GcCow::new(place);
-                let mutbl = translate_mutbl(bkind.to_mutbl_lossy());
-
-                let ptr_ty = PtrType::Ref { mutbl, pointee };
-
-                ValueExpr::AddrOf { target, ptr_ty }
-            }
-            rs::Rvalue::AddressOf(_mutbl, place) => {
-                let place = translate_place(place, fcx);
-                let target = GcCow::new(place);
-
-                let ptr_ty = PtrType::Raw;
-
-                ValueExpr::AddrOf { target, ptr_ty }
-            }
-            rs::Rvalue::Aggregate(box agg, operands) => {
-                let ty = rv.ty(&fcx.body, fcx.cx.tcx);
-                let ty = fcx.translate_ty(ty);
-                match ty {
-                    Type::Union { .. } => {
-                        let rs::AggregateKind::Adt(_, _, _, _, Some(field_idx)) = agg else {
-                            panic!()
-                        };
-                        assert_eq!(operands.len(), 1);
-                        let expr = translate_operand(&operands[rs::FieldIdx::from_u32(0)], fcx);
-                        ValueExpr::Union {
-                            field: field_idx.index().into(),
-                            expr: GcCow::new(expr),
-                            union_ty: ty,
-                        }
-                    }
-                    Type::Tuple { .. } | Type::Array { .. } => {
-                        let ops: List<_> =
-                            operands.iter().map(|x| translate_operand(x, fcx)).collect();
-                        ValueExpr::Tuple(ops, ty)
-                    }
-                    Type::Enum { variants, .. } => {
-                        let rs::AggregateKind::Adt(_, variant_idx, _, _, _) = agg else { panic!() };
-                        let discriminant = fcx
-                            .discriminant_for_variant(rv.ty(&fcx.body, fcx.cx.tcx), *variant_idx);
-                        let ops: List<_> =
-                            operands.iter().map(|x| translate_operand(x, fcx)).collect();
-
-                        // We represent the multiple fields of an enum variant as a MiniRust tuple.
-                        let data = GcCow::new(ValueExpr::Tuple(
-                            ops,
-                            variants.get(discriminant).unwrap().ty,
-                        ));
-                        ValueExpr::Variant { discriminant, data, enum_ty: ty }
-                    }
-                    _ => panic!("invalid aggregate type!"),
+                    ValueExpr::BinOp { operator: op, left: l, right: r }
                 }
-            }
-            rs::Rvalue::CopyForDeref(place) =>
-                ValueExpr::Load { source: GcCow::new(translate_place(place, fcx)) },
-            rs::Rvalue::Len(place) => {
-                // as slices are unsupported as of now, we only need to care for arrays.
-                let ty = place.ty(&fcx.body, fcx.cx.tcx).ty;
-                let Type::Array { elem: _, count } = fcx.translate_ty(ty) else { panic!() };
-                ValueExpr::Constant(Constant::Int(count), <usize>::get_type())
-            }
-            rs::Rvalue::Discriminant(place) =>
-                ValueExpr::GetDiscriminant { place: GcCow::new(translate_place(place, fcx)) },
-            rs::Rvalue::Cast(rs::CastKind::IntToInt, operand, ty) => {
-                let operand_ty = fcx.translate_ty(operand.ty(&fcx.body.local_decls, fcx.cx.tcx));
-                let operand = translate_operand(operand, fcx);
-                let Type::Int(int_ty) = fcx.translate_ty(*ty) else {
-                    panic!("attempting to IntToInt-Cast to non-int type!");
-                };
+                rs::Rvalue::UnaryOp(unop, operand) =>
+                    match unop {
+                        rs::UnOp::Neg => {
+                            let ty = operand.ty(&self.body, self.cx.tcx);
+                            let ty = self.translate_ty(ty);
+                            let Type::Int(int_ty) = ty else {
+                                panic!("Neg operation with non-int type!");
+                            };
 
-                let unop = match operand_ty {
-                    Type::Int(_) => UnOp::Int(UnOpInt::Cast, int_ty),
-                    Type::Bool => UnOp::Bool(UnOpBool::IntCast(int_ty)),
-                    _ => panic!("Attempting to cast non-int or boolean type to int!"),
-                };
-                ValueExpr::UnOp { operator: unop, operand: GcCow::new(operand) }
-            }
-            rs::Rvalue::Cast(rs::CastKind::PointerExposeAddress, operand, _) => {
-                let operand = translate_operand(operand, fcx);
-                let expose = Statement::Expose { value: operand };
-                let addr = build::ptr_addr(operand);
+                            let operand = self.translate_operand(operand);
 
-                return Some((vec![expose], addr));
-            }
-            rs::Rvalue::Cast(rs::CastKind::PointerFromExposedAddress, operand, ty) => {
-                // TODO untested so far! (Can't test because of `predict`)
-                let operand = translate_operand(operand, fcx);
-                let Type::Ptr(ptr_ty) = fcx.translate_ty(*ty) else { panic!() };
+                            ValueExpr::UnOp {
+                                operator: UnOp::Int(UnOpInt::Neg, int_ty),
+                                operand: GcCow::new(operand),
+                            }
+                        }
+                        rs::UnOp::Not => {
+                            let ty = operand.ty(&self.body, self.cx.tcx);
+                            let ty = self.translate_ty(ty);
+                            let Type::Bool = ty else {
+                                panic!("Not operation with non-boolean type!");
+                            };
 
-                ValueExpr::UnOp {
-                    operator: UnOp::PtrFromExposed(ptr_ty),
-                    operand: GcCow::new(operand),
+                            let operand = self.translate_operand(operand);
+
+                            ValueExpr::UnOp {
+                                operator: UnOp::Bool(UnOpBool::Not),
+                                operand: GcCow::new(operand),
+                            }
+                        }
+                    },
+                rs::Rvalue::Ref(_, bkind, place) => {
+                    let ty = place.ty(&self.body, self.cx.tcx).ty;
+                    let pointee = self.layout_of(ty);
+
+                    let place = self.translate_place(place);
+                    let target = GcCow::new(place);
+                    let mutbl = translate_mutbl(bkind.to_mutbl_lossy());
+
+                    let ptr_ty = PtrType::Ref { mutbl, pointee };
+
+                    ValueExpr::AddrOf { target, ptr_ty }
                 }
-            }
-            rs::Rvalue::Cast(rs::CastKind::PtrToPtr, operand, ty) => {
-                let operand = translate_operand(operand, fcx);
-                let Type::Ptr(ptr_ty) = fcx.translate_ty(*ty) else { panic!() };
+                rs::Rvalue::AddressOf(_mutbl, place) => {
+                    let place = self.translate_place(place);
+                    let target = GcCow::new(place);
 
-                ValueExpr::UnOp {
-                    operator: UnOp::Transmute(Type::Ptr(ptr_ty)),
-                    operand: GcCow::new(operand),
+                    let ptr_ty = PtrType::Raw;
+
+                    ValueExpr::AddrOf { target, ptr_ty }
                 }
-            }
-            rs::Rvalue::Repeat(op, c) => {
-                let c = c.try_eval_target_usize(fcx.cx.tcx, rs::ParamEnv::reveal_all()).unwrap();
-                let c = Int::from(c);
+                rs::Rvalue::Aggregate(box agg, operands) => {
+                    let ty = rv.ty(&self.body, self.cx.tcx);
+                    let ty = self.translate_ty(ty);
+                    match ty {
+                        Type::Union { .. } => {
+                            let rs::AggregateKind::Adt(_, _, _, _, Some(field_idx)) = agg else {
+                                panic!()
+                            };
+                            assert_eq!(operands.len(), 1);
+                            let expr = self.translate_operand(&operands[rs::FieldIdx::from_u32(0)]);
+                            ValueExpr::Union {
+                                field: field_idx.index().into(),
+                                expr: GcCow::new(expr),
+                                union_ty: ty,
+                            }
+                        }
+                        Type::Tuple { .. } | Type::Array { .. } => {
+                            let ops: List<_> =
+                                operands.iter().map(|x| self.translate_operand(x)).collect();
+                            ValueExpr::Tuple(ops, ty)
+                        }
+                        Type::Enum { variants, .. } => {
+                            let rs::AggregateKind::Adt(_, variant_idx, _, _, _) = agg else {
+                                panic!()
+                            };
+                            let discriminant = self.discriminant_for_variant(
+                                rv.ty(&self.body, self.cx.tcx),
+                                *variant_idx,
+                            );
+                            let ops: List<_> =
+                                operands.iter().map(|x| self.translate_operand(x)).collect();
 
-                let elem_ty = fcx.translate_ty(op.ty(&fcx.body, fcx.cx.tcx));
-                let op = translate_operand(op, fcx);
+                            // We represent the multiple fields of an enum variant as a MiniRust tuple.
+                            let data = GcCow::new(ValueExpr::Tuple(
+                                ops,
+                                variants.get(discriminant).unwrap().ty,
+                            ));
+                            ValueExpr::Variant { discriminant, data, enum_ty: ty }
+                        }
+                        _ => panic!("invalid aggregate type!"),
+                    }
+                }
+                rs::Rvalue::CopyForDeref(place) =>
+                    ValueExpr::Load { source: GcCow::new(self.translate_place(place)) },
+                rs::Rvalue::Len(place) => {
+                    // as slices are unsupported as of now, we only need to care for arrays.
+                    let ty = place.ty(&self.body, self.cx.tcx).ty;
+                    let Type::Array { elem: _, count } = self.translate_ty(ty) else { panic!() };
+                    ValueExpr::Constant(Constant::Int(count), <usize>::get_type())
+                }
+                rs::Rvalue::Discriminant(place) =>
+                    ValueExpr::GetDiscriminant { place: GcCow::new(self.translate_place(place)) },
+                rs::Rvalue::Cast(rs::CastKind::IntToInt, operand, ty) => {
+                    let operand_ty =
+                        self.translate_ty(operand.ty(&self.body.local_decls, self.cx.tcx));
+                    let operand = self.translate_operand(operand);
+                    let Type::Int(int_ty) = self.translate_ty(*ty) else {
+                        panic!("attempting to IntToInt-Cast to non-int type!");
+                    };
 
-                let ty = Type::Array { elem: GcCow::new(elem_ty), count: c };
+                    let unop = match operand_ty {
+                        Type::Int(_) => UnOp::Int(UnOpInt::Cast, int_ty),
+                        Type::Bool => UnOp::Bool(UnOpBool::IntCast(int_ty)),
+                        _ => panic!("Attempting to cast non-int or boolean type to int!"),
+                    };
+                    ValueExpr::UnOp { operator: unop, operand: GcCow::new(operand) }
+                }
+                rs::Rvalue::Cast(rs::CastKind::PointerExposeAddress, operand, _) => {
+                    let operand = self.translate_operand(operand);
+                    let expose = Statement::Expose { value: operand };
+                    let addr = build::ptr_addr(operand);
 
-                let ls = list![op; c];
-                ValueExpr::Tuple(ls, ty)
-            }
-            rs::Rvalue::Cast(
-                rs::CastKind::PointerCoercion(rs::adjustment::PointerCoercion::ReifyFnPointer),
-                func,
-                _,
-            ) => {
-                let rs::Operand::Constant(box f1) = func else { panic!() };
-                let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
-                let rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
-                let instance =
-                    rs::Instance::resolve(fcx.cx.tcx, rs::ParamEnv::reveal_all(), *f, substs_ref)
-                        .unwrap()
-                        .unwrap();
+                    return Some((vec![expose], addr));
+                }
+                rs::Rvalue::Cast(rs::CastKind::PointerFromExposedAddress, operand, ty) => {
+                    // TODO untested so far! (Can't test because of `predict`)
+                    let operand = self.translate_operand(operand);
+                    let Type::Ptr(ptr_ty) = self.translate_ty(*ty) else { panic!() };
 
-                build::fn_ptr(fcx.cx.get_fn_name(instance).0.get_internal())
-            }
-            rs::Rvalue::NullaryOp(rs::NullOp::DebugAssertions, _ty) => {
-                // Like Miri, since we are able to detect language UB ourselves we can disable these checks.
-                build::const_bool(false)
-            }
-            x => {
-                dbg!(x);
-                todo!()
-            }
-        },
-    ))
-}
+                    ValueExpr::UnOp {
+                        operator: UnOp::PtrFromExposed(ptr_ty),
+                        operand: GcCow::new(operand),
+                    }
+                }
+                rs::Rvalue::Cast(rs::CastKind::PtrToPtr, operand, ty) => {
+                    let operand = self.translate_operand(operand);
+                    let Type::Ptr(ptr_ty) = self.translate_ty(*ty) else { panic!() };
 
-pub fn translate_operand<'cx, 'tcx>(
-    operand: &rs::Operand<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> ValueExpr {
-    match operand {
-        rs::Operand::Constant(box c) => translate_const(&c.const_, fcx),
-        rs::Operand::Copy(place) =>
-            ValueExpr::Load { source: GcCow::new(translate_place(place, fcx)) },
-        rs::Operand::Move(place) =>
-            ValueExpr::Load { source: GcCow::new(translate_place(place, fcx)) },
+                    ValueExpr::UnOp {
+                        operator: UnOp::Transmute(Type::Ptr(ptr_ty)),
+                        operand: GcCow::new(operand),
+                    }
+                }
+                rs::Rvalue::Repeat(op, c) => {
+                    let c =
+                        c.try_eval_target_usize(self.cx.tcx, rs::ParamEnv::reveal_all()).unwrap();
+                    let c = Int::from(c);
+
+                    let elem_ty = self.translate_ty(op.ty(&self.body, self.cx.tcx));
+                    let op = self.translate_operand(op);
+
+                    let ty = Type::Array { elem: GcCow::new(elem_ty), count: c };
+
+                    let ls = list![op; c];
+                    ValueExpr::Tuple(ls, ty)
+                }
+                rs::Rvalue::Cast(
+                    rs::CastKind::PointerCoercion(rs::adjustment::PointerCoercion::ReifyFnPointer),
+                    func,
+                    _,
+                ) => {
+                    let rs::Operand::Constant(box f1) = func else { panic!() };
+                    let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
+                    let rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
+                    let instance = rs::Instance::resolve(
+                        self.cx.tcx,
+                        rs::ParamEnv::reveal_all(),
+                        *f,
+                        substs_ref,
+                    )
+                    .unwrap()
+                    .unwrap();
+
+                    build::fn_ptr(self.cx.get_fn_name(instance).0.get_internal())
+                }
+                rs::Rvalue::NullaryOp(rs::NullOp::DebugAssertions, _ty) => {
+                    // Like Miri, since we are able to detect language UB ourselves we can disable these checks.
+                    build::const_bool(false)
+                }
+                x => {
+                    dbg!(x);
+                    todo!()
+                }
+            },
+        ))
     }
-}
 
-pub fn translate_place<'cx, 'tcx>(
-    place: &rs::Place<'tcx>,
-    fcx: &mut FnCtxt<'cx, 'tcx>,
-) -> PlaceExpr {
-    let mut expr = PlaceExpr::Local(fcx.local_name_map[&place.local]);
-    for (i, proj) in place.projection.iter().enumerate() {
-        match proj {
-            rs::ProjectionElem::Field(f, _ty) => {
-                let f = f.index();
-                let indirected = GcCow::new(expr);
-                expr = PlaceExpr::Field { root: indirected, field: f.into() };
-            }
-            rs::ProjectionElem::Deref => {
-                let x = GcCow::new(expr);
-                let x = ValueExpr::Load { source: x };
-                let x = GcCow::new(x);
-
-                let ty = rs::Place::ty_from(
-                    place.local,
-                    &place.projection[..(i + 1)],
-                    &fcx.body,
-                    fcx.cx.tcx,
-                )
-                .ty;
-                let ty = fcx.translate_ty(ty);
-
-                expr = PlaceExpr::Deref { operand: x, ty };
-            }
-            rs::ProjectionElem::Index(loc) => {
-                let i = PlaceExpr::Local(fcx.local_name_map[&loc]);
-                let i = GcCow::new(i);
-                let i = ValueExpr::Load { source: i };
-                let i = GcCow::new(i);
-                let root = GcCow::new(expr);
-                expr = PlaceExpr::Index { root, index: i };
-            }
-            rs::ProjectionElem::Downcast(_variant_name, variant_idx) => {
-                let root = GcCow::new(expr);
-                let ty = rs::Place::ty_from(
-                    place.local,
-                    &place.projection[..(i + 1)],
-                    &fcx.body,
-                    fcx.cx.tcx,
-                )
-                .ty;
-                let discriminant = fcx.discriminant_for_variant(ty, variant_idx);
-                expr = PlaceExpr::Downcast { root, discriminant };
-            }
-            x => todo!("{:?}", x),
+    pub fn translate_operand(&mut self, operand: &rs::Operand<'tcx>) -> ValueExpr {
+        match operand {
+            rs::Operand::Constant(box c) => self.translate_const(&c.const_),
+            rs::Operand::Copy(place) =>
+                ValueExpr::Load { source: GcCow::new(self.translate_place(place)) },
+            rs::Operand::Move(place) =>
+                ValueExpr::Load { source: GcCow::new(self.translate_place(place)) },
         }
     }
-    expr
+    pub fn translate_place(&mut self, place: &rs::Place<'tcx>) -> PlaceExpr {
+        let mut expr = PlaceExpr::Local(self.local_name_map[&place.local]);
+        for (i, proj) in place.projection.iter().enumerate() {
+            match proj {
+                rs::ProjectionElem::Field(f, _ty) => {
+                    let f = f.index();
+                    let indirected = GcCow::new(expr);
+                    expr = PlaceExpr::Field { root: indirected, field: f.into() };
+                }
+                rs::ProjectionElem::Deref => {
+                    let x = GcCow::new(expr);
+                    let x = ValueExpr::Load { source: x };
+                    let x = GcCow::new(x);
+
+                    let ty = rs::Place::ty_from(
+                        place.local,
+                        &place.projection[..(i + 1)],
+                        &self.body,
+                        self.cx.tcx,
+                    )
+                    .ty;
+                    let ty = self.translate_ty(ty);
+
+                    expr = PlaceExpr::Deref { operand: x, ty };
+                }
+                rs::ProjectionElem::Index(loc) => {
+                    let i = PlaceExpr::Local(self.local_name_map[&loc]);
+                    let i = GcCow::new(i);
+                    let i = ValueExpr::Load { source: i };
+                    let i = GcCow::new(i);
+                    let root = GcCow::new(expr);
+                    expr = PlaceExpr::Index { root, index: i };
+                }
+                rs::ProjectionElem::Downcast(_variant_name, variant_idx) => {
+                    let root = GcCow::new(expr);
+                    let ty = rs::Place::ty_from(
+                        place.local,
+                        &place.projection[..(i + 1)],
+                        &self.body,
+                        self.cx.tcx,
+                    )
+                    .ty;
+                    let discriminant = self.discriminant_for_variant(ty, variant_idx);
+                    expr = PlaceExpr::Downcast { root, discriminant };
+                }
+                x => todo!("{:?}", x),
+            }
+        }
+        expr
+    }
 }


### PR DESCRIPTION
Much simpler than I had first anticipated.
This PR turns all `minimize` functions that use `FnCtxt` into methods instead.
I'm unsure how to handle the imports now (`use bb::*`). So far I deleted them to compile without warning but now the `mod bb` stand unused around.

closes #159 
