### PR TITLE
minimize: remove Option wrap from `translate_stmt`

### DIFF
--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -24,7 +24,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     stmts.push(Statement::Assign { destination, source });
                     stmts
                 } else {
-                    vec![] // assign of unsupported rvalues is IGNORED!
+                    vec![] // FIXME: assign of unsupported rvalues is IGNORED!
                 }
             }
             rs::StatementKind::StorageLive(local) => {


### PR DESCRIPTION
Removed the `Option` in `translate_stmt` by returning an empty vector instead.
I tried to remove the option from `translate_rvalue` as well, this would require support for the `BitAnd` operation.
Adding this support for `Int` is easy, but support for `Bool` is also required (possibly by casting to `Int` and doing the operation there, but I don't know if hacking a solution together is the right thing.)

Edit: changed `BinAdd` to `BitAnd` sorry for the confustion