### PR TITLE
add `unchecked` binary ops

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -111,8 +111,29 @@ impl<M: Memory> Machine<M> {
         use IntBinOp::*;
         ret(match op {
             Add => left + right,
+            AddUnchecked => {
+                let result = left + right;
+                if !left_ty.can_represent(result) {
+                    throw_ub!("overflow in unchecked add");
+                }
+                result
+            }
             Sub => left - right,
+            SubUnchecked => {
+                let result = left - right;
+                if !left_ty.can_represent(result) {
+                    throw_ub!("overflow in unchecked sub");
+                }
+                result
+            }
             Mul => left * right,
+            MulUnchecked => {
+                let result = left * right;
+                if !left_ty.can_represent(result) {
+                    throw_ub!("overflow in unchecked mul");
+                }
+                result
+            }
             Div => {
                 if right == 0 {
                     throw_ub!("division by zero");
@@ -132,6 +153,18 @@ impl<M: Memory> Machine<M> {
                 match op {
                     Shl => left << offset,
                     Shr => left >> offset,
+                    _ => panic!(),
+                }
+            }
+            ShlUnchecked | ShrUnchecked => {
+                let bits = left_ty.size.bits();
+                if right < 0 || right >= bits {
+                    throw_ub!("overflow in unchecked shift");
+                }
+
+                match op {
+                    ShlUnchecked => left << right,
+                    ShrUnchecked => left >> right,
                     _ => panic!(),
                 }
             }

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -130,10 +130,19 @@ pub enum UnOp {
 pub enum IntBinOp {
     /// Add two integer values.
     Add,
+    /// Add two integer values.
+    /// Throws UB on overflow.
+    AddUnchecked,
     /// Subtract two integer values.
     Sub,
+    /// Subtract two integer values.
+    /// Throws UB on overflow.
+    SubUnchecked,
     /// Multiply two integer values.
     Mul,
+    /// Multiply two integer values.
+    /// Throws UB on overflow.
+    MulUnchecked,
     /// Divide two integer values.
     /// Division by zero is UB.
     Div,
@@ -142,8 +151,14 @@ pub enum IntBinOp {
     Rem,
     /// Shift left `<<`
     Shl,
+    /// Shift left `<<`
+    /// Throws UB if right operand not in range 0..left::BITS.
+    ShlUnchecked,
     /// Shift right `>>` (arithmetic shift for unsigned integers, logical shift for signed integers)
     Shr,
+    /// Shift right `>>` (arithmetic shift for unsigned integers, logical shift for signed integers)
+    /// Throws UB if right operand not in range 0..left::BITS.
+    ShrUnchecked,
     /// Bitwise-and two integer values.
     BitAnd,
     /// Bitwise-or two integer values.

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -334,8 +334,9 @@ impl ValueExpr {
                         let Type::Int(right) = right else {
                             throw_ill_formed!("BinOp::Int: invalid right type");
                         };
+                        use IntBinOp::*;
                         // Shift operators allow unequal left and right type
-                        if !matches!(int_op, IntBinOp::Shl | IntBinOp::Shr) {
+                        if !matches!(int_op, Shl | Shr | ShlUnchecked | ShrUnchecked) {
                             ensure_wf(left == right, "BinOp:Int: right and left type are not equal")?;
                         }
                         Type::Int(left)

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -32,6 +32,11 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     (BitAnd, Type::Int(_)) => BinOp::Int(IntBinOp::BitAnd),
                     (BitOr, Type::Int(_)) => BinOp::Int(IntBinOp::BitOr),
                     (BitXor, Type::Int(_)) => BinOp::Int(IntBinOp::BitXor),
+                    (AddUnchecked, Type::Int(_)) => BinOp::Int(IntBinOp::AddUnchecked),
+                    (SubUnchecked, Type::Int(_)) => BinOp::Int(IntBinOp::SubUnchecked),
+                    (MulUnchecked, Type::Int(_)) => BinOp::Int(IntBinOp::MulUnchecked),
+                    (ShlUnchecked, Type::Int(_)) => BinOp::Int(IntBinOp::ShlUnchecked),
+                    (ShrUnchecked, Type::Int(_)) => BinOp::Int(IntBinOp::ShrUnchecked),
 
                     (Lt, Type::Int(_)) => BinOp::IntRel(IntRel::Lt),
                     (Le, Type::Int(_)) => BinOp::IntRel(IntRel::Le),

--- a/tooling/minimize/tests/pass/ops.rs
+++ b/tooling/minimize/tests/pass/ops.rs
@@ -1,3 +1,4 @@
+#![feature(unchecked_shifts)]
 fn black_box<T>(t: T) -> T { t }
 
 fn main() {
@@ -18,6 +19,14 @@ fn main() {
     assert!(black_box(171) & 62 == 42);
     assert!(black_box(10) | 34 == 42);
     assert!(black_box(36) ^ 14 == 42);
+    assert!(unsafe { black_box(12_i32).unchecked_add(30) } == 42);
+    assert!(unsafe { black_box(55_i32).unchecked_sub(13) } == 42);
+    assert!(unsafe { black_box(7_i32).unchecked_mul(6) } == 42);
+    // For unchecked shifts Rust only allows for u32 on right side 
+    assert!(unsafe { black_box(i32::MAX).unchecked_shl(1u32) } == -2);
+    assert!(unsafe { black_box(i32::MIN).unchecked_shl(1u32) } == 0);
+    assert!(unsafe { black_box(-1_i32).unchecked_shr(1u32) } == -1);
+    assert!(unsafe { black_box(84_i32).unchecked_shr(1u32) } == 42);
 
     assert!(black_box(10) > 2);
     assert!(black_box(10) >= 2);

--- a/tooling/minitest/src/lib.rs
+++ b/tooling/minitest/src/lib.rs
@@ -56,6 +56,23 @@ pub fn assert_ub_eventually(prog: Program, attempts: usize, msg: &str) {
     panic!("did not get expected output after {} attempts", attempts);
 }
 
+/// Create program that assigns `expr` to local of type T and checks if it causes UB.
+#[track_caller]
+pub fn assert_ub_expr<T: TypeConv>(expr: ValueExpr, msg: &str) {
+    let mut p = ProgramBuilder::new();
+
+    let mut f = p.declare_function();
+    let local = f.declare_local::<T>();
+
+    f.storage_live(local);
+    f.assign(local, expr);
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_ub(p, msg);
+}
+
 #[track_caller]
 pub fn assert_ill_formed(prog: Program, msg: &str) {
     let TerminationInfo::IllFormed(info) = run_program(prog) else {

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -109,11 +109,20 @@ fn int_binop(op: IntBinOp, l: ValueExpr, r: ValueExpr) -> ValueExpr {
 pub fn add(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::Add, l, r)
 }
+pub fn unchecked_add(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop(IntBinOp::AddUnchecked, l, r)
+}
 pub fn sub(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::Sub, l, r)
 }
+pub fn unchecked_sub(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop(IntBinOp::SubUnchecked, l, r)
+}
 pub fn mul(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::Mul, l, r)
+}
+pub fn unchecked_mul(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop(IntBinOp::MulUnchecked, l, r)
 }
 pub fn div(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::Div, l, r)
@@ -121,8 +130,14 @@ pub fn div(l: ValueExpr, r: ValueExpr) -> ValueExpr {
 pub fn shl(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::Shl, l, r)
 }
+pub fn unchecked_shl(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop(IntBinOp::ShlUnchecked, l, r)
+}
 pub fn shr(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::Shr, l, r)
+}
+pub fn unchecked_shr(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_binop(IntBinOp::ShrUnchecked, l, r)
 }
 pub fn bit_and(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::BitAnd, l, r)

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -158,21 +158,27 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             }
         }
         ValueExpr::BinOp { operator: BinOp::Int(int_op), left, right } => {
-            let int_op = match int_op {
-                IntBinOp::Add => "+",
-                IntBinOp::Sub => "-",
-                IntBinOp::Mul => "*",
-                IntBinOp::Div => "/",
-                IntBinOp::Rem => "%",
-                IntBinOp::Shl => "<<",
-                IntBinOp::Shr => ">>",
-                IntBinOp::BitAnd => "&",
-                IntBinOp::BitOr => "|",
-                IntBinOp::BitXor => "^",
-            };
-
             let l = fmt_value_expr(left.extract(), comptypes).to_atomic_string();
             let r = fmt_value_expr(right.extract(), comptypes).to_atomic_string();
+
+            use IntBinOp::*;
+            let int_op = match int_op {
+                Add => "+",
+                Sub => "-",
+                Mul => "*",
+                Div => "/",
+                Rem => "%",
+                Shl => "<<",
+                Shr => ">>",
+                BitAnd => "&",
+                BitOr => "|",
+                BitXor => "^",
+                AddUnchecked => return FmtExpr::Atomic(format!("AddUnchecked({l}, {r})")),
+                SubUnchecked => return FmtExpr::Atomic(format!("SubUnchecked({l}, {r})")),
+                MulUnchecked => return FmtExpr::Atomic(format!("MulUnchecked({l}, {r})")),
+                ShlUnchecked => return FmtExpr::Atomic(format!("ShlUnchecked({l}, {r})")),
+                ShrUnchecked => return FmtExpr::Atomic(format!("ShrUnchecked({l}, {r})")),
+            };
 
             FmtExpr::NonAtomic(format!("{l} {int_op} {r}"))
         }


### PR DESCRIPTION
part of #186 

Add the unchecked binary ops `UncheckedAdd`, `UncheckedSub`, `UncheckedMul`, `UncheckedShl`, and `UncheckedShr` to MiniRust.

Currently the formatter uses `+(unchecked)` to format these ops, I did not find a better way yet.