### PR TITLE
miniutil: new test api

### DIFF
--- a/tooling/minitest/src/tests/builder_api.rs
+++ b/tooling/minitest/src/tests/builder_api.rs
@@ -1,0 +1,172 @@
+use std::u32;
+
+use crate::*;
+
+#[test]
+fn global_var() {
+    let mut p = ProgramBuilder::new();
+    let var = p.declare_global_zero_initialized::<u32>();
+
+    let mut f = p.declare_function();
+    f.assign(var, const_int(42u32));
+    f.if_(eq(load(var), const_int(42u32)), |f| f.exit(), |f| f.unreachable());
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+fn local_var() {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+    let var = f.declare_local::<u32>();
+    f.storage_live(var);
+    f.assign(var, const_int(42u32));
+    f.if_(eq(load(var), const_int(42u32)), |_| {}, |f| f.unreachable());
+    f.exit();
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+fn arg_and_ret_var() {
+    let mut p = ProgramBuilder::new();
+
+    let add_two_if_42: FnName = {
+        let mut f = p.declare_function();
+        let var = f.declare_arg::<u32>();
+        let ret = f.declare_ret::<u32>();
+        f.if_(eq(load(var), const_int(42u32)), |_| {}, |f| f.unreachable());
+        f.assign(ret, add(load(var), const_int(2u32)));
+        f.return_();
+        p.finish_function(f)
+    };
+
+    let start: FnName = {
+        let mut start = p.declare_function();
+        let ret_place = start.declare_local::<u32>();
+        start.storage_live(ret_place);
+        start.call(ret_place, add_two_if_42, &[by_value(const_int(42u32))]);
+        start.if_(eq(load(ret_place), const_int(44u32)), |f| f.exit(), |f| f.unreachable());
+        p.finish_function(start)
+    };
+
+    let p = p.finish_program(start);
+    assert_stop(p);
+}
+
+#[test]
+fn switch_int() {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+    let var = f.declare_local::<u32>();
+    f.storage_live(var);
+    f.assign(var, const_int(42_u32));
+    f.switch_int(
+        load(var),
+        &[
+            (41, &|f| f.assign(var, add(load(var), const_int(0u32)))),
+            (42, &|f| f.assign(var, add(load(var), const_int(1u32)))),
+            (43, &|f| f.assign(var, add(load(var), const_int(0u32)))),
+        ],
+        |f| f.assign(var, add(load(var), const_int(0u32))),
+    );
+    f.if_(eq(load(var), const_int(43_u32)), |_| {}, |f| f.unreachable());
+    f.storage_dead(var);
+    f.exit();
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+fn while_() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let var = f.declare_local::<u32>();
+    let counter = f.declare_local::<u32>();
+    f.storage_live(var);
+    f.storage_live(counter);
+    f.assign(var, const_int(0u32));
+    f.assign(counter, const_int(0u32));
+    f.while_(lt(load(counter), const_int(42u32)), |f| {
+        f.assign(counter, add(load(counter), const_int(1u32)));
+        f.assign(var, add(load(var), const_int(2u32)));
+    });
+    f.if_(eq(load(var), const_int(84u32)), |f| f.exit(), |f| f.unreachable());
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+#[should_panic(expected = "PlaceExpr is not a local")]
+fn storage_live_with_non_local() {
+    let mut p = ProgramBuilder::new();
+    let g = p.declare_global_zero_initialized::<i32>();
+    let mut f = p.declare_function();
+    f.storage_live(g);
+}
+
+#[test]
+#[should_panic(expected = "PlaceExpr is not a local")]
+fn storage_dead_with_non_local() {
+    let mut p = ProgramBuilder::new();
+    let g = p.declare_global_zero_initialized::<i32>();
+
+    let mut f = p.declare_function();
+    f.storage_dead(g);
+}
+
+#[test]
+#[should_panic(expected = "finish_block: there is no block to finish")]
+fn double_exit() {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+    f.exit();
+    f.exit(); // this is wrong, we already finished the block
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+#[should_panic(expected = "There is no current block. Cannot insert statement/terminator.")]
+fn statement_after_exit() {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+    let var = f.declare_local::<u32>();
+    f.exit();
+    f.assign(var, const_int(42_u32)); // this is wrong, we already finished the block
+    f.exit();
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+#[should_panic(
+    expected = "Function has an unfinished block. You need to return or exit from the last block."
+)]
+fn no_exit() {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+    let var = f.declare_local::<u32>();
+    f.storage_live(var);
+    f.assign(var, const_int(42_u32));
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}

--- a/tooling/minitest/src/tests/locks.rs
+++ b/tooling/minitest/src/tests/locks.rs
@@ -12,37 +12,50 @@ use crate::*;
 /// By making the critical section large (256 times around a loop)
 /// we get a high probability that the handover happened.
 fn lock_handover() {
-    let locals = [<()>::get_type(), <u32>::get_type()];
+    let mut p = ProgramBuilder::new();
+    let lock = p.declare_global_zero_initialized::<u32>();
 
-    let b0 = block!(
-        storage_live(1),
-        assign(local(1), const_int::<u32>(0)),
-        lock_acquire(load(global::<u32>(0)), 1)
-    );
-    let b1 = block!(if_(eq(load(local(1)), const_int::<u32>(256)), 3, 2));
-    let b2 = block!(assign(local(1), add(load(local(1)), const_int::<u32>(1))), goto(1));
-    let b3 = block!(lock_release(load(global::<u32>(0)), 4));
-    let b4 = block!(return_());
-    let critical = function(Ret::Yes, 0, &locals, &[b0, b1, b2, b3, b4]);
+    let critical: FnName = {
+        let mut critical = p.declare_function();
+        let val = critical.declare_local::<u32>();
 
-    let locals = [<u32>::get_type(), <()>::get_type()];
+        critical.storage_live(val);
+        critical.assign(val, const_int(0u32));
+        critical.lock_acquire(load(lock));
+        critical.while_(ne(load(val), const_int(256_u32)), |f| {
+            f.assign(val, add(load(val), const_int(1u32)));
+        });
+        critical.lock_release(load(lock));
+        critical.return_();
 
-    let b0 = block!(storage_live(0), storage_live(1), lock_create(global::<u32>(0), 1),);
-    let b1 = block!(spawn(fn_ptr(1), null(), local(0), 2));
-    let b2 = block!(call(2, &[], local(1), Some(3)));
-    let b3 = block!(join(load(local(0)), 4));
-    let b4 = block!(exit());
-    let main = function(Ret::No, 0, &locals, &[b0, b1, b2, b3, b4]);
+        p.finish_function(critical)
+    };
 
-    let locals = [<()>::get_type(), <*const ()>::get_type()];
+    let mut second = p.declare_function();
 
-    let b0 = block!(call(2, &[], local(0), Some(1)));
-    let b1 = block!(return_());
-    let second = function(Ret::Yes, 1, &locals, &[b0, b1]);
+    let main: FnName = {
+        let mut main = p.declare_function();
+        let thread_id = main.declare_local::<u32>();
 
-    let globals = [global_int::<u32>()];
+        main.storage_live(thread_id);
+        main.lock_create(lock);
+        main.spawn(second.name(), null(), thread_id);
+        main.call_ignoreret(critical, &[]);
+        main.join(load(thread_id));
+        main.exit();
 
-    let p = program_with_globals(&[main, second, critical], &globals);
+        p.finish_function(main)
+    };
+
+    // implement function `second`
+    {
+        second.declare_arg::<*const ()>();
+        second.call_ignoreret(critical, &[]);
+        second.return_();
+        p.finish_function(second);
+    }
+
+    let p = p.finish_program(main);
     assert_stop(p);
 }
 
@@ -73,40 +86,49 @@ fn lock_handover() {
 /// If a handover occurs and data race detection does not synchronize the acquirer,
 /// it immediatly writing to global_1 would be a data race with the release.
 fn lock_handover_data_race() {
-    let locals = [<()>::get_type()];
+    let mut p = ProgramBuilder::new();
+    let lock = p.declare_global_zero_initialized::<u32>();
+    let gstore = p.declare_global_zero_initialized::<*const u32>();
 
-    let ptr_ty = <*const u32>::get_type();
+    let critical: FnName = {
+        let mut critical = p.declare_function();
 
-    let p_ptype = <u32>::get_type();
+        critical.lock_acquire(load(lock));
+        critical.atomic_store(
+            addr_of(gstore, <*const *const u32>::get_type()),
+            addr_of(lock, <*const u32>::get_type()),
+        );
+        critical.lock_release(load(deref(load(gstore), <u32>::get_type())));
+        critical.return_();
 
-    let b0 = block!(lock_acquire(load(global::<u32>(0)), 1));
-    let b1 = block!(atomic_store(
-        addr_of(global::<*const u32>(1), <*const *const u32>::get_type()),
-        addr_of(global::<u32>(0), ptr_ty),
-        2
-    ));
-    let b2 = block!(lock_release(load(deref(load(global::<*const u32>(1)), p_ptype)), 3));
-    let b3 = block!(return_());
-    let critical = function(Ret::Yes, 0, &locals, &[b0, b1, b2, b3]);
+        p.finish_function(critical)
+    };
 
-    let locals = [<u32>::get_type(), <()>::get_type()];
+    let mut second = p.declare_function();
 
-    let b0 = block!(storage_live(0), storage_live(1), lock_create(global::<u32>(0), 1),);
-    let b1 = block!(spawn(fn_ptr(1), null(), local(0), 2));
-    let b2 = block!(call(2, &[], local(1), Some(3)));
-    let b3 = block!(join(load(local(0)), 4));
-    let b4 = block!(exit());
-    let main = function(Ret::No, 0, &locals, &[b0, b1, b2, b3, b4]);
+    let main: FnName = {
+        let mut main = p.declare_function();
+        let thread_id = main.declare_local::<u32>();
 
-    let locals = [<()>::get_type(), <*const ()>::get_type()];
+        main.storage_live(thread_id);
+        main.lock_create(lock);
+        main.spawn(second.name(), null(), thread_id);
+        main.call_ignoreret(critical, &[]);
+        main.join(load(thread_id));
+        main.exit();
 
-    let b0 = block!(call(2, &[], local(0), Some(1)));
-    let b1 = block!(return_());
-    let second = function(Ret::Yes, 1, &locals, &[b0, b1]);
+        p.finish_function(main)
+    };
 
-    let globals = [global_int::<u32>(), global_ptr::<u32>()];
+    // implement function `second`
+    {
+        second.declare_arg::<*const ()>();
+        second.call_ignoreret(critical, &[]);
+        second.return_();
+        p.finish_function(second);
+    }
 
-    let p = program_with_globals(&[main, second, critical], &globals);
+    let p = p.finish_program(main);
     assert_stop_always(p, 10);
 }
 
@@ -305,27 +327,35 @@ fn deadlock() {
     // The second function then tries to get this lock while the main tries to join the second thread.
     // In such a situation both threads wait for each other and we have a deadlock.
 
-    // The locals are used to store the thread ids.
-    let locals = [<u32>::get_type()];
+    let mut p = ProgramBuilder::new();
+    let lock = p.declare_global_zero_initialized::<u32>();
 
-    let b0 = block!(lock_create(global::<u32>(0), 1));
-    let b1 = block!(lock_acquire(load(global::<u32>(0)), 2));
-    let b2 = block!(storage_live(0), spawn(fn_ptr(1), null(), local(0), 3));
-    let b3 = block!(join(load(local(0)), 4));
-    let b4 = block!(lock_release(load(global::<u32>(0)), 5));
-    let b5 = block!(exit());
-    let main = function(Ret::No, 0, &locals, &[b0, b1, b2, b3, b4, b5]);
+    let mut second = p.declare_function();
 
-    let locals = [<()>::get_type(), <*const ()>::get_type()];
-    let b0 = block!(lock_acquire(load(global::<u32>(0)), 1));
-    let b1 = block!(lock_release(load(global::<u32>(0)), 2));
-    let b2 = block!(return_());
-    let second = function(Ret::Yes, 1, &locals, &[b0, b1, b2]);
+    let main: FnName = {
+        let mut main = p.declare_function();
+        let thread_id = main.declare_local::<u32>();
 
-    // global(0) is used as a lock. We store the lock id there.
-    let globals = [global_int::<u32>()];
+        main.lock_create(lock);
+        main.lock_acquire(load(lock));
+        main.storage_live(thread_id);
+        main.spawn(second.name(), null(), thread_id);
+        main.join(load(thread_id));
+        main.lock_release(load(lock));
+        main.exit();
 
-    let p = program_with_globals(&[main, second], &globals);
+        p.finish_function(main)
+    };
 
+    // implement function `second`
+    {
+        second.declare_arg::<*const ()>();
+        second.lock_acquire(load(lock));
+        second.lock_release(load(lock));
+        second.return_();
+        p.finish_function(second);
+    }
+
+    let p = p.finish_program(main);
     assert_deadlock(p);
 }

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod align;
 mod atomic;
 mod atomic_fetch;
 mod bool;
+mod builder_api;
 mod call;
 mod compare_exchange;
 mod concurrency;

--- a/tooling/minitest/src/tests/packed.rs
+++ b/tooling/minitest/src/tests/packed.rs
@@ -21,16 +21,21 @@ fn packed_works() {
 
 #[test]
 fn packed_is_not_aligned() {
-    let locals = [make_packed(), <&i32>::get_type()];
-    let b0 = block!(
-        storage_live(0),
-        assign(field(local(0), 0), const_int(0i32),),
-        storage_live(1),
-        assign(local(1), addr_of(field(local(0), 0), <&i32>::get_type()),),
-        exit(),
-    );
-    let f = function(Ret::No, 0, &locals, &[b0]);
-    let p = program(&[f]);
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+    let tuple = f.declare_local_with_ty(make_packed());
+    let int_ptr = f.declare_local::<&i32>();
+
+    f.storage_live(tuple);
+    f.assign(field(tuple, 0), const_int(0i32));
+    f.storage_live(int_ptr);
+    f.assign(int_ptr, addr_of(field(tuple, 0), <&i32>::get_type()));
+    f.exit();
+
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
     assert_ub_eventually(
         p,
         16,

--- a/tooling/miniutil/src/build/function.rs
+++ b/tooling/miniutil/src/build/function.rs
@@ -5,6 +5,13 @@ pub fn fn_ptr(fn_name: u32) -> ValueExpr {
     fn_ptr_conv(fn_name, CallingConvention::C)
 }
 
+pub fn fn_ptr_by_name(name: FnName) -> ValueExpr {
+    let c = Constant::FnPointer(name);
+    // For now we use the C ABI for everything since that's what `spawn` needs...
+    let t = Type::Ptr(PtrType::FnPtr(CallingConvention::C));
+    ValueExpr::Constant(c, t)
+}
+
 pub fn fn_ptr_conv(fn_name: u32, conv: CallingConvention) -> ValueExpr {
     let x = Name::from_internal(fn_name as _);
     let x = FnName(x);

--- a/tooling/miniutil/src/build/global.rs
+++ b/tooling/miniutil/src/build/global.rs
@@ -1,5 +1,16 @@
 use crate::build::*;
 
+impl ProgramBuilder {
+    pub fn declare_global_zero_initialized<T: TypeConv>(&mut self) -> PlaceExpr {
+        let bytes = List::from_elem(Some(0), T::get_size().bytes());
+        let global = Global { bytes, relocations: list!(), align: <T>::get_align() };
+        let name = GlobalName(Name::from_internal(self.next_global));
+        self.next_global += 1;
+        self.globals.try_insert(name, global).unwrap();
+        global_by_name::<T>(name)
+    }
+}
+
 /// Global Int initialized to zero.
 pub fn global_int<T: TypeConv>() -> Global {
     let bytes = List::from_elem(Some(0), T::get_size().bytes());

--- a/tooling/miniutil/src/build/mod.rs
+++ b/tooling/miniutil/src/build/mod.rs
@@ -39,6 +39,181 @@ pub use ty::*;
 mod ty_conv;
 pub use ty_conv::*;
 
+pub struct ProgramBuilder {
+    functions: Map<FnName, Function>,
+    globals: Map<GlobalName, Global>,
+    next_fn: u32,
+    next_global: u32,
+}
+
+impl ProgramBuilder {
+    pub fn new() -> ProgramBuilder {
+        ProgramBuilder {
+            functions: Default::default(),
+            globals: Default::default(),
+            next_fn: 0,
+            next_global: 0,
+        }
+    }
+
+    pub fn finish_program(self, start_function: FnName) -> Program {
+        Program { functions: self.functions, start: start_function, globals: self.globals }
+    }
+
+    pub fn declare_function(&mut self) -> FunctionBuilder {
+        let name = FnName(Name::from_internal(self.next_fn));
+        self.next_fn += 1;
+        FunctionBuilder::new(name)
+    }
+
+    #[track_caller]
+    pub fn finish_function(&mut self, f: FunctionBuilder) -> FnName {
+        let name = f.name();
+        let f = f.finish_function();
+        self.functions.try_insert(name, f).unwrap();
+        name
+    }
+}
+
+pub struct FunctionBuilder {
+    name: FnName,
+    locals: Map<LocalName, Type>,
+    args: List<LocalName>,
+    blocks: Map<BbName, BasicBlock>,
+
+    start: BbName,
+    ret: Option<LocalName>,
+
+    cur_block: Option<CurBlock>,
+
+    next_block: u32,
+    next_local: u32,
+}
+
+impl FunctionBuilder {
+    fn new(name: FnName) -> FunctionBuilder {
+        let mut fb = FunctionBuilder {
+            name,
+            locals: Default::default(),
+            blocks: Default::default(),
+            args: Default::default(),
+            start: BbName(Name::from_internal(0)),
+            ret: None,
+            cur_block: None,
+            next_block: 0,
+            next_local: 0,
+        };
+        // prepare the starting block
+        let start_block = fb.declare_block();
+        // Make sure we set `start` correctly above.
+        assert_eq!(start_block, fb.start);
+        fb.set_cur_block(start_block);
+        fb
+    }
+
+    fn declare_block(&mut self) -> BbName {
+        let name = BbName(Name::from_internal(self.next_block));
+        self.next_block += 1;
+        name
+    }
+
+    fn set_cur_block(&mut self, name: BbName) {
+        if self.blocks.contains_key(name) {
+            panic!("Already inserted a block with this name.")
+        }
+        self.cur_block = match self.cur_block {
+            None => Some(CurBlock::new(name)),
+            Some(_) =>
+                panic!("There is an unfinished current block. Cannot set a new current block."),
+        };
+    }
+
+    fn cur_block(&mut self) -> &mut CurBlock {
+        self.cur_block
+            .as_mut()
+            .expect("There is no current block. Cannot insert statement/terminator.")
+    }
+
+    #[track_caller]
+    fn finish_function(mut self) -> Function {
+        if self.cur_block.is_some() {
+            panic!(
+                "Function has an unfinished block. You need to return or exit from the last block."
+            )
+        }
+
+        // Default return type to `()`
+        if self.ret.is_none() {
+            self.declare_ret::<()>();
+        }
+
+        Function {
+            locals: self.locals,
+            args: self.args,
+            ret: self.ret.unwrap(),
+            calling_convention: CallingConvention::C,
+            blocks: self.blocks,
+            start: self.start,
+        }
+    }
+
+    pub fn name(&self) -> FnName {
+        self.name
+    }
+
+    fn fresh_local_name(&mut self) -> LocalName {
+        let name = LocalName(Name::from_internal(self.next_local));
+        self.next_local += 1;
+        name
+    }
+
+    pub fn declare_local<T: TypeConv>(&mut self) -> PlaceExpr {
+        let name = self.fresh_local_name();
+        self.locals.try_insert(name, T::get_type()).unwrap();
+        local_by_name(name)
+    }
+
+    pub fn declare_local_with_ty(&mut self, t: Type) -> PlaceExpr {
+        let name = self.fresh_local_name();
+        self.locals.try_insert(name, t).unwrap();
+        local_by_name(name)
+    }
+
+    #[track_caller]
+    pub fn declare_ret<T: TypeConv>(&mut self) -> PlaceExpr {
+        let name = match self.ret {
+            Some(_) => panic!("Ret local already set."),
+            None => self.fresh_local_name(),
+        };
+        self.locals.try_insert(name, T::get_type()).unwrap();
+        self.ret = Some(name);
+        local_by_name(name)
+    }
+
+    pub fn declare_arg<T: TypeConv>(&mut self) -> PlaceExpr {
+        let name = self.fresh_local_name();
+        self.locals.try_insert(name, T::get_type()).unwrap();
+        self.args.push(name);
+        local_by_name(name)
+    }
+}
+
+struct CurBlock {
+    statements: List<Statement>,
+    name: BbName,
+}
+
+impl CurBlock {
+    pub fn new(name: BbName) -> CurBlock {
+        CurBlock { statements: Default::default(), name }
+    }
+}
+
+fn bbname_into_u32(name: BbName) -> u32 {
+    let BbName(name) = name;
+    name.get_internal()
+}
+
 pub fn align(bytes: impl Into<Int>) -> Align {
     let bytes = bytes.into();
     Align::from_bytes(bytes).unwrap()

--- a/tooling/miniutil/src/build/statement.rs
+++ b/tooling/miniutil/src/build/statement.rs
@@ -1,5 +1,31 @@
 use crate::build::*;
 
+impl FunctionBuilder {
+    pub fn assign(&mut self, destination: PlaceExpr, source: ValueExpr) {
+        self.cur_block().statements.push(Statement::Assign { destination, source });
+    }
+
+    pub fn set_discriminant(&mut self, destination: PlaceExpr, value: impl Into<Int>) {
+        self.cur_block()
+            .statements
+            .push(Statement::SetDiscriminant { destination, value: value.into() });
+    }
+
+    pub fn validate(&mut self, place: PlaceExpr, fn_entry: bool) {
+        self.cur_block().statements.push(Statement::Validate { place, fn_entry });
+    }
+
+    pub fn storage_live(&mut self, local: PlaceExpr) {
+        let PlaceExpr::Local(name) = local else { panic!("PlaceExpr is not a local") };
+        self.cur_block().statements.push(Statement::StorageLive(name));
+    }
+
+    pub fn storage_dead(&mut self, local: PlaceExpr) {
+        let PlaceExpr::Local(name) = local else { panic!("PlaceExpr is not a local") };
+        self.cur_block().statements.push(Statement::StorageDead(name));
+    }
+}
+
 pub fn assign(destination: PlaceExpr, source: ValueExpr) -> Statement {
     Statement::Assign { destination, source }
 }

--- a/tooling/miniutil/src/build/terminator.rs
+++ b/tooling/miniutil/src/build/terminator.rs
@@ -1,5 +1,250 @@
 use crate::build::*;
 
+impl FunctionBuilder {
+    #[track_caller]
+    fn finish_block(&mut self, terminator: Terminator) {
+        let cur_block = self.cur_block.take().expect("finish_block: there is no block to finish");
+        let bb = BasicBlock { statements: cur_block.statements, terminator };
+        self.blocks.try_insert(cur_block.name, bb).unwrap();
+    }
+
+    // terminators with 0 following blocks
+    pub fn exit(&mut self) {
+        self.finish_block(exit());
+    }
+
+    pub fn unreachable(&mut self) {
+        self.finish_block(Terminator::Unreachable);
+    }
+
+    fn goto(&mut self, dest: BbName) {
+        self.finish_block(Terminator::Goto(dest));
+    }
+
+    pub fn return_(&mut self) {
+        self.finish_block(Terminator::Return);
+    }
+
+    /// Call a function that does not return.
+    pub fn call_noret(&mut self, ret: PlaceExpr, f: FnName, args: &[ArgumentExpr]) {
+        self.finish_block(Terminator::Call {
+            callee: fn_ptr_by_name(f),
+            arguments: args.iter().copied().collect(),
+            ret,
+            next_block: None,
+        });
+    }
+
+    // terminators with exactly 1 following block
+    pub fn call(&mut self, ret: PlaceExpr, f: FnName, args: &[ArgumentExpr]) {
+        let next_block = self.declare_block();
+        self.finish_block(Terminator::Call {
+            callee: fn_ptr_by_name(f),
+            arguments: args.iter().copied().collect(),
+            ret,
+            next_block: Some(next_block),
+        });
+        self.set_cur_block(next_block)
+    }
+
+    /// Ignore unit type return value.
+    pub fn call_ignoreret(&mut self, f: FnName, args: &[ArgumentExpr]) {
+        let next_block = self.declare_block();
+        self.finish_block(Terminator::Call {
+            callee: fn_ptr_by_name(f),
+            arguments: args.iter().copied().collect(),
+            ret: zst_place(),
+            next_block: Some(next_block),
+        });
+        self.set_cur_block(next_block);
+    }
+
+    pub fn assume(&mut self, val: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(assume(val, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block);
+    }
+
+    pub fn print(&mut self, arg: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(print(arg, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block);
+    }
+
+    pub fn eprint(&mut self, arg: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(eprint(arg, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn allocate(&mut self, size: ValueExpr, align: ValueExpr, ret_place: PlaceExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(allocate(size, align, ret_place, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn deallocate(&mut self, ptr: ValueExpr, size: ValueExpr, align: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(deallocate(ptr, size, align, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn spawn(&mut self, f: FnName, data_ptr: ValueExpr, ret: PlaceExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(spawn(fn_ptr_by_name(f), data_ptr, ret, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn join(&mut self, thread_id: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(join(thread_id, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn atomic_store(&mut self, ptr: ValueExpr, src: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(atomic_store(ptr, src, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn atomic_load(&mut self, dest: PlaceExpr, ptr: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(atomic_load(dest, ptr, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn atomic_fetch(
+        &mut self,
+        binop: FetchBinOp,
+        dest: PlaceExpr,
+        ptr: ValueExpr,
+        other: ValueExpr,
+    ) {
+        let next_block = self.declare_block();
+        self.finish_block(atomic_fetch(binop, dest, ptr, other, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn compare_exchange(
+        &mut self,
+        dest: PlaceExpr,
+        ptr: ValueExpr,
+        current: ValueExpr,
+        next_val: ValueExpr,
+    ) {
+        let next_block = self.declare_block();
+        self.finish_block(compare_exchange(
+            dest,
+            ptr,
+            current,
+            next_val,
+            bbname_into_u32(next_block),
+        ));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn expose_provenance(&mut self, dest: PlaceExpr, ptr: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(expose_provenance(dest, ptr, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn with_exposed_provenance(&mut self, dest: PlaceExpr, addr: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(with_exposed_provenance(dest, addr, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn lock_create(&mut self, ret: PlaceExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(lock_create(ret, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn lock_acquire(&mut self, lock_id: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(lock_acquire(lock_id, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    pub fn lock_release(&mut self, lock_id: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(lock_release(lock_id, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
+    // terminators with 2 or more following blocks
+    pub fn if_<F, G>(&mut self, condition: ValueExpr, then_branch: F, else_branch: G)
+    where
+        F: Fn(&mut Self),
+        G: Fn(&mut Self),
+    {
+        self.switch_int(bool_to_int::<u8>(condition), &[(1, &then_branch)], else_branch);
+    }
+
+    pub fn switch_int<T, G>(
+        &mut self,
+        value: ValueExpr,
+        cases: &[(T, &dyn Fn(&mut Self))],
+        fallback: G,
+    ) where
+        T: Clone + Into<Int>,
+        G: Fn(&mut Self),
+    {
+        // closures + blocks we we run the closures on
+        let mut branches: Vec<(&dyn Fn(&mut Self), BbName)> = Vec::new();
+        // branch map for switch terminator
+        let mut branch_map: Map<Int, BbName> = Map::new();
+
+        for (case, branch) in cases {
+            let new_block = self.declare_block();
+            branch_map.try_insert(case.clone().into(), new_block).unwrap();
+            branches.push((branch, new_block));
+        }
+
+        let fallback_block = self.declare_block();
+        let switch = Terminator::Switch { value, cases: branch_map, fallback: fallback_block };
+        self.finish_block(switch);
+
+        // None means that every branch finished on its own and we don't need a after_switch_block
+        let mut after_switch_block: Option<BbName> = None;
+
+        // Add the fallback block to the list of blocks to build.
+        branches.push((&fallback, fallback_block));
+
+        for (branch, block) in branches {
+            self.set_cur_block(block);
+            branch(self);
+            // If the current block not finished, jump to `after_switch_block`.
+            if self.cur_block.is_some() {
+                let jump_to_block = *after_switch_block.get_or_insert_with(|| self.declare_block());
+                self.goto(jump_to_block);
+            }
+        }
+        if let Some(after_switch_block) = after_switch_block {
+            self.set_cur_block(after_switch_block);
+        }
+    }
+
+    pub fn while_<F: Fn(&mut Self)>(&mut self, condition: ValueExpr, body: F) {
+        // goto new block such that condition sits alone in dedicated block
+        let cond = self.declare_block();
+        self.goto(cond);
+        self.set_cur_block(cond);
+
+        self.if_(
+            condition,
+            |f| {
+                body(f);
+                if f.cur_block.is_some() {
+                    f.goto(cond);
+                }
+            },
+            |_| {},
+        );
+    }
+}
+
 pub fn goto(x: u32) -> Terminator {
     Terminator::Goto(BbName(Name::from_internal(x)))
 }
@@ -38,14 +283,6 @@ pub fn call(f: u32, args: &[ArgumentExpr], ret: PlaceExpr, next: Option<u32>) ->
         ret,
         next_block: next.map(|x| BbName(Name::from_internal(x))),
     }
-}
-
-pub fn by_value(val: ValueExpr) -> ArgumentExpr {
-    ArgumentExpr::ByValue(val)
-}
-
-pub fn in_place(arg: PlaceExpr) -> ArgumentExpr {
-    ArgumentExpr::InPlace(arg)
 }
 
 pub fn assume(val: ValueExpr, next: u32) -> Terminator {


### PR DESCRIPTION
closes #160 
This PR adds a new miniutil test API. The implementation follows the interface proposed in #160 relatively closely. (The only thing I didn't add from issue #160 was `addr_of_constptr(var)`.)

We add two structures:
- `ProgramBuilder`, which takes care of the program, functions and global variables
- `FunctionBuilder`, which takes care of args, ret, locals, blocks, statements and terminators

New test file `builder_api.rs` tests all new public methods that have been added.
I also rewrote some tests in `locks.rs` and `packed.rs` to show what the interface looks like in the wild.