### PR TITLE
Fix `expose` well-formedness check

### DIFF
--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -396,7 +396,7 @@ impl Statement {
             }
             Expose { value } => {
                 let v = value.check_wf::<T>(live_locals, prog)?;
-                ensure(matches!(v, Type::Ptr(_)));
+                ensure(matches!(v, Type::Ptr(_)))?;
                 live_locals
             }
             SetDiscriminant { destination, value } => {

--- a/tooling/minitest/src/tests/expose.rs
+++ b/tooling/minitest/src/tests/expose.rs
@@ -1,0 +1,30 @@
+use crate::*;
+
+/// Test if `expose` called with non-pointer is ill-formed.
+#[test]
+fn requires_pointer() {
+    let locals = [];
+    let blocks = [block!(expose(const_bool(false)), exit())];
+
+    let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
+    assert_ill_formed(program);
+}
+
+/// Test if `expose` called with pointer works.
+#[test]
+fn pointer_works() {
+    let locals = [<i32>::get_type(), <*const i32>::get_type()];
+    let blocks = [block!(
+        storage_live(0),
+        assign(local(0), const_int::<i32>(42)),
+        storage_live(1),
+        assign(local(1), addr_of(local(1), <*const i32>::get_type()),),
+        expose(load(local(1))),
+        storage_dead(1),
+        storage_dead(0),
+        exit(),
+    )];
+
+    let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
+    assert_stop(program);
+}

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod div_zero;
 mod enum_discriminant;
 mod enum_downcast;
 mod enum_representation;
+mod expose;
 mod heap_intrinsics;
 mod ill_formed;
 mod invalid_offset;


### PR DESCRIPTION
Just a small bug fix + test for a forgotten `?` in `expose` wf check.
I'm not sure where to put the tests, there's not really a structure in `minitest/src/tests`, so I created a new file and put the test in there.