### PR TITLE
Add better errors to well-formedness check

### DIFF
--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -114,9 +114,7 @@ The transition function simply dispatches to evaluating the next statement/termi
 ```rust
 impl<M: Memory> Machine<M> {
     pub fn new(prog: Program, stdout: DynWrite, stderr: DynWrite) -> NdResult<Machine<M>> {
-        if prog.check_wf::<M::T>().is_none() {
-            throw_ill_formed!();
-        }
+        prog.check_wf::<M::T>()?;
 
         let mut mem = AtomicMemory::<M>::new();
         let mut global_ptrs = Map::new();

--- a/spec/prelude/main.md
+++ b/spec/prelude/main.md
@@ -24,7 +24,7 @@ pub enum TerminationInfo {
     /// The program was executed and the machine stopped without error.
     MachineStop,
     /// The program was ill-formed.
-    IllFormed,
+    IllFormed(String),
     /// The program did not terminate but no thread can make progress.
     Deadlock,
     /// The program terminated successfully but memory was leaked.
@@ -53,11 +53,13 @@ macro_rules! throw_memory_leak {
         do yeet TerminationInfo::MemoryLeak
     };
 }
+
 macro_rules! throw_ill_formed {
-    () => {
-        do yeet TerminationInfo::IllFormed
+    ($($tt:tt)*) => {
+        do yeet TerminationInfo::IllFormed(format!($($tt)*))
     };
 }
+
 macro_rules! throw_deadlock {
     () => {
         do yeet TerminationInfo::Deadlock

--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -112,8 +112,11 @@ fn main() {
         } else {
             match run_program(prog) {
                 // We can't use tcx.dcx().fatal due to <https://github.com/oli-obk/ui_test/issues/226>
-                TerminationInfo::IllFormed =>
-                    show_error!("program not well-formed (this is a bug in minimize)"),
+                TerminationInfo::IllFormed(err) =>
+                    show_error!(
+                        "program not well-formed (this is a bug in minimize):\n    {}",
+                        err.get_internal()
+                    ),
                 TerminationInfo::MachineStop => { /* silent exit. */ }
                 TerminationInfo::Ub(err) => show_error!("UB: {}", err.get_internal()),
                 TerminationInfo::Deadlock => show_error!("program dead-locked"),

--- a/tooling/minitest/src/lib.rs
+++ b/tooling/minitest/src/lib.rs
@@ -57,8 +57,11 @@ pub fn assert_ub_eventually(prog: Program, attempts: usize, msg: &str) {
 }
 
 #[track_caller]
-pub fn assert_ill_formed(prog: Program) {
-    assert_eq!(run_program(prog), TerminationInfo::IllFormed);
+pub fn assert_ill_formed(prog: Program, msg: &str) {
+    let TerminationInfo::IllFormed(info) = run_program(prog) else {
+        panic!("program is not ill formed!")
+    };
+    assert_eq!(info.get_internal(), msg, "program is ill-formed with a different error message");
 }
 
 #[track_caller]

--- a/tooling/minitest/src/tests/atomic_fetch.rs
+++ b/tooling/minitest/src/tests/atomic_fetch.rs
@@ -154,5 +154,5 @@ fn atomic_fetch_op() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ill_formed(p);
+    assert_ill_formed(p, "IntrinsicOp::AtomicFetchAndOp: non atomic op");
 }

--- a/tooling/minitest/src/tests/bool.rs
+++ b/tooling/minitest/src/tests/bool.rs
@@ -49,7 +49,7 @@ fn boolean_not_requires_boolean_op() {
     let locals = &[<bool>::get_type()];
     let statements = &[storage_live(0), assign(local(0), not(const_int(0u8))), storage_dead(0)];
     let program = small_program(locals, statements);
-    assert_ill_formed(program);
+    assert_ill_formed(program, "UnOp::Bool: invalid operand");
 }
 
 /// Tests that bool2int requires a boolean operand
@@ -59,7 +59,7 @@ fn bool2int_requires_boolean_op() {
     let statements =
         &[storage_live(0), assign(local(0), bool_to_int::<u8>(const_int(0u8))), storage_dead(0)];
     let program = small_program(locals, statements);
-    assert_ill_formed(program);
+    assert_ill_formed(program, "Cast::BoolToInt: invalid operand");
 }
 
 /// Test that BinOpBool::BitAnd works
@@ -93,7 +93,7 @@ fn bit_and_requires_bool() {
         exit(),
     );
     let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "BinOp::Bool: invalid left type");
 }
 
 // Test that BinOpBool::BitAnd fails with int
@@ -107,5 +107,5 @@ fn bit_and_no_bool_int_mixing() {
         exit(),
     );
     let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "BinOp::Bool: invalid left type");
 }

--- a/tooling/minitest/src/tests/call.rs
+++ b/tooling/minitest/src/tests/call.rs
@@ -46,7 +46,7 @@ fn call_non_exist() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ill_formed(p);
+    assert_ill_formed(p, "Constant::FnPointer: invalid function name");
 }
 
 #[test]

--- a/tooling/minitest/src/tests/enum_discriminant.rs
+++ b/tooling/minitest/src/tests/enum_discriminant.rs
@@ -13,7 +13,7 @@ fn ill_formed_invalid_discriminant_set() {
         set_discriminant(local(0), 0), // ill-formed here
     ];
     let program = small_program(&locals, &stmts);
-    assert_ill_formed(program);
+    assert_ill_formed(program, "Statement::SetDiscriminant: invalid discriminant write");
 }
 
 /// Tests that both `get_discriminant` and `set_discriminant` generally work.

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -16,7 +16,7 @@ fn out_of_bounds_downcast() {
         assign(local(1), load(downcast(local(0), 1))), // ill-formed here, variant 1 doesn't exist
     ];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "PlaceExpr::Downcast: invalid discriminant");
 }
 
 /// Works: Both assigning to and from a downcast.

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -15,7 +15,7 @@ fn ill_sized_enum_variant() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Type::Enum: variant size is not the same as enum size");
 }
 
 /// Ill-formed: the two variants have different sizes
@@ -33,7 +33,7 @@ fn inconsistently_sized_enum_variants() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Type::Enum: variant size is not the same as enum size");
 }
 
 /// Ill-formed: no variants but discriminator returns variant 1
@@ -43,7 +43,7 @@ fn ill_formed_discriminator() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Discriminator: invalid discriminant");
 }
 
 /// Ill-formed: discriminator branch has a case of -1 which is an invalid value for u8.
@@ -73,7 +73,7 @@ fn ill_formed_discriminator_branch() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Discriminator: invalid branch start bound");
 }
 
 /// Ill-formed: the discriminator branch children overlap.
@@ -96,7 +96,7 @@ fn ill_formed_discriminator_overlaps() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Discriminator: branch ranges overlap");
 }
 
 /// Ill-formed: the discriminator branch children overlap.
@@ -119,7 +119,7 @@ fn ill_formed_discriminator_overlaps_2() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Discriminator: branch ranges overlap");
 }
 
 /// Ill-formed: discriminant is of type u8 but variant has discriminant -1.
@@ -135,7 +135,7 @@ fn ill_formed_discriminant_value() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Type::Enum: invalid value for discriminant");
 }
 
 /// Works: simple roundtrip for both variants of an enum like Option<bool>
@@ -196,7 +196,7 @@ fn ill_formed_variant_constant() {
         assign(local(0), variant(0, unit(), enum_ty)), // ill-formed here
     ];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "ValueExpr::Variant: invalid discriminant");
 }
 
 /// Ill-formed: The data of the variant value does not match the type
@@ -214,7 +214,7 @@ fn ill_formed_variant_constant_data() {
         assign(local(0), variant(1, unit(), enum_ty)), // ill-formed here
     ];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "ValueExpr::Variant: invalid discriminant");
 }
 
 /// Ill-formed: Ensures that the enum alignment is at least as big as all the variant alignments.
@@ -229,7 +229,7 @@ fn ill_formed_enum_must_have_maximal_alignment_of_inner() {
     let locals = [enum_ty];
     let stmts = [];
     let prog = small_program(&locals, &stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Type::Enum: invalid align requirement");
 }
 
 const U32_INTTYPE: IntType =

--- a/tooling/minitest/src/tests/ill_formed.rs
+++ b/tooling/minitest/src/tests/ill_formed.rs
@@ -5,7 +5,7 @@ fn dead_before_live() {
     let locals = vec![<bool>::get_type()];
     let stmts = vec![storage_dead(0)];
     let p = small_program(&locals, &stmts);
-    assert_ill_formed(p);
+    assert_ill_formed(p, "Statement::StorageDead: local already dead");
 }
 
 #[test]
@@ -13,7 +13,7 @@ fn double_live() {
     let locals = vec![<bool>::get_type()];
     let stmts = vec![storage_live(0), storage_live(0)];
     let p = small_program(&locals, &stmts);
-    assert_ill_formed(p);
+    assert_ill_formed(p, "Statement::StorageLive: local already live");
 }
 
 #[test]
@@ -25,13 +25,13 @@ fn neg_count_array() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_ill_formed(p);
+    assert_ill_formed(p, "Type::Array: negative amount of elements");
 }
 
 #[test]
 fn no_main() {
     let p = program(&[]);
-    assert_ill_formed(p);
+    assert_ill_formed(p, "Program: start function does not exist");
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn too_large_local() {
     let stmts = &[];
 
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "Type: size not valid");
 }
 
 #[test]
@@ -50,5 +50,5 @@ fn type_mismatch() {
     let locals = &[<i32>::get_type()];
     let stmts = &[storage_live(0), assign(local(0), const_int::<u32>(0))];
     let p = small_program(locals, stmts);
-    assert_ill_formed(p);
+    assert_ill_formed(p, "Statement::Assign: destination and source type differ");
 }

--- a/tooling/minitest/src/tests/int.rs
+++ b/tooling/minitest/src/tests/int.rs
@@ -32,7 +32,7 @@ fn bit_and_requires_int() {
         exit(),
     );
     let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "BinOp::Int: invalid left type");
 }
 
 // Test that BinOpInt::BitAnd fails with bool
@@ -46,5 +46,5 @@ fn bit_and_no_int_bool_mixing() {
         exit(),
     );
     let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
-    assert_ill_formed(prog);
+    assert_ill_formed(prog, "BinOp::Int: invalid left type");
 }

--- a/tooling/minitest/src/tests/switch.rs
+++ b/tooling/minitest/src/tests/switch.rs
@@ -11,7 +11,7 @@ fn if_int_ill_formed() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_ill_formed(program);
+    assert_ill_formed(program, "Cast::BoolToInt: invalid operand");
 }
 
 /// tests that the if case can be reached.
@@ -46,7 +46,7 @@ fn boolean_switch_is_ill_formed() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_ill_formed(program);
+    assert_ill_formed(program, "Terminator::Switch: switch is not Int");
 }
 
 /// tests that switch_int can access an arbitrary case and the fallback case.


### PR DESCRIPTION
Closes #164
- Changed `check_wf` return type to `Result<(), TerminationInfo>` such that we can append error information.
- Added a String to `TerminationInfo::IllFormed` for the error message.
- Adapted the `throw_ill_formed` macro such that it adds the position of the error.
- Made `ensure` a macro as well such that it interacts nicely with `throw_ill_formed`.

The error messages are quite brief in the moment, but I am also happy to change that to more descriptive ones.