### PR TITLE
miniutil: add assume test to `mod.rs`

### DIFF
--- a/tooling/minitest/src/tests/assume.rs
+++ b/tooling/minitest/src/tests/assume.rs
@@ -3,7 +3,6 @@ use crate::*;
 #[test]
 fn assume_true() {
     let locals = [];
-    let n = const_int::<usize>(4);
     let b0 = block!(assume(const_bool(true), 1));
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
@@ -14,7 +13,6 @@ fn assume_true() {
 #[test]
 fn assume_false() {
     let locals = [];
-    let n = const_int::<usize>(4);
     let b0 = block!(assume(const_bool(false), 1));
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
@@ -25,7 +23,6 @@ fn assume_false() {
 #[test]
 fn assume_wrong_argnum() {
     let locals = [];
-    let n = const_int::<usize>(4);
     let b0 = block!(Terminator::Intrinsic {
         intrinsic: IntrinsicOp::Assume,
         arguments: list![], // no arguments
@@ -38,19 +35,17 @@ fn assume_wrong_argnum() {
     assert_ub(p, "invalid number of arguments for `Assume` intrinsic");
 }
 
-
 #[test]
 fn assume_wrong_argty() {
     let locals = [];
-    let n = const_int::<usize>(4);
     let b0 = block!(Terminator::Intrinsic {
         intrinsic: IntrinsicOp::Assume,
-        arguments: list![const_int::<i32>((0))], // should be bool, not int
+        arguments: list![const_int::<i32>(0)], // should be bool, not int
         ret: zst_place(),
         next_block: Some(BbName(Name::from_internal(1))),
     });
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid first argument for `Assume` intrinsic: not a Boolean");
+    assert_ub(p, "invalid argument for `Assume` intrinsic: not a Boolean");
 }

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod align;
+mod assume;
 mod atomic;
 mod atomic_fetch;
 mod bool;


### PR DESCRIPTION
Small bugfix, `assume.rs` wasn't added to `mod.rs` and was therefore never tested.