### PR TITLE
Add shift operators

### DIFF
--- a/spec/lang/step/intrinsics.md
+++ b/spec/lang/step/intrinsics.md
@@ -476,9 +476,9 @@ impl<M: Memory> Machine<M> {
             throw_ub!("invalid second argument to `AtomicFetchAndOp` intrinsic: not same type as return value");
         }
 
-        if !matches!(ret_ty, Type::Int(_)) {
+        let Type::Int(int_ty) = ret_ty else {
             throw_ub!("invalid return type for `AtomicFetchAndOp` intrinsic: only works with integers");
-        }
+        };
 
         let size = ret_ty.size::<M::T>();
         // All integer sizes are powers of two.
@@ -495,7 +495,7 @@ impl<M: Memory> Machine<M> {
         let Value::Int(previous_int) = previous else { unreachable!() };
 
         // Perform operation.
-        let next_int = self.eval_int_bin_op(op, previous_int, other_int)?;
+        let next_int = self.eval_int_bin_op(op, previous_int, other_int, int_ty)?;
         let next = Value::Int(next_int);
 
         // Store it again.

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -140,6 +140,10 @@ pub enum IntBinOp {
     /// Remainder of a division, the `%` operator.
     /// Throws UB, if the modulus (second operand) is zero.
     Rem,
+    /// Shift left `<<`
+    Shl,
+    /// Shift right `>>` (arithmetic shift for unsigned integers, logical shift for signed integers)
+    Shr,
     /// Bitwise-and two integer values.
     BitAnd,
     /// Bitwise-or two integer values.

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -327,12 +327,18 @@ impl ValueExpr {
                 let left = left.check_wf::<T>(locals, prog)?;
                 let right = right.check_wf::<T>(locals, prog)?;
                 match operator {
-                    Int(_int_op) => {
-                        let Type::Int(int_ty) = left else {
+                    Int(int_op) => {
+                        let Type::Int(left) = left else {
                             throw_ill_formed!("BinOp::Int: invalid left type");
                         };
-                        ensure_wf(right == Type::Int(int_ty), "BinOp::Int: invalid right type")?;
-                        Type::Int(int_ty)
+                        let Type::Int(right) = right else {
+                            throw_ill_formed!("BinOp::Int: invalid right type");
+                        };
+                        // Shift operators allow unequal left and right type
+                        if !matches!(int_op, IntBinOp::Shl | IntBinOp::Shr) {
+                            ensure_wf(left == right, "BinOp:Int: right and left type are not equal")?;
+                        }
+                        Type::Int(left)
                     }
                     IntRel(_int_rel) => {
                         let Type::Int(int_ty) = left else {

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -10,9 +10,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             smir::Rvalue::Use(operand) => self.translate_operand_smir(operand, span),
             smir::Rvalue::BinaryOp(bin_op, l, r) => {
                 let lty_smir = l.ty(&self.locals_smir).unwrap();
-                let rty_smir = r.ty(&self.locals_smir).unwrap();
-
-                assert_eq!(lty_smir, rty_smir);
+                let lty = self.translate_ty_smir(lty_smir, span);
 
                 let l = self.translate_operand_smir(l, span);
                 let r = self.translate_operand_smir(r, span);
@@ -20,7 +18,6 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 let l = GcCow::new(l);
                 let r = GcCow::new(r);
 
-                let lty = self.translate_ty_smir(lty_smir, span);
                 use smir::BinOp::*;
                 let op = match (bin_op, lty) {
                     (Offset, Type::Ptr(_)) => BinOp::PtrOffset { inbounds: true },
@@ -30,6 +27,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     (Mul, Type::Int(_)) => BinOp::Int(IntBinOp::Mul),
                     (Div, Type::Int(_)) => BinOp::Int(IntBinOp::Div),
                     (Rem, Type::Int(_)) => BinOp::Int(IntBinOp::Rem),
+                    (Shl, Type::Int(_)) => BinOp::Int(IntBinOp::Shl),
+                    (Shr, Type::Int(_)) => BinOp::Int(IntBinOp::Shr),
                     (BitAnd, Type::Int(_)) => BinOp::Int(IntBinOp::BitAnd),
                     (BitOr, Type::Int(_)) => BinOp::Int(IntBinOp::BitOr),
                     (BitXor, Type::Int(_)) => BinOp::Int(IntBinOp::BitXor),

--- a/tooling/minimize/tests/pass/ops.rs
+++ b/tooling/minimize/tests/pass/ops.rs
@@ -11,6 +11,10 @@ fn main() {
     assert!(black_box(7) * 6 == 42);
     assert!(black_box(504) / 12 == 42);
     assert!(black_box(112) % 70 == 42);
+    assert!(black_box(i32::MAX) << 1 == -2);
+    assert!(black_box(i32::MIN) << 1u8 == 0);
+    assert!(black_box(-1) >> 1 == -1);
+    assert!(black_box(84) >> 1u8 == 42);
     assert!(black_box(171) & 62 == 42);
     assert!(black_box(10) | 34 == 42);
     assert!(black_box(36) ^ 14 == 42);

--- a/tooling/minitest/src/tests/int.rs
+++ b/tooling/minitest/src/tests/int.rs
@@ -106,3 +106,68 @@ fn bit_int_not_works() {
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
     assert_stop(prog);
 }
+
+#[test]
+fn shl_works() {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+
+    f.assume(eq(shl(const_int(1u8), const_int(7u8)), const_int(128u8)));
+    f.assume(eq(shl(const_int(1u8), const_int(0u8)), const_int(1u8)));
+    f.assume(eq(shl(const_int(-1i32), const_int(1i32)), const_int(-2i32)));
+    f.assume(eq(shl(const_int(i32::MAX), const_int(1)), const_int(-2i32)));
+
+    // Shl should allow for different integer types for left and right operands
+    f.assume(eq(shl(const_int(1u16), const_int(7i32)), const_int(128u16)));
+
+    // Test if shift calculates the euclidean modulo of right operand with number of bits of left
+    // 8 % 8 = 0; shift by 0
+    f.assume(eq(shl(const_int(1u8), const_int(8)), const_int(1u8)));
+    // 9 % 8 = 1; shift by 1
+    f.assume(eq(shl(const_int(1u8), const_int(9)), const_int(2u8)));
+    // -1 % 8 = 7; (for solution in 0..8) shift by 7
+    f.assume(eq(shl(const_int(1u8), const_int(-1)), const_int(128u8)));
+    f.exit();
+
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+fn shr_works() {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+
+    // Logical shr for unsigned integers
+    f.assume(eq(shr(const_int(u8::MAX), const_int(7u8)), const_int(1u8)));
+    f.assume(eq(shr(const_int(1u8), const_int(0)), const_int(1u8)));
+
+    // Arithmetic shr for signed integers
+    f.assume(eq(shr(const_int(-4i16), const_int(1u16)), const_int(-2i16)));
+    f.assume(eq(shr(const_int(-1i32), const_int(1)), const_int(-1i32)));
+    f.assume(eq(shr(const_int(1i32), const_int(1)), const_int(0i32)));
+    f.assume(eq(shr(const_int(i32::MAX), const_int(1)), const_int(i32::MAX / 2)));
+    f.assume(eq(shr(const_int(i32::MIN), const_int(1)), const_int(i32::MIN / 2)));
+
+    // Shr should allow for different integer types for left and right operands
+    f.assume(eq(shr(const_int(u8::MAX), const_int(7i32)), const_int(1u8)));
+    f.assume(eq(shr(const_int(-4i16), const_int(1u8)), const_int(-2i16)));
+
+    // Test if shift calculates the euclidean modulo of right operand with number of bits of left
+    // 8 % 8 = 0; shift by 0
+    f.assume(eq(shr(const_int(1u8), const_int(8)), const_int(1u8)));
+    // 9 % 8 = 1; shift by 1
+    f.assume(eq(shr(const_int(2u8), const_int(9)), const_int(1u8)));
+    // -1 % 8 = 7; (for solution in 0..8) shift by 7
+    f.assume(eq(shr(const_int(u8::MAX), const_int(-1)), const_int(1u8)));
+    f.exit();
+
+    let f = p.finish_function(f);
+
+    let p = p.finish_program(f);
+    assert_stop(p);
+}

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -118,6 +118,12 @@ pub fn mul(l: ValueExpr, r: ValueExpr) -> ValueExpr {
 pub fn div(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::Div, l, r)
 }
+pub fn shl(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop(IntBinOp::Shl, l, r)
+}
+pub fn shr(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop(IntBinOp::Shr, l, r)
+}
 pub fn bit_and(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::BitAnd, l, r)
 }

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -159,14 +159,16 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
         }
         ValueExpr::BinOp { operator: BinOp::Int(int_op), left, right } => {
             let int_op = match int_op {
-                IntBinOp::Add => '+',
-                IntBinOp::Sub => '-',
-                IntBinOp::Mul => '*',
-                IntBinOp::Div => '/',
-                IntBinOp::Rem => '%',
-                IntBinOp::BitAnd => '&',
-                IntBinOp::BitOr => '|',
-                IntBinOp::BitXor => '^',
+                IntBinOp::Add => "+",
+                IntBinOp::Sub => "-",
+                IntBinOp::Mul => "*",
+                IntBinOp::Div => "/",
+                IntBinOp::Rem => "%",
+                IntBinOp::Shl => "<<",
+                IntBinOp::Shr => ">>",
+                IntBinOp::BitAnd => "&",
+                IntBinOp::BitOr => "|",
+                IntBinOp::BitXor => "^",
             };
 
             let l = fmt_value_expr(left.extract(), comptypes).to_atomic_string();


### PR DESCRIPTION
part of #186 

Implemented the shift operator according to [mir specification](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.BinOp.html#variant.Shl).
Adapted well-formedness check, such that for shift ops the left and right type don't have to be equivalent. 