### PR TITLE
minimize: add caching of types

### DIFF
--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -120,7 +120,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             rs::TerminatorKind::Call { func, target, destination, args, .. } =>
                 self.translate_call(func, args, destination, target, span),
             rs::TerminatorKind::SwitchInt { discr, targets } => {
-                let ty = self.translate_ty(discr.ty(&self.body, self.tcx), span);
+                let ty = discr.ty(&self.body, self.tcx);
+                let ty = self.translate_ty(ty, span);
 
                 let discr_op = self.translate_operand(discr, span);
                 let (value, int_ty) = match ty {

--- a/tooling/minimize/src/enums.rs
+++ b/tooling/minimize/src/enums.rs
@@ -4,7 +4,7 @@ use crate::rustc_middle::ty::layout::PrimitiveExt;
 
 impl<'tcx> Ctxt<'tcx> {
     pub fn translate_enum(
-        &self,
+        &mut self,
         ty: rs::Ty<'tcx>,
         adt_def: rs::AdtDef<'tcx>,
         sref: rs::GenericArgsRef<'tcx>,
@@ -165,7 +165,7 @@ impl<'tcx> Ctxt<'tcx> {
     }
 
     pub fn discriminant_for_variant_smir(
-        &self,
+        &mut self,
         ty: smir::Ty,
         variant_idx: smir::VariantIdx,
         span: rs::Span,
@@ -178,7 +178,7 @@ impl<'tcx> Ctxt<'tcx> {
     }
 
     pub fn discriminant_for_variant(
-        &self,
+        &mut self,
         ty: rs::Ty<'tcx>,
         variant_idx: rs::VariantIdx,
         span: rs::Span,

--- a/tooling/minimize/src/function.rs
+++ b/tooling/minimize/src/function.rs
@@ -34,6 +34,12 @@ impl<'cx, 'tcx> std::ops::Deref for FnCtxt<'cx, 'tcx> {
     }
 }
 
+impl<'cx, 'tcx> std::ops::DerefMut for FnCtxt<'cx, 'tcx> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.cx
+    }
+}
+
 impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
     pub fn new(instance: rs::Instance<'tcx>, cx: &'cx mut Ctxt<'tcx>) -> Self {
         let body = cx.tcx.optimized_mir(instance.def_id());
@@ -88,7 +94,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
         for (id, local_name) in &self.local_name_map {
             let local_decl = &self.body.local_decls[*id];
             let span = local_decl.source_info.span;
-            self.locals.insert(*local_name, self.translate_ty(local_decl.ty, span));
+            let ty = self.cx.translate_ty(local_decl.ty, span);
+            self.locals.insert(*local_name, ty);
         }
 
         // the number of locals which are implicitly storage live.

--- a/tooling/minimize/src/program.rs
+++ b/tooling/minimize/src/program.rs
@@ -12,6 +12,8 @@ pub struct Ctxt<'tcx> {
     pub globals: Map<GlobalName, Global>,
 
     pub functions: Map<FnName, Function>,
+
+    pub ty_cache: HashMap<rs::Ty<'tcx>, Type>,
 }
 
 impl<'tcx> Ctxt<'tcx> {
@@ -47,6 +49,7 @@ impl<'tcx> Ctxt<'tcx> {
             alloc_map: Default::default(),
             globals: Default::default(),
             functions: Default::default(),
+            ty_cache: Default::default(),
         }
     }
 

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -130,11 +130,9 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                         let smir::AggregateKind::Adt(_, variant_idx, _, _, _) = agg else {
                             panic!()
                         };
-                        let discriminant = self.discriminant_for_variant_smir(
-                            rv.ty(&self.locals_smir).unwrap(),
-                            *variant_idx,
-                            span,
-                        );
+                        let variant_ty = rv.ty(&self.locals_smir).unwrap();
+                        let discriminant =
+                            self.discriminant_for_variant_smir(variant_ty, *variant_idx, span);
                         let ops: List<_> =
                             operands.iter().map(|x| self.translate_operand_smir(x, span)).collect();
 
@@ -166,7 +164,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 let c = c.eval_target_usize().unwrap();
                 let c = Int::from(c);
 
-                let elem_ty = self.translate_ty_smir(op.ty(&self.locals_smir).unwrap(), span);
+                let elem_ty = op.ty(&self.locals_smir).unwrap();
+                let elem_ty = self.translate_ty_smir(elem_ty, span);
                 let op = self.translate_operand_smir(op, span);
 
                 let ty = Type::Array { elem: GcCow::new(elem_ty), count: c };
@@ -175,8 +174,8 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 ValueExpr::Tuple(ls, ty)
             }
             smir::Rvalue::Cast(smir::CastKind::IntToInt, operand, ty) => {
-                let operand_ty =
-                    self.translate_ty_smir(operand.ty(&self.locals_smir).unwrap(), span);
+                let operand_ty = operand.ty(&self.locals_smir).unwrap();
+                let operand_ty = self.translate_ty_smir(operand_ty, span);
                 let operand = self.translate_operand_smir(operand, span);
                 let Type::Int(int_ty) = self.translate_ty_smir(*ty, span) else {
                     rs::span_bug!(span, "Attempting to IntToInt-Cast to non-int type!");


### PR DESCRIPTION
closes #161 

Now minimize can do the translation fast but now the type explodes in MiniRust instead.
Thus if we run the test mentioned in #161 we still run out of memory. 