### PR TITLE
minimize: call `span_bug!`

### DIFF
--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -18,9 +18,11 @@ extern crate stable_mir;
 mod rs {
     pub use rustc_middle::mir::UnevaluatedConst;
     pub use rustc_middle::mir::{self, interpret::*, *};
+    pub use rustc_middle::span_bug;
     pub use rustc_middle::ty::*;
     pub use rustc_mir_dataflow::storage::always_storage_live_locals;
     pub use rustc_span::source_map::Spanned;
+    pub use rustc_span::Span;
     pub use rustc_target::abi::{call::*, Align, FieldIdx, Layout, Size};
 }
 


### PR DESCRIPTION
Added `span_bug!` to all places where failing code seemed possible.
But it often points to some internal Rust code that generates that generates that error.
