### PR TITLE
Add `BitAnd` to MiniRust

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -117,6 +117,7 @@ impl<M: Memory> Machine<M> {
                 }
                 left % right
             }
+            BitAnd => left & right,
         })
     }
     fn eval_bin_op(
@@ -217,6 +218,32 @@ impl<M: Memory> Machine<M> {
             self.ptr_offset_wrapping(left, right)
         };
         ret((Value::Ptr(result), l_ty))
+    }
+}
+```
+
+### Boolean operations
+
+```rust
+impl<M: Memory> Machine<M> {
+    fn eval_bin_op_bool(&mut self, op: BinOpBool, left: bool, right: bool) -> bool {
+        use BinOpBool::*;
+        match op {
+            BitAnd => left & right,
+        }
+    }
+    fn eval_bin_op(
+        &mut self,
+        BinOp::Bool(op): BinOp,
+        (left, l_ty): (Value<M>, Type),
+        (right, _r_ty): (Value<M>, Type)
+    ) -> Result<(Value<M>, Type)> {
+        let Value::Bool(left) = left else { panic!("non-boolean input to boolean binop") };
+        let Value::Bool(right) = right else { panic!("non-boolean input to boolean binop") };
+
+        // Perform the operation.
+        let result = self.eval_bin_op_bool(op, left, right);
+        ret((Value::Bool(result), Type::Bool))
     }
 }
 ```

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -113,7 +113,7 @@ pub enum UnOpBool {
 pub enum UnOp {
     /// An operation on integers, with the given output type.
     Int(UnOpInt, IntType),
-    /// An operation on booleans.
+    /// An operation on booleans; returns a boolean.
     Bool(UnOpBool),
     /// Integer-to-pointer cast (uses previously exposed provenance).
     PtrFromExposed(PtrType),
@@ -134,6 +134,8 @@ pub enum BinOpInt {
     /// Remainder of a division, the `%` operator.
     /// Throws UB, if the modulus (second operand) is zero.
     Rem,
+    /// Bitwise-and two integer values.
+    BitAnd
 }
 
 /// A relation between integers.
@@ -152,6 +154,11 @@ pub enum IntRel {
     Ne,
 }
 
+pub enum BinOpBool {
+    /// Bitwise-and on booleans.
+    BitAnd,
+} 
+
 pub enum BinOp {
     /// An operation on integers, with the given output type.
     Int(BinOpInt, IntType),
@@ -159,6 +166,8 @@ pub enum BinOp {
     IntRel(IntRel),
     /// Pointer arithmetic (with or without inbounds requirement).
     PtrOffset { inbounds: bool },
+    /// An operation on booleans
+    Bool(BinOpBool),
 }
 ```
 

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -314,6 +314,11 @@ impl ValueExpr {
                         ensure(matches!(right, Type::Int(_)))?;
                         left
                     }
+                    Bool(_bool_op) => {
+                        ensure(matches!(left, Type::Bool))?;
+                        ensure(matches!(right, Type::Bool))?;
+                        Type::Bool
+                    }
                 }
             }
         })

