### PR TITLE
Add `IntWithOverflow` to `BinOp`

### DIFF
--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -166,6 +166,17 @@ pub enum IntBinOp {
     /// Bitwise-xor two integer values.
     BitXor,
 }
+pub enum IntBinOpWithOverflow {
+    /// Add two integer values, returns a tuple of the result integer
+    /// and a bool indicating whether the calculation overflowed.
+    Add,
+    /// Subtract two integer values, returns a tuple of the result integer
+    /// and a bool indicating whether the calculation overflowed.
+    Sub,
+    /// Multiply two integers, returns a tuple of the result integer
+    /// and a bool indicating whether the calculation overflowed.
+    Mul,
+}
 /// A relation between integers.
 pub enum IntRel {
     /// less than
@@ -181,6 +192,7 @@ pub enum IntRel {
     /// inequal
     Ne,
 }
+
 pub enum BoolBinOp {
     /// Bitwise-and on booleans.
     BitAnd,
@@ -192,6 +204,9 @@ pub enum BoolBinOp {
 pub enum BinOp {
     /// An operation on integers (both must have the same type); returns an integer of the same type.
     Int(IntBinOp),
+    /// An operation on integers (both must have same type); returns a tuple of integer of the same type
+    /// and a boolean that is true if the result is not equal to the infinite-precision result.
+    IntWithOverflow(IntBinOpWithOverflow),
     /// A relation between integers (both must have the same type); returns a boolean.
     IntRel(IntRel),
     /// The three-way comparison of integers (both must have same type); returns an i8:

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -189,5 +189,17 @@ impl IntType {
     pub fn bring_in_bounds(&self, i: Int) -> Int {
         i.bring_in_bounds(self.signed, self.size)
     }
+
+    /// Generate the return type for IntWithOverflow
+    pub fn with_overflow<T: Target>(&self) -> Type {
+        // Define a tuple type with two fields: An integer followed directly by a boolean.
+        let fields = list![(Size::ZERO, Type::Int(*self)), (self.size, Type::Bool)];
+        // Alignment is always the one of the integer as boolean has align requirement 1.
+        let align = self.align::<T>();
+        // The total size is `self.size + 1` rounded up to the next multiple of `align`.
+        // Since `self.size` is already a multiple of `align`, we can compute this as follows:
+        let size = self.size + Size::from_bytes(align.bytes()).unwrap();
+        Type::Tuple { fields, size, align }
+    }
 }
 ```

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -341,6 +341,13 @@ impl ValueExpr {
                         }
                         Type::Int(left)
                     }
+                    IntWithOverflow(_int_op) => {
+                        let Type::Int(int_ty) = left else {
+                            throw_ill_formed!("BinOp::IntWithOverflow: invalid left type");
+                        };
+                        ensure_wf(right == Type::Int(int_ty), "BinOp::IntWithOverflow: invalid right type")?;
+                        int_ty.with_overflow::<T>()
+                    }
                     IntRel(_int_rel) => {
                         let Type::Int(int_ty) = left else {
                             throw_ill_formed!("BinOp::IntRel: invalid left type");

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -85,6 +85,18 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
 
                 value_expr
             }
+            smir::Rvalue::CheckedBinaryOp(op, l, r) => {
+                let l = GcCow::new(self.translate_operand_smir(l, span));
+                let r = GcCow::new(self.translate_operand_smir(r, span));
+
+                let op = match op {
+                    smir::BinOp::Add => BinOp::IntWithOverflow(IntBinOpWithOverflow::Add),
+                    smir::BinOp::Sub => BinOp::IntWithOverflow(IntBinOpWithOverflow::Sub),
+                    smir::BinOp::Mul => BinOp::IntWithOverflow(IntBinOpWithOverflow::Mul),
+                    x => panic!("CheckedBinaryOp {x:?} not supported."),
+                };
+                ValueExpr::BinOp { operator: op, left: l, right: r }
+            }
             smir::Rvalue::UnaryOp(unop, operand) => {
                 let ty_smir = operand.ty(&self.locals_smir).unwrap();
                 let ty = self.translate_ty_smir(ty_smir, span);

--- a/tooling/minimize/tests/pass/ops.rs
+++ b/tooling/minimize/tests/pass/ops.rs
@@ -33,6 +33,24 @@ fn main() {
     assert!(black_box(42).cmp(&42) == Ordering::Equal);
     assert!(black_box(42).cmp(&43) == Ordering::Less);
 
+    assert!(black_box(41_i32).checked_add(1) == Some(42));
+    assert!(black_box(i32::MAX).checked_add(1) == None);
+    assert!(black_box(43_i32).checked_sub(1) == Some(42));
+    assert!(black_box(i32::MIN).checked_sub(1) == None);
+    assert!(black_box(21_i32).checked_mul(2) == Some(42));
+    assert!(black_box(i32::MIN).checked_mul(-1) == None);
+
+    assert!(black_box(41_i32).overflowing_add(1) == (42, false));
+    assert!(black_box(i32::MAX).overflowing_add(1) == (i32::MIN, true));
+    assert!(black_box(43_i32).overflowing_sub(1) == (42, false));
+    assert!(black_box(i32::MIN).overflowing_sub(1) == (i32::MAX, true));
+    assert!(black_box(21_i32).overflowing_mul(2) == (42, false));
+    assert!(black_box(i32::MIN).overflowing_mul(-1) == (i32::MIN, true));
+
+    assert!(black_box(42).cmp(&41) == Ordering::Greater);
+    assert!(black_box(42).cmp(&42) == Ordering::Equal);
+    assert!(black_box(42).cmp(&43) == Ordering::Less);
+
     assert!(black_box(10) > 2);
     assert!(black_box(10) >= 2);
     assert!(!(black_box(10) < 2));

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -149,6 +149,24 @@ pub fn bit_xor(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop(IntBinOp::BitXor, l, r)
 }
 
+fn int_overflow(op: IntBinOpWithOverflow, l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    ValueExpr::BinOp {
+        operator: BinOp::IntWithOverflow(op),
+        left: GcCow::new(l),
+        right: GcCow::new(r),
+    }
+}
+
+pub fn overflow_add(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_overflow(IntBinOpWithOverflow::Add, l, r)
+}
+pub fn overflow_sub(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_overflow(IntBinOpWithOverflow::Sub, l, r)
+}
+pub fn overflow_mul(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_overflow(IntBinOpWithOverflow::Mul, l, r)
+}
+
 fn int_rel(op: IntRel, l: ValueExpr, r: ValueExpr) -> ValueExpr {
     ValueExpr::BinOp { operator: BinOp::IntRel(op), left: GcCow::new(l), right: GcCow::new(r) }
 }

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -182,6 +182,17 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
 
             FmtExpr::NonAtomic(format!("{l} {int_op} {r}"))
         }
+        ValueExpr::BinOp { operator: BinOp::IntWithOverflow(op), left, right } => {
+            let l = fmt_value_expr(left.extract(), comptypes).to_atomic_string();
+            let r = fmt_value_expr(right.extract(), comptypes).to_atomic_string();
+
+            let name = match op {
+                IntBinOpWithOverflow::Add => "Add",
+                IntBinOpWithOverflow::Sub => "Sub",
+                IntBinOpWithOverflow::Mul => "Mul",
+            };
+            FmtExpr::Atomic(format!("{name}WithOverflow({l}, {r})"))
+        }
         ValueExpr::BinOp { operator: BinOp::IntRel(rel), left, right } => {
             let rel = match rel {
                 IntRel::Lt => "<",


### PR DESCRIPTION
part of #186 

Couldn't test the translation of `minimize` as for that the Rust intrinsic `unlikely` is missing.
Added some commented out tests until that is fixed.