### PR TITLE
Mark used bytes of enums for unions

### DIFF
--- a/tooling/minimize/src/chunks.rs
+++ b/tooling/minimize/src/chunks.rs
@@ -64,7 +64,14 @@ fn mark_used_bytes(ty: Type, markers: &mut [bool]) {
                 mark_used_bytes(elem, &mut markers[offset..]);
             }
         }
-        Type::Enum { .. } => panic!("unsupported!"),
+        Type::Enum { variants, .. } =>
+            for Variant { ty, tagger } in variants.values() {
+                mark_used_bytes(ty, markers);
+                for (offset, (ity, _)) in tagger {
+                    let offset = offset.bytes().try_to_usize().unwrap();
+                    mark_size(ity.size, &mut markers[offset..]);
+                }
+            },
     }
 }
 

--- a/tooling/minimize/tests/pass/union.rs
+++ b/tooling/minimize/tests/pass/union.rs
@@ -12,6 +12,46 @@ union B {
     f2: u8,
 }
 
+
+#[derive(Clone, Copy)]
+union EnumUnion {
+    data: Option<i32>,
+}
+
+fn extract_some_int(u: EnumUnion) -> i32 {
+    unsafe {
+        match u.data {
+            Some(i) => i,
+            None => unreachable!(),
+        }
+    }
+}
+
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct TestStruct(i8, i16);
+
+#[derive(Clone, Copy)]
+union StructUnion {
+    data: TestStruct,
+}
+
+fn extract_struct(u: StructUnion) -> TestStruct {
+    unsafe { u.data }
+}
+
+
+#[derive(Clone, Copy)]
+union ArrayUnion {
+    data: [[i8; 3]; 2]
+}
+
+fn extract_array(u: ArrayUnion) -> [[i8; 3]; 2] {
+    unsafe { u.data }
+}
+
+
+
 fn main() {
     let mut x = A { f2: ()};
     x.f1 = 20;
@@ -20,4 +60,22 @@ fn main() {
     }
 
     let _y = B { f2: 0 };
+
+    // Make sure the value in `data` is preserved for enums, structs and arrays.
+    let u = EnumUnion { data: Some(42) };
+    assert!(extract_some_int(u) == 42);
+
+    let u = StructUnion { data: TestStruct(12, 1200) };
+    let s = extract_struct(u);
+    assert!(s.0 == 12);
+    assert!(s.1 == 1200);
+    
+    let u = ArrayUnion { data: [[42;3], [12;3]] };
+    let a = extract_array(u);
+    assert!(a[0][0] == 42);
+    assert!(a[0][1] == 42);
+    assert!(a[0][2] == 42);
+    assert!(a[1][0] == 12);
+    assert!(a[1][1] == 12);
+    assert!(a[1][2] == 12);
 }

--- a/tooling/minimize/tests/ub/enum_mark_used_bytes.rs
+++ b/tooling/minimize/tests/ub/enum_mark_used_bytes.rs
@@ -1,0 +1,33 @@
+include!("../helper/transmute.rs");
+
+/// This test case ensures that enums correctly mark their used bytes for unions and don't mark padding.
+/// It creates a union with all initialized bytes, and then after a copy tries to read all bytes.
+/// The read should fail as padding will get uninitialized during the copy.
+/// For alignment reasons the bytes are read as `u16`, as the enum is 2-byte aligned.
+
+#[derive(Clone, Copy)]
+#[repr(u16)]
+#[allow(unused)]
+enum Inner {
+    WithData(u16, u8),
+    Empty,
+}
+
+#[derive(Clone, Copy)]
+union TestUnion {
+    _data: Inner
+}
+
+// Shorthand for an array of `u8` with the same size of the union.
+type UnionAsArray = [u8; std::mem::size_of::<TestUnion>()];
+
+fn get_union_as_array(u: TestUnion) -> UnionAsArray {
+    unsafe { transmute::<TestUnion, UnionAsArray>(u) }
+}
+
+
+fn main() {
+    let zero = [0u8; std::mem::size_of::<TestUnion>()];
+    let u: TestUnion = unsafe { transmute::<UnionAsArray, TestUnion>(zero) };
+    let _shorts = get_union_as_array(u);
+}

--- a/tooling/minimize/tests/ub/enum_mark_used_bytes.stderr
+++ b/tooling/minimize/tests/ub/enum_mark_used_bytes.stderr
@@ -1,0 +1,1 @@
+UB: load at type Array { elem: Int(IntType { signed: Unsigned, size: Size(1 bytes) }), count: 6 } but the data in memory violates the validity invariant


### PR DESCRIPTION
Implements `mark_used_bytes` for enums.
Also adds test cases to ensure that relevant data in structs, enums and arrays is marked, and that padding is not marked in the case of enums.

Fixes https://github.com/minirust/minirust/issues/167