--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -19,13 +19,9 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         match &stmt.kind {
             rs::StatementKind::Assign(box (place, rval)) => {
                 let destination = self.translate_place(place);
-                if let Some((mut stmts, source)) = self.translate_rvalue(rval) {
-                    // this puts the extra statements before the evaluation of `destination`!
-                    stmts.push(Statement::Assign { destination, source });
-                    stmts
-                } else {
-                    vec![] // FIXME: assign of unsupported rvalues is IGNORED!
-                }
+                let (mut stmts, source) = self.translate_rvalue(rval);
+                stmts.push(Statement::Assign { destination, source });
+                stmts
             }
             rs::StatementKind::StorageLive(local) => {
                 vec![Statement::StorageLive(self.local_name_map[&local])]

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -4,18 +4,12 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
     /// Translate an rvalue -- could generate a bunch of helper statements.
     /// Those will be executed *before* the actual assignment, and in particular
     /// before evaluation the destination place of the assignment.
-    pub fn translate_rvalue(
-        &mut self,
-        rv: &rs::Rvalue<'tcx>,
-    ) -> Option<(Vec<Statement>, ValueExpr)> {
+    pub fn translate_rvalue(&mut self, rv: &rs::Rvalue<'tcx>) -> (Vec<Statement>, ValueExpr) {
         self.translate_rvalue_smir(&smir::stable(rv))
     }
 
-    pub fn translate_rvalue_smir(
-        &mut self,
-        rv: &smir::Rvalue,
-    ) -> Option<(Vec<Statement>, ValueExpr)> {
-        Some((
+    pub fn translate_rvalue_smir(&mut self, rv: &smir::Rvalue) -> (Vec<Statement>, ValueExpr) {
+        (
             vec![],
             match rv {
                 smir::Rvalue::Use(operand) => self.translate_operand_smir(operand),
@@ -197,7 +191,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     let expose = Statement::Expose { value: operand };
                     let addr = build::ptr_addr(operand);
 
-                    return Some((vec![expose], addr));
+                    return (vec![expose], addr);
                 }
                 smir::Rvalue::Cast(smir::CastKind::PointerFromExposedAddress, operand, ty) => {
                     // TODO untested so far! (Can't test because of `predict`)
@@ -253,7 +247,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     todo!()
                 }
             },
-        ))
+        )
     }
 
     pub fn translate_operand(&mut self, operand: &rs::Operand<'tcx>) -> ValueExpr {

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -33,39 +33,39 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     let r = GcCow::new(r);
 
                     use smir::BinOp::*;
-                    let op = if *bin_op == Offset {
-                        BinOp::PtrOffset { inbounds: true }
-                    } else {
-                        // everything else right-now is a int op!
-
-                        let op = |x| {
-                            let Type::Int(int_ty) = self.translate_ty_smir(lty) else {
-                                panic!("arithmetic operation with non-int type unsupported!");
-                            };
-
-                            BinOp::Int(x, int_ty)
+                    let op_int = |x| {
+                        let Type::Int(int_ty) = self.translate_ty_smir(lty) else {
+                            panic!("arithmetic operation with non-int type unsupported!");
                         };
-                        let rel = |x| BinOp::IntRel(x);
+                        BinOp::Int(x, int_ty)
+                    };
+                    let rel = |x| BinOp::IntRel(x);
+                    let op = match *bin_op {
+                        Offset => BinOp::PtrOffset { inbounds: true },
+                        // all int ops
+                        Add => op_int(BinOpInt::Add),
+                        Sub => op_int(BinOpInt::Sub),
+                        Mul => op_int(BinOpInt::Mul),
+                        Div => op_int(BinOpInt::Div),
+                        Rem => op_int(BinOpInt::Rem),
 
-                        match bin_op {
-                            Add => op(BinOpInt::Add),
-                            Sub => op(BinOpInt::Sub),
-                            Mul => op(BinOpInt::Mul),
-                            Div => op(BinOpInt::Div),
-                            Rem => op(BinOpInt::Rem),
+                        Lt => rel(IntRel::Lt),
+                        Le => rel(IntRel::Le),
+                        Gt => rel(IntRel::Gt),
+                        Ge => rel(IntRel::Ge),
+                        Eq => rel(IntRel::Eq),
+                        Ne => rel(IntRel::Ne),
 
-                            Lt => rel(IntRel::Lt),
-                            Le => rel(IntRel::Le),
-                            Gt => rel(IntRel::Gt),
-                            Ge => rel(IntRel::Ge),
-                            Eq => rel(IntRel::Eq),
-                            Ne => rel(IntRel::Ne),
-
-                            BitAnd => return None,
-                            x => {
-                                dbg!(x);
-                                todo!("unsupported BinOp")
-                            }
+                        // implemented for int and bool
+                        BitAnd =>
+                            match self.translate_ty_smir(lty) {
+                                Type::Int(int_ty) => BinOp::Int(BinOpInt::BitAnd, int_ty),
+                                Type::Bool => BinOp::Bool(BinOpBool::BitAnd),
+                                _ => panic!("bit-and only supported for int and bool."),
+                            },
+                        x => {
+                            dbg!(x);
+                            todo!()
                         }
                     };
 

--- a/tooling/minimize/tests/pass/ops.rs
+++ b/tooling/minimize/tests/pass/ops.rs
@@ -10,6 +10,7 @@ fn main() {
     print(black_box(7) * 6);
     print(black_box(504) / 12);
     print(black_box(112) % 70);
+    print(black_box(171) & 62);
 
     print(black_box(10) > 2);
     print(black_box(10) >= 2);
@@ -17,4 +18,6 @@ fn main() {
     print(black_box(10) <= 2);
     print(black_box(10) == 2);
     print(black_box(10) != 2);
+
+    print(black_box(true) & true);
 }

--- a/tooling/minimize/tests/pass/ops.stdout
+++ b/tooling/minimize/tests/pass/ops.stdout
@@ -4,9 +4,11 @@
 42
 42
 42
+42
 true
 true
 false
 false
 false
+true
 true

--- a/tooling/minitest/src/tests/bool.rs
+++ b/tooling/minitest/src/tests/bool.rs
@@ -61,3 +61,51 @@ fn bool2int_requires_boolean_op() {
     let program = small_program(locals, statements);
     assert_ill_formed(program);
 }
+
+/// Test that bit_and::<bool> works for bool
+#[test]
+fn bit_and_bool_works() {
+    let locals = [];
+    let unreach_block = 5;
+    let blocks = [
+        // if false go to next block
+        block!(if_(bit_and::<bool>(const_bool(false), const_bool(false)), unreach_block, 1)),
+        block!(if_(bit_and::<bool>(const_bool(false), const_bool(true)), unreach_block, 2)),
+        block!(if_(bit_and::<bool>(const_bool(true), const_bool(false)), unreach_block, 3)),
+        // if true go to next block
+        block!(if_(bit_and::<bool>(const_bool(true), const_bool(true)), 4, unreach_block)),
+        block!(exit()),
+        block!(unreachable()),
+    ];
+    let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
+    assert_stop(prog);
+}
+
+// Test that bit_and::<bool> fails with non-int/non-bool
+#[test]
+fn bit_and_requires_bool() {
+    let locals = [<bool>::get_type()];
+    let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type());
+    let b0 = block!(
+        storage_live(0),
+        assign(local(0), bit_and::<bool>(const_arr, const_arr)),
+        storage_dead(0),
+        exit(),
+    );
+    let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
+    assert_ill_formed(prog);
+}
+
+// Test that bit_and::<bool> fails with int
+#[test]
+fn bit_and_no_bool_int_mixing() {
+    let locals = [<bool>::get_type()];
+    let b0 = block!(
+        storage_live(0),
+        assign(local(0), bit_and::<bool>(const_int::<i32>(1), const_int::<i32>(0))),
+        storage_dead(0),
+        exit(),
+    );
+    let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
+    assert_ill_formed(prog);
+}

--- a/tooling/minitest/src/tests/int.rs
+++ b/tooling/minitest/src/tests/int.rs
@@ -1,0 +1,50 @@
+use crate::*;
+
+/// Test that bit_and works for ints
+#[test]
+fn bit_and_int_works() {
+    let locals = [];
+    let unreach_block = 5;
+    let bit_and = |x, y| bit_and::<i32>(const_int::<i32>(x), const_int::<i32>(y));
+
+    let blocks = [
+        block!(if_(eq(bit_and(171, 62), const_int::<i32>(42)), 1, unreach_block)),
+        block!(if_(eq(bit_and(171, -214), const_int::<i32>(42)), 2, unreach_block)),
+        block!(if_(eq(bit_and(-2645, 62), const_int::<i32>(42)), 3, unreach_block)),
+        block!(if_(eq(bit_and(-41, -10), const_int::<i32>(-42)), 4, unreach_block)),
+        block!(exit()),
+        block!(unreachable()),
+    ];
+
+    let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
+    assert_stop(prog);
+}
+
+// Test that bit_and::<int_ty> fails with non-int/non-bool
+#[test]
+fn bit_and_requires_int() {
+    let locals = [<i32>::get_type()];
+    let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type());
+    let b0 = block!(
+        storage_live(0),
+        assign(local(0), bit_and::<i32>(const_arr, const_arr)),
+        storage_dead(0),
+        exit(),
+    );
+    let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
+    assert_ill_formed(prog);
+}
+
+// Test that bit_and::<int_ty> fails with bool
+#[test]
+fn bit_and_no_int_bool_mixing() {
+    let locals = [<i32>::get_type()];
+    let b0 = block!(
+        storage_live(0),
+        assign(local(0), bit_and::<i32>(const_bool(false), const_bool(true))),
+        storage_dead(0),
+        exit(),
+    );
+    let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
+    assert_ill_formed(prog);
+}

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod enum_downcast;
 mod enum_representation;
 mod heap_intrinsics;
 mod ill_formed;
+mod int;
 mod invalid_offset;
 mod locks;
 mod main;

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -122,6 +122,9 @@ pub fn mul<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
 pub fn div<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop::<T>(BinOpInt::Div, l, r)
 }
+pub fn bit_and<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop::<T>(BinOpInt::BitAnd, l, r)
+}
 
 fn int_rel(op: IntRel, l: ValueExpr, r: ValueExpr) -> ValueExpr {
     ValueExpr::BinOp { operator: BinOp::IntRel(op), left: GcCow::new(l), right: GcCow::new(r) }
@@ -149,6 +152,17 @@ pub fn le(l: ValueExpr, r: ValueExpr) -> ValueExpr {
 
 pub fn lt(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_rel(IntRel::Lt, l, r)
+}
+
+fn bool_binop<T: TypeConv>(op: BinOpBool, l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    if T::get_type() != Type::Bool {
+        panic!("boolean operator received non-boolean type!");
+    }
+    ValueExpr::BinOp { operator: BinOp::Bool(op), left: GcCow::new(l), right: GcCow::new(r) }
+}
+
+pub fn bool_bit_and<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    bool_binop::<T>(BinOpBool::BitAnd, l, r)
 }
 
 pub enum InBounds {

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -123,7 +123,11 @@ pub fn div<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop::<T>(BinOpInt::Div, l, r)
 }
 pub fn bit_and<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
-    int_binop::<T>(BinOpInt::BitAnd, l, r)
+    if T::get_type() == Type::Bool {
+        bool_binop(BinOpBool::BitAnd, l, r)
+    } else {
+        int_binop::<T>(BinOpInt::BitAnd, l, r)
+    }
 }
 
 fn int_rel(op: IntRel, l: ValueExpr, r: ValueExpr) -> ValueExpr {
@@ -154,15 +158,8 @@ pub fn lt(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_rel(IntRel::Lt, l, r)
 }
 
-fn bool_binop<T: TypeConv>(op: BinOpBool, l: ValueExpr, r: ValueExpr) -> ValueExpr {
-    if T::get_type() != Type::Bool {
-        panic!("boolean operator received non-boolean type!");
-    }
+fn bool_binop(op: BinOpBool, l: ValueExpr, r: ValueExpr) -> ValueExpr {
     ValueExpr::BinOp { operator: BinOp::Bool(op), left: GcCow::new(l), right: GcCow::new(r) }
-}
-
-pub fn bool_bit_and<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
-    bool_binop::<T>(BinOpBool::BitAnd, l, r)
 }
 
 pub enum InBounds {

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -170,6 +170,7 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
                 BinOpInt::Mul => '*',
                 BinOpInt::Div => '/',
                 BinOpInt::Rem => '%',
+                BinOpInt::BitAnd => '&',
             };
 
             let int_ty = fmt_int_type(int_ty).to_string();
@@ -203,6 +204,15 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             let l = fmt_value_expr(left.extract(), comptypes).to_string();
             let r = fmt_value_expr(right.extract(), comptypes).to_string();
             FmtExpr::Atomic(format!("{offset_name}({l}, {r})"))
+        }
+        ValueExpr::BinOp { operator: BinOp::Bool(bool_op), left, right } => {
+            let bool_op = match bool_op {
+                BinOpBool::BitAnd => '&',
+            };
+            let l = fmt_value_expr(left.extract(), comptypes).to_atomic_string();
+            let r = fmt_value_expr(right.extract(), comptypes).to_atomic_string();
+            // due to overlap with integer binop add <bool> to operator
+            FmtExpr::NonAtomic(format!("{l} {bool_op}<bool> {r}"))
         }
     }
 }


### PR DESCRIPTION
Add `BitAnd` to the binary ops of `Int` and `Bool`. The `translate_rvalue` now returns the new operation instead of None &rarr; therefore the return type does not have to be `Option` wrapped anymore. 
Should I add some additional tests for this?