### PR TITLE
minimize: add `span_bug!` to `translate_ty`

### DIFF
--- a/tooling/minimize/src/function.rs
+++ b/tooling/minimize/src/function.rs
@@ -87,7 +87,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         // convert mirs Local-types to minirust.
         for (id, local_name) in &self.local_name_map {
             let local_decl = &self.body.local_decls[*id];
-            self.locals.insert(*local_name, self.translate_ty(local_decl.ty));
+            let span = local_decl.source_info.span;
+            self.locals.insert(*local_name, self.translate_ty(local_decl.ty, span));
         }
 
         // the number of locals which are implicitly storage live.


### PR DESCRIPTION
This PR proposes two approaches handling `span` (and adding `span_bug!` to `translate_ty`)
1. **Simple approach (first commit)**: Pass `span` as an argument to each function as before.
2. **Experimental approach (second commit)**: Store `span` in `Ctxt` (change `TyCtxt` &rarr; `TyCtxtAt`)

The benefits of the experimental approach is that we get concise code and easy access to `span` whenever we need it, the disadvantage is that we have to remember to update `span`.