### PR TITLE
Migrate rvalue to StableMIR

### DIFF
--- a/tooling/minimize/src/constant.rs
+++ b/tooling/minimize/src/constant.rs
@@ -9,7 +9,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         }
     }
 
-    pub fn translate_const_stable(&mut self, c: &smir::Const) -> ValueExpr {
+    pub fn translate_const_smir(&mut self, c: &smir::Const) -> ValueExpr {
         self.translate_const(&smir::internal(self.tcx, c))
     }
 

--- a/tooling/minimize/src/constant.rs
+++ b/tooling/minimize/src/constant.rs
@@ -9,6 +9,10 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         }
     }
 
+    pub fn translate_const_stable(&mut self, c: &smir::Const) -> ValueExpr {
+        self.translate_const(&smir::internal(self.tcx, c))
+    }
+
     fn translate_const_val(&mut self, val: &rs::ConstValue<'tcx>, ty: rs::Ty<'tcx>) -> ValueExpr {
         let ty = self.translate_ty(ty);
 

--- a/tooling/minimize/src/enums.rs
+++ b/tooling/minimize/src/enums.rs
@@ -177,6 +177,10 @@ impl<'tcx> Ctxt<'tcx> {
             .collect()
     }
 
+    pub fn discriminant_for_variant_stable(&self, ty: smir::Ty, variant_idx: smir::VariantIdx) -> Int {
+        self.discriminant_for_variant(smir::internal(self.tcx, ty), smir::internal(self.tcx, variant_idx))
+    }
+
     pub fn discriminant_for_variant(&self, ty: rs::Ty<'tcx>, variant_idx: rs::VariantIdx) -> Int {
         let rs::TyKind::Adt(adt_def, _) = ty.kind() else {
             panic!("Getting discriminant for a variant of a non-enum type!")

--- a/tooling/minimize/src/enums.rs
+++ b/tooling/minimize/src/enums.rs
@@ -177,8 +177,15 @@ impl<'tcx> Ctxt<'tcx> {
             .collect()
     }
 
-    pub fn discriminant_for_variant_stable(&self, ty: smir::Ty, variant_idx: smir::VariantIdx) -> Int {
-        self.discriminant_for_variant(smir::internal(self.tcx, ty), smir::internal(self.tcx, variant_idx))
+    pub fn discriminant_for_variant_smir(
+        &self,
+        ty: smir::Ty,
+        variant_idx: smir::VariantIdx,
+    ) -> Int {
+        self.discriminant_for_variant(
+            smir::internal(self.tcx, ty),
+            smir::internal(self.tcx, variant_idx),
+        )
     }
 
     pub fn discriminant_for_variant(&self, ty: rs::Ty<'tcx>, variant_idx: rs::VariantIdx) -> Int {

--- a/tooling/minimize/src/get.rs
+++ b/tooling/minimize/src/get.rs
@@ -31,7 +31,9 @@ impl<F: FnOnce(Program) + Send + Copy> Callbacks for Cb<F> {
         queries: &'tcx Queries<'tcx>,
     ) -> Compilation {
         queries.global_ctxt().unwrap().enter(|arg| {
-            let prog = Ctxt::new(arg).translate();
+            let prog = smir::run(arg, || {
+                Ctxt::new(arg).translate()
+            }).unwrap();
             (self.callback)(prog);
         });
 

--- a/tooling/minimize/src/get.rs
+++ b/tooling/minimize/src/get.rs
@@ -31,9 +31,9 @@ impl<F: FnOnce(Program) + Send + Copy> Callbacks for Cb<F> {
         queries: &'tcx Queries<'tcx>,
     ) -> Compilation {
         queries.global_ctxt().unwrap().enter(|arg| {
-            let prog = smir::run(arg, || {
-                Ctxt::new(arg).translate()
-            }).unwrap();
+            // StableMIR can only be used inside a `run` call, to guarantee its context is properly
+            // initialized. Calls to StableMIR functions will panic if done outside a run.
+            let prog = smir::run(arg, || Ctxt::new(arg).translate()).unwrap();
             (self.callback)(prog);
         });
 

--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -10,16 +10,25 @@ extern crate rustc_interface;
 extern crate rustc_middle;
 extern crate rustc_mir_dataflow;
 extern crate rustc_session;
+extern crate rustc_smir;
 extern crate rustc_span;
 extern crate rustc_target;
+extern crate stable_mir;
 
 mod rs {
     pub use rustc_middle::mir::UnevaluatedConst;
-    pub use rustc_middle::mir::{self, interpret::*, tcx::PlaceTy, *};
+    pub use rustc_middle::mir::{self, interpret::*, *};
     pub use rustc_middle::ty::*;
     pub use rustc_mir_dataflow::storage::always_storage_live_locals;
     pub use rustc_span::source_map::Spanned;
     pub use rustc_target::abi::{call::*, Align, FieldIdx, Layout, Size};
+}
+
+mod smir {
+    pub use rustc_smir::rustc_internal::*;
+    pub use stable_mir::mir::mono::*;
+    pub use stable_mir::mir::*;
+    pub use stable_mir::ty::*;
 }
 
 pub use minirust_rs::libspecr::hidden::*;
@@ -40,9 +49,11 @@ pub use miniutil::run::*;
 pub use miniutil::DefaultTarget;
 
 mod program;
+
 use program::*;
 
 mod ty;
+
 use ty::*;
 
 mod bb;
@@ -52,12 +63,15 @@ mod rvalue;
 mod constant;
 
 mod get;
+
 use get::get_mini;
 
 mod chunks;
+
 use chunks::calc_chunks;
 
 mod enums;
+
 use enums::int_from_bits;
 
 use std::collections::HashMap;

--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -49,11 +49,9 @@ pub use miniutil::run::*;
 pub use miniutil::DefaultTarget;
 
 mod program;
-
 use program::*;
 
 mod ty;
-
 use ty::*;
 
 mod bb;
@@ -63,15 +61,12 @@ mod rvalue;
 mod constant;
 
 mod get;
-
 use get::get_mini;
 
 mod chunks;
-
 use chunks::calc_chunks;
 
 mod enums;
-
 use enums::int_from_bits;
 
 use std::collections::HashMap;

--- a/tooling/minimize/src/program.rs
+++ b/tooling/minimize/src/program.rs
@@ -62,6 +62,10 @@ impl<'tcx> Ctxt<'tcx> {
         *self.fn_name_map.entry(key).or_insert_with(|| FnName(Name::from_internal(len as _)))
     }
 
+    pub fn get_fn_name_stable(&mut self, key: smir::Instance) -> FnName {
+        self.get_fn_name(smir::internal(self.tcx, key))
+    }
+
     pub fn rs_layout_of(&self, ty: rs::Ty<'tcx>) -> rs::Layout<'tcx> {
         self.tcx.layout_of(rs::ParamEnv::reveal_all().and(ty)).unwrap().layout
     }
@@ -126,6 +130,8 @@ pub struct FnCtxt<'cx, 'tcx> {
 
     pub locals: Map<LocalName, Type>,
     pub blocks: Map<BbName, BasicBlock>,
+
+    pub locals_stable: Vec<smir::LocalDecl>,
 }
 
 impl<'cx, 'tcx> std::ops::Deref for FnCtxt<'cx, 'tcx> {
@@ -146,6 +152,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             rs::ParamEnv::reveal_all(),
             rs::EarlyBinder::bind(body.clone()),
         );
+        let locals_stable = smir::stable(&body).locals().to_vec();
 
         FnCtxt {
             body,
@@ -155,6 +162,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             bb_name_map: Default::default(),
             locals: Default::default(),
             blocks: Default::default(),
+            locals_stable,
         }
     }
 

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -6,26 +6,26 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         &mut self,
         rv: &rs::Rvalue<'tcx>,
     ) -> Option<(Vec<Statement>, ValueExpr)> {
-        self.translate_rvalue_stable(&smir::stable(rv))
+        self.translate_rvalue_smir(&smir::stable(rv))
     }
 
-    pub fn translate_rvalue_stable(
+    pub fn translate_rvalue_smir(
         &mut self,
         rv: &smir::Rvalue,
     ) -> Option<(Vec<Statement>, ValueExpr)> {
         Some((
             vec![],
             match rv {
-                smir::Rvalue::Use(operand) => self.translate_operand_stable(operand),
+                smir::Rvalue::Use(operand) => self.translate_operand_smir(operand),
                 smir::Rvalue::CheckedBinaryOp(bin_op, l, r)
                 | smir::Rvalue::BinaryOp(bin_op, l, r) => {
-                    let lty = l.ty(&self.locals_stable).unwrap();
-                    let rty = r.ty(&self.locals_stable).unwrap();
+                    let lty = l.ty(&self.locals_smir).unwrap();
+                    let rty = r.ty(&self.locals_smir).unwrap();
 
                     assert_eq!(lty, rty);
 
-                    let l = self.translate_operand_stable(l);
-                    let r = self.translate_operand_stable(r);
+                    let l = self.translate_operand_smir(l);
+                    let r = self.translate_operand_smir(r);
 
                     let l = GcCow::new(l);
                     let r = GcCow::new(r);
@@ -37,7 +37,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                         // everything else right-now is a int op!
 
                         let op = |x| {
-                            let Type::Int(int_ty) = self.translate_ty_stable(lty) else {
+                            let Type::Int(int_ty) = self.translate_ty_smir(lty) else {
                                 panic!("arithmetic operation with non-int type unsupported!");
                             };
 
@@ -72,13 +72,13 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 smir::Rvalue::UnaryOp(unop, operand) =>
                     match unop {
                         smir::UnOp::Neg => {
-                            let ty = operand.ty(&self.locals_stable).unwrap();
-                            let ty = self.translate_ty_stable(ty);
+                            let ty = operand.ty(&self.locals_smir).unwrap();
+                            let ty = self.translate_ty_smir(ty);
                             let Type::Int(int_ty) = ty else {
                                 panic!("Neg operation with non-int type!");
                             };
 
-                            let operand = self.translate_operand_stable(operand);
+                            let operand = self.translate_operand_smir(operand);
 
                             ValueExpr::UnOp {
                                 operator: UnOp::Int(UnOpInt::Neg, int_ty),
@@ -86,13 +86,13 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                             }
                         }
                         smir::UnOp::Not => {
-                            let ty = operand.ty(&self.locals_stable).unwrap();
-                            let ty = self.translate_ty_stable(ty);
+                            let ty = operand.ty(&self.locals_smir).unwrap();
+                            let ty = self.translate_ty_smir(ty);
                             let Type::Bool = ty else {
                                 panic!("Not operation with non-boolean type!");
                             };
 
-                            let operand = self.translate_operand_stable(operand);
+                            let operand = self.translate_operand_smir(operand);
 
                             ValueExpr::UnOp {
                                 operator: UnOp::Bool(UnOpBool::Not),
@@ -101,19 +101,19 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                         }
                     },
                 smir::Rvalue::Ref(_, bkind, place) => {
-                    let ty = place.ty(&self.locals_stable).unwrap();
-                    let pointee = self.layout_of_stable(ty);
+                    let ty = place.ty(&self.locals_smir).unwrap();
+                    let pointee = self.layout_of_smir(ty);
 
-                    let place = self.translate_place_stable(place);
+                    let place = self.translate_place_smir(place);
                     let target = GcCow::new(place);
-                    let mutbl = translate_mutbl_stable(bkind.to_mutable_lossy());
+                    let mutbl = translate_mutbl_smir(bkind.to_mutable_lossy());
 
                     let ptr_ty = PtrType::Ref { mutbl, pointee };
 
                     ValueExpr::AddrOf { target, ptr_ty }
                 }
                 smir::Rvalue::AddressOf(_mutbl, place) => {
-                    let place = self.translate_place_stable(place);
+                    let place = self.translate_place_smir(place);
                     let target = GcCow::new(place);
 
                     let ptr_ty = PtrType::Raw;
@@ -121,15 +121,15 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     ValueExpr::AddrOf { target, ptr_ty }
                 }
                 smir::Rvalue::Aggregate(agg, operands) => {
-                    let ty = rv.ty(&self.locals_stable).unwrap();
-                    let ty = self.translate_ty_stable(ty);
+                    let ty = rv.ty(&self.locals_smir).unwrap();
+                    let ty = self.translate_ty_smir(ty);
                     match ty {
                         Type::Union { .. } => {
                             let smir::AggregateKind::Adt(_, _, _, _, Some(field_idx)) = agg else {
                                 panic!()
                             };
                             assert_eq!(operands.len(), 1);
-                            let expr = self.translate_operand_stable(&operands[0]);
+                            let expr = self.translate_operand_smir(&operands[0]);
                             ValueExpr::Union {
                                 field: (*field_idx).into(),
                                 expr: GcCow::new(expr),
@@ -138,19 +138,19 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                         }
                         Type::Tuple { .. } | Type::Array { .. } => {
                             let ops: List<_> =
-                                operands.iter().map(|x| self.translate_operand_stable(x)).collect();
+                                operands.iter().map(|x| self.translate_operand_smir(x)).collect();
                             ValueExpr::Tuple(ops, ty)
                         }
                         Type::Enum { variants, .. } => {
                             let smir::AggregateKind::Adt(_, variant_idx, _, _, _) = agg else {
                                 panic!()
                             };
-                            let discriminant = self.discriminant_for_variant_stable(
-                                rv.ty(&self.locals_stable).unwrap(),
+                            let discriminant = self.discriminant_for_variant_smir(
+                                rv.ty(&self.locals_smir).unwrap(),
                                 *variant_idx,
                             );
                             let ops: List<_> =
-                                operands.iter().map(|x| self.translate_operand_stable(x)).collect();
+                                operands.iter().map(|x| self.translate_operand_smir(x)).collect();
 
                             // We represent the multiple fields of an enum variant as a MiniRust tuple.
                             let data = GcCow::new(ValueExpr::Tuple(
@@ -163,24 +163,23 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     }
                 }
                 smir::Rvalue::CopyForDeref(place) =>
-                    ValueExpr::Load { source: GcCow::new(self.translate_place_stable(place)) },
+                    ValueExpr::Load { source: GcCow::new(self.translate_place_smir(place)) },
                 smir::Rvalue::Len(place) => {
                     // as slices are unsupported as of now, we only need to care for arrays.
-                    let ty = place.ty(&self.locals_stable).unwrap();
-                    let Type::Array { elem: _, count } = self.translate_ty_stable(ty) else {
+                    let ty = place.ty(&self.locals_smir).unwrap();
+                    let Type::Array { elem: _, count } = self.translate_ty_smir(ty) else {
                         panic!()
                     };
                     ValueExpr::Constant(Constant::Int(count), <usize>::get_type())
                 }
                 smir::Rvalue::Discriminant(place) =>
                     ValueExpr::GetDiscriminant {
-                        place: GcCow::new(self.translate_place_stable(place)),
+                        place: GcCow::new(self.translate_place_smir(place)),
                     },
                 smir::Rvalue::Cast(smir::CastKind::IntToInt, operand, ty) => {
-                    let operand_ty =
-                        self.translate_ty_stable(operand.ty(&self.locals_stable).unwrap());
-                    let operand = self.translate_operand_stable(operand);
-                    let Type::Int(int_ty) = self.translate_ty_stable(*ty) else {
+                    let operand_ty = self.translate_ty_smir(operand.ty(&self.locals_smir).unwrap());
+                    let operand = self.translate_operand_smir(operand);
+                    let Type::Int(int_ty) = self.translate_ty_smir(*ty) else {
                         panic!("attempting to IntToInt-Cast to non-int type!");
                     };
 
@@ -192,7 +191,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     ValueExpr::UnOp { operator: unop, operand: GcCow::new(operand) }
                 }
                 smir::Rvalue::Cast(smir::CastKind::PointerExposeAddress, operand, _) => {
-                    let operand = self.translate_operand_stable(operand);
+                    let operand = self.translate_operand_smir(operand);
                     let expose = Statement::Expose { value: operand };
                     let addr = build::ptr_addr(operand);
 
@@ -200,8 +199,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 }
                 smir::Rvalue::Cast(smir::CastKind::PointerFromExposedAddress, operand, ty) => {
                     // TODO untested so far! (Can't test because of `predict`)
-                    let operand = self.translate_operand_stable(operand);
-                    let Type::Ptr(ptr_ty) = self.translate_ty_stable(*ty) else { panic!() };
+                    let operand = self.translate_operand_smir(operand);
+                    let Type::Ptr(ptr_ty) = self.translate_ty_smir(*ty) else { panic!() };
 
                     ValueExpr::UnOp {
                         operator: UnOp::PtrFromExposed(ptr_ty),
@@ -209,8 +208,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     }
                 }
                 smir::Rvalue::Cast(smir::CastKind::PtrToPtr, operand, ty) => {
-                    let operand = self.translate_operand_stable(operand);
-                    let Type::Ptr(ptr_ty) = self.translate_ty_stable(*ty) else { panic!() };
+                    let operand = self.translate_operand_smir(operand);
+                    let Type::Ptr(ptr_ty) = self.translate_ty_smir(*ty) else { panic!() };
 
                     ValueExpr::UnOp {
                         operator: UnOp::Transmute(Type::Ptr(ptr_ty)),
@@ -221,8 +220,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     let c = c.eval_target_usize().unwrap();
                     let c = Int::from(c);
 
-                    let elem_ty = self.translate_ty_stable(op.ty(&self.locals_stable).unwrap());
-                    let op = self.translate_operand_stable(op);
+                    let elem_ty = self.translate_ty_smir(op.ty(&self.locals_smir).unwrap());
+                    let op = self.translate_operand_smir(op);
 
                     let ty = Type::Array { elem: GcCow::new(elem_ty), count: c };
 
@@ -236,12 +235,12 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 ) => {
                     let smir::Operand::Constant(f1) = func else { panic!() };
                     let smir::TyKind::RigidTy(smir::RigidTy::FnDef(f, substs_ref)) = f1.ty().kind()
-                        else {
-                            panic!()
-                        };
+                    else {
+                        panic!()
+                    };
                     let instance = smir::Instance::resolve(f, &substs_ref).unwrap();
 
-                    build::fn_ptr(self.cx.get_fn_name_stable(instance).0.get_internal())
+                    build::fn_ptr(self.cx.get_fn_name_smir(instance).0.get_internal())
                 }
                 smir::Rvalue::NullaryOp(smir::NullOp::DebugAssertions, _ty) => {
                     // Like Miri, since we are able to detect language UB ourselves we can disable these checks.
@@ -256,27 +255,27 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
     }
 
     pub fn translate_operand(&mut self, operand: &rs::Operand<'tcx>) -> ValueExpr {
-        self.translate_operand_stable(&smir::stable(operand))
+        self.translate_operand_smir(&smir::stable(operand))
     }
 
-    pub fn translate_operand_stable(&mut self, operand: &smir::Operand) -> ValueExpr {
+    pub fn translate_operand_smir(&mut self, operand: &smir::Operand) -> ValueExpr {
         match operand {
-            smir::Operand::Constant(c) => self.translate_const_stable(&c.literal),
+            smir::Operand::Constant(c) => self.translate_const_smir(&c.literal),
             smir::Operand::Copy(place) =>
-                ValueExpr::Load { source: GcCow::new(self.translate_place_stable(place)) },
+                ValueExpr::Load { source: GcCow::new(self.translate_place_smir(place)) },
             smir::Operand::Move(place) =>
-                ValueExpr::Load { source: GcCow::new(self.translate_place_stable(place)) },
+                ValueExpr::Load { source: GcCow::new(self.translate_place_smir(place)) },
         }
     }
 
     pub fn translate_place(&mut self, place: &rs::Place<'tcx>) -> PlaceExpr {
-        self.translate_place_stable(&smir::stable(place))
+        self.translate_place_smir(&smir::stable(place))
     }
 
-    pub fn translate_place_stable(&mut self, place: &smir::Place) -> PlaceExpr {
+    pub fn translate_place_smir(&mut self, place: &smir::Place) -> PlaceExpr {
         // Initial state: start with the local the place is based on
         let expr = PlaceExpr::Local(self.local_name_map[&place.local.into()]);
-        let place_ty = self.locals_stable[place.local].ty;
+        let place_ty = self.locals_smir[place.local].ty;
         // Fold over all projections
         let (expr, _place_ty) =
             place.projection.iter().fold((expr, place_ty), |(expr, place_ty), proj| {
@@ -291,7 +290,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                         let x = ValueExpr::Load { source: x };
                         let x = GcCow::new(x);
 
-                        let ty = self.translate_ty_stable(this_ty);
+                        let ty = self.translate_ty_smir(this_ty);
 
                         PlaceExpr::Deref { operand: x, ty }
                     }
@@ -306,7 +305,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     smir::ProjectionElem::Downcast(variant_idx) => {
                         let root = GcCow::new(expr);
                         let discriminant =
-                            self.discriminant_for_variant_stable(this_ty, *variant_idx);
+                            self.discriminant_for_variant_smir(this_ty, *variant_idx);
                         PlaceExpr::Downcast { root, discriminant }
                     }
                     x => todo!("{:?}", x),

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -6,31 +6,38 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         &mut self,
         rv: &rs::Rvalue<'tcx>,
     ) -> Option<(Vec<Statement>, ValueExpr)> {
+        self.translate_rvalue_stable(&smir::stable(rv))
+    }
+
+    pub fn translate_rvalue_stable(
+        &mut self,
+        rv: &smir::Rvalue,
+    ) -> Option<(Vec<Statement>, ValueExpr)> {
         Some((
             vec![],
             match rv {
-                rs::Rvalue::Use(operand) => self.translate_operand(operand),
-                rs::Rvalue::CheckedBinaryOp(bin_op, box (l, r))
-                | rs::Rvalue::BinaryOp(bin_op, box (l, r)) => {
-                    let lty = l.ty(&self.body, self.tcx);
-                    let rty = r.ty(&self.body, self.tcx);
+                smir::Rvalue::Use(operand) => self.translate_operand_stable(operand),
+                smir::Rvalue::CheckedBinaryOp(bin_op, l, r)
+                | smir::Rvalue::BinaryOp(bin_op, l, r) => {
+                    let lty = l.ty(&self.locals_stable).unwrap();
+                    let rty = r.ty(&self.locals_stable).unwrap();
 
                     assert_eq!(lty, rty);
 
-                    let l = self.translate_operand(l);
-                    let r = self.translate_operand(r);
+                    let l = self.translate_operand_stable(l);
+                    let r = self.translate_operand_stable(r);
 
                     let l = GcCow::new(l);
                     let r = GcCow::new(r);
 
-                    use rs::BinOp::*;
+                    use smir::BinOp::*;
                     let op = if *bin_op == Offset {
                         BinOp::PtrOffset { inbounds: true }
                     } else {
                         // everything else right-now is a int op!
 
                         let op = |x| {
-                            let Type::Int(int_ty) = self.translate_ty(lty) else {
+                            let Type::Int(int_ty) = self.translate_ty_stable(lty) else {
                                 panic!("arithmetic operation with non-int type unsupported!");
                             };
 
@@ -62,30 +69,30 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
 
                     ValueExpr::BinOp { operator: op, left: l, right: r }
                 }
-                rs::Rvalue::UnaryOp(unop, operand) =>
+                smir::Rvalue::UnaryOp(unop, operand) =>
                     match unop {
-                        rs::UnOp::Neg => {
-                            let ty = operand.ty(&self.body, self.tcx);
-                            let ty = self.translate_ty(ty);
+                        smir::UnOp::Neg => {
+                            let ty = operand.ty(&self.locals_stable).unwrap();
+                            let ty = self.translate_ty_stable(ty);
                             let Type::Int(int_ty) = ty else {
                                 panic!("Neg operation with non-int type!");
                             };
 
-                            let operand = self.translate_operand(operand);
+                            let operand = self.translate_operand_stable(operand);
 
                             ValueExpr::UnOp {
                                 operator: UnOp::Int(UnOpInt::Neg, int_ty),
                                 operand: GcCow::new(operand),
                             }
                         }
-                        rs::UnOp::Not => {
-                            let ty = operand.ty(&self.body, self.tcx);
-                            let ty = self.translate_ty(ty);
+                        smir::UnOp::Not => {
+                            let ty = operand.ty(&self.locals_stable).unwrap();
+                            let ty = self.translate_ty_stable(ty);
                             let Type::Bool = ty else {
                                 panic!("Not operation with non-boolean type!");
                             };
 
-                            let operand = self.translate_operand(operand);
+                            let operand = self.translate_operand_stable(operand);
 
                             ValueExpr::UnOp {
                                 operator: UnOp::Bool(UnOpBool::Not),
@@ -93,57 +100,57 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                             }
                         }
                     },
-                rs::Rvalue::Ref(_, bkind, place) => {
-                    let ty = place.ty(&self.body, self.tcx).ty;
-                    let pointee = self.layout_of(ty);
+                smir::Rvalue::Ref(_, bkind, place) => {
+                    let ty = place.ty(&self.locals_stable).unwrap();
+                    let pointee = self.layout_of_stable(ty);
 
-                    let place = self.translate_place(place);
+                    let place = self.translate_place_stable(place);
                     let target = GcCow::new(place);
-                    let mutbl = translate_mutbl(bkind.to_mutbl_lossy());
+                    let mutbl = translate_mutbl_stable(bkind.to_mutable_lossy());
 
                     let ptr_ty = PtrType::Ref { mutbl, pointee };
 
                     ValueExpr::AddrOf { target, ptr_ty }
                 }
-                rs::Rvalue::AddressOf(_mutbl, place) => {
-                    let place = self.translate_place(place);
+                smir::Rvalue::AddressOf(_mutbl, place) => {
+                    let place = self.translate_place_stable(place);
                     let target = GcCow::new(place);
 
                     let ptr_ty = PtrType::Raw;
 
                     ValueExpr::AddrOf { target, ptr_ty }
                 }
-                rs::Rvalue::Aggregate(box agg, operands) => {
-                    let ty = rv.ty(&self.body, self.tcx);
-                    let ty = self.translate_ty(ty);
+                smir::Rvalue::Aggregate(agg, operands) => {
+                    let ty = rv.ty(&self.locals_stable).unwrap();
+                    let ty = self.translate_ty_stable(ty);
                     match ty {
                         Type::Union { .. } => {
-                            let rs::AggregateKind::Adt(_, _, _, _, Some(field_idx)) = agg else {
+                            let smir::AggregateKind::Adt(_, _, _, _, Some(field_idx)) = agg else {
                                 panic!()
                             };
                             assert_eq!(operands.len(), 1);
-                            let expr = self.translate_operand(&operands[rs::FieldIdx::from_u32(0)]);
+                            let expr = self.translate_operand_stable(&operands[0]);
                             ValueExpr::Union {
-                                field: field_idx.index().into(),
+                                field: (*field_idx).into(),
                                 expr: GcCow::new(expr),
                                 union_ty: ty,
                             }
                         }
                         Type::Tuple { .. } | Type::Array { .. } => {
                             let ops: List<_> =
-                                operands.iter().map(|x| self.translate_operand(x)).collect();
+                                operands.iter().map(|x| self.translate_operand_stable(x)).collect();
                             ValueExpr::Tuple(ops, ty)
                         }
                         Type::Enum { variants, .. } => {
-                            let rs::AggregateKind::Adt(_, variant_idx, _, _, _) = agg else {
+                            let smir::AggregateKind::Adt(_, variant_idx, _, _, _) = agg else {
                                 panic!()
                             };
-                            let discriminant = self.discriminant_for_variant(
-                                rv.ty(&self.body, self.tcx),
+                            let discriminant = self.discriminant_for_variant_stable(
+                                rv.ty(&self.locals_stable).unwrap(),
                                 *variant_idx,
                             );
                             let ops: List<_> =
-                                operands.iter().map(|x| self.translate_operand(x)).collect();
+                                operands.iter().map(|x| self.translate_operand_stable(x)).collect();
 
                             // We represent the multiple fields of an enum variant as a MiniRust tuple.
                             let data = GcCow::new(ValueExpr::Tuple(
@@ -155,21 +162,25 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                         _ => panic!("invalid aggregate type!"),
                     }
                 }
-                rs::Rvalue::CopyForDeref(place) =>
-                    ValueExpr::Load { source: GcCow::new(self.translate_place(place)) },
-                rs::Rvalue::Len(place) => {
+                smir::Rvalue::CopyForDeref(place) =>
+                    ValueExpr::Load { source: GcCow::new(self.translate_place_stable(place)) },
+                smir::Rvalue::Len(place) => {
                     // as slices are unsupported as of now, we only need to care for arrays.
-                    let ty = place.ty(&self.body, self.tcx).ty;
-                    let Type::Array { elem: _, count } = self.translate_ty(ty) else { panic!() };
+                    let ty = place.ty(&self.locals_stable).unwrap();
+                    let Type::Array { elem: _, count } = self.translate_ty_stable(ty) else {
+                        panic!()
+                    };
                     ValueExpr::Constant(Constant::Int(count), <usize>::get_type())
                 }
-                rs::Rvalue::Discriminant(place) =>
-                    ValueExpr::GetDiscriminant { place: GcCow::new(self.translate_place(place)) },
-                rs::Rvalue::Cast(rs::CastKind::IntToInt, operand, ty) => {
+                smir::Rvalue::Discriminant(place) =>
+                    ValueExpr::GetDiscriminant {
+                        place: GcCow::new(self.translate_place_stable(place)),
+                    },
+                smir::Rvalue::Cast(smir::CastKind::IntToInt, operand, ty) => {
                     let operand_ty =
-                        self.translate_ty(operand.ty(&self.body.local_decls, self.tcx));
-                    let operand = self.translate_operand(operand);
-                    let Type::Int(int_ty) = self.translate_ty(*ty) else {
+                        self.translate_ty_stable(operand.ty(&self.locals_stable).unwrap());
+                    let operand = self.translate_operand_stable(operand);
+                    let Type::Int(int_ty) = self.translate_ty_stable(*ty) else {
                         panic!("attempting to IntToInt-Cast to non-int type!");
                     };
 
@@ -180,62 +191,59 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     };
                     ValueExpr::UnOp { operator: unop, operand: GcCow::new(operand) }
                 }
-                rs::Rvalue::Cast(rs::CastKind::PointerExposeAddress, operand, _) => {
-                    let operand = self.translate_operand(operand);
+                smir::Rvalue::Cast(smir::CastKind::PointerExposeAddress, operand, _) => {
+                    let operand = self.translate_operand_stable(operand);
                     let expose = Statement::Expose { value: operand };
                     let addr = build::ptr_addr(operand);
 
                     return Some((vec![expose], addr));
                 }
-                rs::Rvalue::Cast(rs::CastKind::PointerFromExposedAddress, operand, ty) => {
+                smir::Rvalue::Cast(smir::CastKind::PointerFromExposedAddress, operand, ty) => {
                     // TODO untested so far! (Can't test because of `predict`)
-                    let operand = self.translate_operand(operand);
-                    let Type::Ptr(ptr_ty) = self.translate_ty(*ty) else { panic!() };
+                    let operand = self.translate_operand_stable(operand);
+                    let Type::Ptr(ptr_ty) = self.translate_ty_stable(*ty) else { panic!() };
 
                     ValueExpr::UnOp {
                         operator: UnOp::PtrFromExposed(ptr_ty),
                         operand: GcCow::new(operand),
                     }
                 }
-                rs::Rvalue::Cast(rs::CastKind::PtrToPtr, operand, ty) => {
-                    let operand = self.translate_operand(operand);
-                    let Type::Ptr(ptr_ty) = self.translate_ty(*ty) else { panic!() };
+                smir::Rvalue::Cast(smir::CastKind::PtrToPtr, operand, ty) => {
+                    let operand = self.translate_operand_stable(operand);
+                    let Type::Ptr(ptr_ty) = self.translate_ty_stable(*ty) else { panic!() };
 
                     ValueExpr::UnOp {
                         operator: UnOp::Transmute(Type::Ptr(ptr_ty)),
                         operand: GcCow::new(operand),
                     }
                 }
-                rs::Rvalue::Repeat(op, c) => {
-                    let c = c.try_eval_target_usize(self.tcx, rs::ParamEnv::reveal_all()).unwrap();
+                smir::Rvalue::Repeat(op, c) => {
+                    let c = c.eval_target_usize().unwrap();
                     let c = Int::from(c);
 
-                    let elem_ty = self.translate_ty(op.ty(&self.body, self.tcx));
-                    let op = self.translate_operand(op);
+                    let elem_ty = self.translate_ty_stable(op.ty(&self.locals_stable).unwrap());
+                    let op = self.translate_operand_stable(op);
 
                     let ty = Type::Array { elem: GcCow::new(elem_ty), count: c };
 
                     let ls = list![op; c];
                     ValueExpr::Tuple(ls, ty)
                 }
-                rs::Rvalue::Cast(
-                    rs::CastKind::PointerCoercion(rs::adjustment::PointerCoercion::ReifyFnPointer),
+                smir::Rvalue::Cast(
+                    smir::CastKind::PointerCoercion(smir::PointerCoercion::ReifyFnPointer),
                     func,
                     _,
                 ) => {
-                    let rs::Operand::Constant(box f1) = func else { panic!() };
-                    let rs::mir::Const::Val(_, f2) = f1.const_ else { panic!() };
-                    let rs::TyKind::FnDef(f, substs_ref) = f2.kind() else { panic!() };
-                    let instance = rs::Instance::expect_resolve(
-                        self.tcx,
-                        rs::ParamEnv::reveal_all(),
-                        *f,
-                        substs_ref,
-                    );
+                    let smir::Operand::Constant(f1) = func else { panic!() };
+                    let smir::TyKind::RigidTy(smir::RigidTy::FnDef(f, substs_ref)) = f1.ty().kind()
+                        else {
+                            panic!()
+                        };
+                    let instance = smir::Instance::resolve(f, &substs_ref).unwrap();
 
-                    build::fn_ptr(self.cx.get_fn_name(instance).0.get_internal())
+                    build::fn_ptr(self.cx.get_fn_name_stable(instance).0.get_internal())
                 }
-                rs::Rvalue::NullaryOp(rs::NullOp::DebugAssertions, _ty) => {
+                smir::Rvalue::NullaryOp(smir::NullOp::DebugAssertions, _ty) => {
                     // Like Miri, since we are able to detect language UB ourselves we can disable these checks.
                     build::const_bool(false)
                 }
@@ -248,49 +256,57 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
     }
 
     pub fn translate_operand(&mut self, operand: &rs::Operand<'tcx>) -> ValueExpr {
+        self.translate_operand_stable(&smir::stable(operand))
+    }
+
+    pub fn translate_operand_stable(&mut self, operand: &smir::Operand) -> ValueExpr {
         match operand {
-            rs::Operand::Constant(box c) => self.translate_const(&c.const_),
-            rs::Operand::Copy(place) =>
-                ValueExpr::Load { source: GcCow::new(self.translate_place(place)) },
-            rs::Operand::Move(place) =>
-                ValueExpr::Load { source: GcCow::new(self.translate_place(place)) },
+            smir::Operand::Constant(c) => self.translate_const_stable(&c.literal),
+            smir::Operand::Copy(place) =>
+                ValueExpr::Load { source: GcCow::new(self.translate_place_stable(place)) },
+            smir::Operand::Move(place) =>
+                ValueExpr::Load { source: GcCow::new(self.translate_place_stable(place)) },
         }
     }
 
     pub fn translate_place(&mut self, place: &rs::Place<'tcx>) -> PlaceExpr {
+        self.translate_place_stable(&smir::stable(place))
+    }
+
+    pub fn translate_place_stable(&mut self, place: &smir::Place) -> PlaceExpr {
         // Initial state: start with the local the place is based on
-        let expr = PlaceExpr::Local(self.local_name_map[&place.local]);
-        let place_ty = rs::PlaceTy::from_ty(self.body.local_decls[place.local].ty);
+        let expr = PlaceExpr::Local(self.local_name_map[&place.local.into()]);
+        let place_ty = self.locals_stable[place.local].ty;
         // Fold over all projections
         let (expr, _place_ty) =
-            place.iter_projections().fold((expr, place_ty), |(expr, place_ty), (_base, proj)| {
-                let this_ty = place_ty.projection_ty(self.tcx, proj);
+            place.projection.iter().fold((expr, place_ty), |(expr, place_ty), proj| {
+                let this_ty = proj.ty(place_ty).unwrap();
                 let this_expr = match proj {
-                    rs::ProjectionElem::Field(f, _ty) => {
-                        let f = f.index();
+                    smir::ProjectionElem::Field(f, _ty) => {
                         let indirected = GcCow::new(expr);
-                        PlaceExpr::Field { root: indirected, field: f.into() }
+                        PlaceExpr::Field { root: indirected, field: (*f).into() }
                     }
-                    rs::ProjectionElem::Deref => {
+                    smir::ProjectionElem::Deref => {
                         let x = GcCow::new(expr);
                         let x = ValueExpr::Load { source: x };
                         let x = GcCow::new(x);
 
-                        let ty = self.translate_ty(this_ty.ty);
+                        let ty = self.translate_ty_stable(this_ty);
 
                         PlaceExpr::Deref { operand: x, ty }
                     }
-                    rs::ProjectionElem::Index(loc) => {
-                        let i = PlaceExpr::Local(self.local_name_map[&loc]);
+                    smir::ProjectionElem::Index(loc) => {
+                        let i = PlaceExpr::Local(self.local_name_map[&(*loc).into()]);
                         let i = GcCow::new(i);
                         let i = ValueExpr::Load { source: i };
                         let i = GcCow::new(i);
                         let root = GcCow::new(expr);
                         PlaceExpr::Index { root, index: i }
                     }
-                    rs::ProjectionElem::Downcast(_variant_name, variant_idx) => {
+                    smir::ProjectionElem::Downcast(variant_idx) => {
                         let root = GcCow::new(expr);
-                        let discriminant = self.discriminant_for_variant(this_ty.ty, variant_idx);
+                        let discriminant =
+                            self.discriminant_for_variant_stable(this_ty, *variant_idx);
                         PlaceExpr::Downcast { root, discriminant }
                     }
                     x => todo!("{:?}", x),

--- a/tooling/minimize/src/ty.rs
+++ b/tooling/minimize/src/ty.rs
@@ -11,12 +11,11 @@ impl<'tcx> Ctxt<'tcx> {
         Layout { size, align, inhabited }
     }
 
-    pub fn layout_of_stable(&self, ty: smir::Ty) -> Layout {
+    pub fn layout_of_smir(&self, ty: smir::Ty) -> Layout {
         self.layout_of(smir::internal(self.tcx, ty))
     }
 
-
-    pub fn translate_ty_stable(&self, ty: smir::Ty) -> Type {
+    pub fn translate_ty_smir(&self, ty: smir::Ty) -> Type {
         self.translate_ty(smir::internal(self.tcx, ty))
     }
 
@@ -126,7 +125,7 @@ pub fn translate_mutbl(mutbl: rs::Mutability) -> Mutability {
     }
 }
 
-pub fn translate_mutbl_stable(mutbl: smir::Mutability) -> Mutability {
+pub fn translate_mutbl_smir(mutbl: smir::Mutability) -> Mutability {
     match mutbl {
         smir::Mutability::Mut => Mutability::Mutable,
         smir::Mutability::Not => Mutability::Immutable,

--- a/tooling/minimize/src/ty.rs
+++ b/tooling/minimize/src/ty.rs
@@ -11,6 +11,15 @@ impl<'tcx> Ctxt<'tcx> {
         Layout { size, align, inhabited }
     }
 
+    pub fn layout_of_stable(&self, ty: smir::Ty) -> Layout {
+        self.layout_of(smir::internal(self.tcx, ty))
+    }
+
+
+    pub fn translate_ty_stable(&self, ty: smir::Ty) -> Type {
+        self.translate_ty(smir::internal(self.tcx, ty))
+    }
+
     pub fn translate_ty(&self, ty: rs::Ty<'tcx>) -> Type {
         match ty.kind() {
             rs::TyKind::Bool => Type::Bool,
@@ -114,6 +123,13 @@ pub fn translate_mutbl(mutbl: rs::Mutability) -> Mutability {
     match mutbl {
         rs::Mutability::Mut => Mutability::Mutable,
         rs::Mutability::Not => Mutability::Immutable,
+    }
+}
+
+pub fn translate_mutbl_stable(mutbl: smir::Mutability) -> Mutability {
+    match mutbl {
+        smir::Mutability::Mut => Mutability::Mutable,
+        smir::Mutability::Not => Mutability::Immutable,
     }
 }
 


### PR DESCRIPTION
- Methods that handle StableMIR objects have the `_stable` suffix for now.