### PR TITLE
add `panic` and `assert`

### DIFF
--- a/spec/lang/step/intrinsics.md
+++ b/spec/lang/step/intrinsics.md
@@ -96,6 +96,22 @@ impl<M: Memory> Machine<M> {
 }
 ```
 
+Currently `Panic` carries no message and aborts directly.
+
+```rust
+impl<M: Memory> Machine<M> {
+    fn eval_intrinsic(
+        &mut self,
+        IntrinsicOp::Panic: IntrinsicOp,
+        arguments: List<(Value<M>, Type)>,
+        ret_ty: Type,
+    ) -> NdResult<Value<M>> {
+        // Stop machine immediatly without any additional checks.
+        throw_abort!("we panicked");
+    }
+}
+```
+
 ## UB control
 
 ```rust

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -353,7 +353,7 @@ impl<M: Memory> Machine<M> {
         let value = self.eval_intrinsic(intrinsic, arguments, ret_ty)?;
 
         // Store return value.
-        // `eval_inrinsic` above must guarantee that `value` has the right type.
+        // `eval_intrinsic` above must guarantee that `value` has the right type.
         self.mem.place_store(ret_place, value, ret_ty)?;
 
         // Jump to next block.

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -349,6 +349,7 @@ pub enum IntrinsicLockOp {
 pub enum IntrinsicOp {
     Assume,
     Exit,
+    Panic,
     PrintStdout,
     PrintStderr,
     Allocate,

--- a/spec/prelude/main.md
+++ b/spec/prelude/main.md
@@ -23,6 +23,8 @@ pub enum TerminationInfo {
     Ub(String),
     /// The program was executed and the machine stopped without error.
     MachineStop,
+    /// The program terminated with a panic
+    Abort(String),
     /// The program was ill-formed.
     IllFormed(String),
     /// The program did not terminate but no thread can make progress.
@@ -42,6 +44,11 @@ macro_rules! throw_ub {
     ($($tt:tt)*) => {
         do yeet TerminationInfo::Ub(format!($($tt)*))
     };
+}
+macro_rules! throw_abort {
+    ($($tt:tt)*) => {
+        do yeet TerminationInfo::Abort(format!($($tt)*))
+    }
 }
 macro_rules! throw_machine_stop {
     () => {

--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -50,7 +50,7 @@ pub use minirust_rs::mem::*;
 pub use minirust_rs::prelude::NdResult;
 pub use minirust_rs::prelude::*;
 
-pub use miniutil::build::{self, TypeConv as _};
+pub use miniutil::build::{self, zst_place, TypeConv as _};
 pub use miniutil::fmt::dump_program;
 pub use miniutil::run::*;
 pub use miniutil::DefaultTarget;
@@ -119,6 +119,7 @@ fn main() {
                         err.get_internal()
                     ),
                 TerminationInfo::MachineStop => { /* silent exit. */ }
+                TerminationInfo::Abort(err) => show_error!("Panic: {}", err.get_internal()),
                 TerminationInfo::Ub(err) => show_error!("UB: {}", err.get_internal()),
                 TerminationInfo::Deadlock => show_error!("program dead-locked"),
                 TerminationInfo::MemoryLeak => show_error!("program leaked memory"),

--- a/tooling/minimize/tests/panic/array_out_of_bounds.rs
+++ b/tooling/minimize/tests/panic/array_out_of_bounds.rs
@@ -1,0 +1,6 @@
+#[allow(unconditional_panic)]
+fn main() {
+    let x = [1, 2];
+    // Assertion failure in in-bounds check:
+    let _y = x[2];
+}

--- a/tooling/minimize/tests/panic/array_out_of_bounds.stderr
+++ b/tooling/minimize/tests/panic/array_out_of_bounds.stderr
@@ -1,0 +1,1 @@
+fatal error: Panic: we panicked

--- a/tooling/minimize/tests/panic/assert.rs
+++ b/tooling/minimize/tests/panic/assert.rs
@@ -1,0 +1,5 @@
+#[allow(unconditional_panic)]
+fn main() {
+    // An assert is put before divisions, so this should panic but not create UB.
+    let _ = 42 / 0;
+}

--- a/tooling/minimize/tests/panic/assert.stderr
+++ b/tooling/minimize/tests/panic/assert.stderr
@@ -1,0 +1,1 @@
+fatal error: Panic: we panicked

--- a/tooling/minimize/tests/ub/array_out_of_bounds.rs
+++ b/tooling/minimize/tests/ub/array_out_of_bounds.rs
@@ -1,7 +1,0 @@
-fn main() {
-    let x = [1, 2];
-    let i = black_box(2);
-    let _y = x[i];
-}
-
-fn black_box(i: usize) -> usize { i }

--- a/tooling/minimize/tests/ub/array_out_of_bounds.stderr
+++ b/tooling/minimize/tests/ub/array_out_of_bounds.stderr
@@ -1,1 +1,0 @@
-fatal error: UB: out-of-bounds array access

--- a/tooling/minimize/tests/ub/div_by_zero.rs
+++ b/tooling/minimize/tests/ub/div_by_zero.rs
@@ -1,8 +1,11 @@
+#![allow(internal_features)] 
+#![feature(core_intrinsics)]
 extern crate intrinsics;
 use intrinsics::*;
 
 fn main() {
-    print(1 / black_box(0));
+    // Use `unchecked_div` to make div-by-zero UB (rather than panic).
+    print(unsafe { std::intrinsics::unchecked_div(1, black_box(0)) });
 }
 
 fn black_box<T>(t: T) -> T { t }

--- a/tooling/minimize/tests/ui.rs
+++ b/tooling/minimize/tests/ui.rs
@@ -43,5 +43,9 @@ fn run_tests(mut configs: Vec<Config>) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    run_tests(vec![cfg("tests/pass", Mode::Pass), cfg("tests/ub", Mode::Panic)])
+    run_tests(vec![
+        cfg("tests/pass", Mode::Pass),
+        cfg("tests/ub", Mode::Panic),
+        cfg("tests/panic", Mode::Panic),
+    ])
 }

--- a/tooling/minitest/src/lib.rs
+++ b/tooling/minitest/src/lib.rs
@@ -31,6 +31,12 @@ pub fn assert_stop_always(prog: Program, attempts: usize) {
 }
 
 #[track_caller]
+pub fn assert_abort(prog: Program, msg: &str) {
+    let msg = prelude::String::from_internal(msg.to_string());
+    assert_eq!(run_program(prog), TerminationInfo::Abort(msg));
+}
+
+#[track_caller]
 pub fn assert_ub(prog: Program, msg: &str) {
     assert_eq!(
         run_program(prog),

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -24,6 +24,7 @@ mod no_preserve_padding;
 mod no_preserve_prov;
 mod null;
 mod packed;
+mod panic;
 mod print;
 mod ptr_offset;
 mod ptr_offset_from;

--- a/tooling/minitest/src/tests/panic.rs
+++ b/tooling/minitest/src/tests/panic.rs
@@ -1,0 +1,13 @@
+use crate::*;
+
+#[test]
+fn panic() {
+    let mut prog = ProgramBuilder::new();
+
+    let mut start = prog.declare_function();
+    start.panic();
+    let start = prog.finish_function(start);
+
+    let prog = prog.finish_program(start);
+    assert_abort(prog, "we panicked");
+}

--- a/tooling/miniutil/src/build/terminator.rs
+++ b/tooling/miniutil/src/build/terminator.rs
@@ -25,6 +25,10 @@ impl FunctionBuilder {
         self.finish_block(Terminator::Return);
     }
 
+    pub fn panic(&mut self) {
+        self.finish_block(panic());
+    }
+
     /// Call a function that does not return.
     pub fn call_noret(&mut self, ret: PlaceExpr, f: FnName, args: &[ArgumentExpr]) {
         self.finish_block(Terminator::Call {
@@ -333,6 +337,15 @@ pub fn deallocate(ptr: ValueExpr, size: ValueExpr, align: ValueExpr, next: u32) 
 pub fn exit() -> Terminator {
     Terminator::Intrinsic {
         intrinsic: IntrinsicOp::Exit,
+        arguments: list![],
+        ret: zst_place(),
+        next_block: None,
+    }
+}
+
+pub fn panic() -> Terminator {
+    Terminator::Intrinsic {
+        intrinsic: IntrinsicOp::Panic,
         arguments: list![],
         ret: zst_place(),
         next_block: None,

--- a/tooling/miniutil/src/fmt/function.rs
+++ b/tooling/miniutil/src/fmt/function.rs
@@ -182,6 +182,7 @@ fn fmt_terminator(t: Terminator, comptypes: &mut Vec<CompType>) -> String {
             let callee = match intrinsic {
                 IntrinsicOp::Assume => "assume",
                 IntrinsicOp::Exit => "exit",
+                IntrinsicOp::Panic => "panic",
                 IntrinsicOp::PrintStdout => "print",
                 IntrinsicOp::PrintStderr => "eprint",
                 IntrinsicOp::Allocate => "allocate",


### PR DESCRIPTION
part of #172 

Add `panic` as intrinsic and `assert` as Terminator.
For now just added strings `"exited"` or `"panicked"` to `MachineStop` to differentiate between the two.
