### PR TITLE
Add RawEq Support.

### DIFF
--- a/spec/lang/step/intrinsics.md
+++ b/spec/lang/step/intrinsics.md
@@ -342,6 +342,68 @@ impl<M: Memory> Machine<M> {
     }
 }
 ```
+## Raw equality
+```rust
+impl<M: Memory> Machine<M> {
+    fn load_raw_data(&mut self, ptr : Pointer<<M as Memory>::Provenance>, ptr_ty : PtrType) -> Result<List<u8>> {
+        // We need the pointee layout to determine how many bytes to load.
+        let PtrType::Ref { pointee, .. } = ptr_ty else {
+            throw_ub!("invalid argument to `RawEq` intrinsic: not a reference");
+        };
+        let Layout { size, align, .. } = pointee;
+        let bytes = self.mem.load(ptr, size, align, Atomicity::None)?;
+
+        // FIXME: This violates provenance monotonicity
+        if bytes.any(|byte| byte.provenance() != None) {
+            throw_ub!("invalid argument to `RawEq` intrinsic: byte has provenance");
+        }
+
+        let Some(data) =  bytes.try_map(|byte| byte.data()) else {
+            throw_ub!("invalid argument to `RawEq` intrinsic: byte is uninitialized");
+        };
+
+        Ok(data)
+    }
+
+    fn eval_intrinsic(
+        &mut self,
+        IntrinsicOp::RawEq: IntrinsicOp,
+        arguments: List<(Value<M>, Type)>,
+        ret_ty: Type,
+    ) -> NdResult<Value<M>> {
+        if arguments.len() != 2 {
+            throw_ub!("invalid number of arguments for `RawEq` intrinsic");
+        }
+        if ret_ty != Type::Bool {
+            throw_ub!("invalid return type for `RawEq` intrinsic")
+        }
+
+        let (left, l_ty) = (arguments).index_at(0);
+        let (right, r_ty) = (arguments).index_at(1);
+
+        if l_ty != r_ty {
+            throw_ub!("invalid arguments to `RawEq` intrinsic: types of arguments are not identical");
+        }
+
+        let Value::Ptr(left) = left else {
+            throw_ub!("invalid first argument to `RawEq` intrinsic: not a pointer");
+        };
+
+        let Value::Ptr(right) = right else {
+            throw_ub!("invalid second argument to `RawEq` intrinsic: not a pointer");
+        };
+
+        let Type::Ptr(l_ty) = l_ty else {
+            throw_ub!("invalid argument type to `RawEq` intrinsic: not a pointer");
+        };
+
+        let left_data = self.load_raw_data(left, l_ty)?;
+        let right_data = self.load_raw_data(right, l_ty)?;
+
+        ret(Value::Bool(left_data == right_data))
+    }
+}
+```
 
 ## Atomic accesses
 

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -355,6 +355,8 @@ pub enum IntrinsicOp {
     Deallocate,
     Spawn,
     Join,
+    /// Determines whether the raw bytes of the two values are equal.
+    RawEq,
     AtomicStore,
     AtomicLoad,
     AtomicCompareExchange,

--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -200,6 +200,17 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                         return Terminator::Goto(self.bb_name_map[&target.unwrap()]);
                     }
                 }
+                "raw_eq" =>
+                    return Terminator::Intrinsic {
+                        intrinsic: IntrinsicOp::RawEq,
+                        arguments: args
+                            .iter()
+                            .map(|x| self.translate_operand(&x.node, x.span))
+                            .collect(),
+                        ret: self.translate_place(&destination, span),
+                        next_block: target.as_ref().map(|t| self.bb_name_map[t]),
+                    },
+
                 "unlikely" | "likely" => {
                     // FIXME: use the "fallback body" provided in the standard library.
                     // translate `unlikely`, `likely` intrinsic into functions that can be called

--- a/tooling/minimize/tests/pass/array.rs
+++ b/tooling/minimize/tests/pass/array.rs
@@ -7,4 +7,6 @@ fn main() {
     print(x[2]);
     print(x[1]);
     print(x[0]);
+    assert!(x == [3, 2, 1, 0]);
+    assert!(!(x == [0, 1, 2, 3]));
 }

--- a/tooling/minimize/tests/pass/union.rs
+++ b/tooling/minimize/tests/pass/union.rs
@@ -69,10 +69,5 @@ fn main() {
     assert!(extract_struct(u) == TestStruct(12, 1200));
     
     let u = ArrayUnion { data: [[42;3], [12;3]] };
-    let a = extract_array(u);
-    assert!(a[0][1] == 42);
-    assert!(a[0][2] == 42);
-    assert!(a[1][0] == 12);
-    assert!(a[1][1] == 12);
-    assert!(a[1][2] == 12);
+    assert!(extract_array(u) == [[42;3], [12;3]]);
 }

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod print;
 mod ptr_offset;
 mod ptr_offset_from;
 mod ptr_partial_overwrite;
+mod raw_eq;
 mod return_;
 mod spawn_join;
 mod switch;

--- a/tooling/minitest/src/tests/raw_eq.rs
+++ b/tooling/minitest/src/tests/raw_eq.rs
@@ -1,0 +1,215 @@
+use crate::*;
+
+#[test]
+fn true_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let dest = f.declare_local::<bool>();
+    let left = f.declare_local::<[u8; 2]>();
+    let right = f.declare_local::<[u8; 2]>();
+
+    let pointee = layout(size(2), align(1));
+    let ptr_ty = ref_ty(pointee);
+
+    let left_ptr = addr_of(left, ptr_ty);
+    let right_ptr = addr_of(right, ptr_ty);
+
+    f.storage_live(dest);
+    f.storage_live(left);
+    f.storage_live(right);
+
+    f.assign(left, array(&[const_int(42u8); 2], <u8>::get_type()));
+    f.assign(right, array(&[const_int(42u8); 2], <u8>::get_type()));
+
+    f.raw_eq(dest, left_ptr, right_ptr);
+
+    f.assume(eq(bool_to_int::<u8>(load(dest)), bool_to_int::<u8>(const_bool(true))));
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+fn false_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let dest = f.declare_local::<bool>();
+    let left = f.declare_local::<[u8; 2]>();
+    let right = f.declare_local::<[u8; 2]>();
+
+    let pointee = layout(size(2), align(1));
+    let ptr_ty = ref_ty(pointee);
+
+    let left_ptr = addr_of(left, ptr_ty);
+    let right_ptr = addr_of(right, ptr_ty);
+
+    f.storage_live(dest);
+    f.storage_live(left);
+    f.storage_live(right);
+
+    f.assign(left, array(&[const_int(42u8); 2], <u8>::get_type()));
+    f.assign(right, array(&[const_int(57u8); 2], <u8>::get_type()));
+
+    f.raw_eq(dest, left_ptr, right_ptr);
+
+    f.assume(eq(bool_to_int::<u8>(load(dest)), bool_to_int::<u8>(const_bool(false))));
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_stop(p);
+}
+
+#[test]
+fn uninit_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let dest = f.declare_local::<bool>();
+    let left = f.declare_local::<[u8; 2]>();
+    let right = f.declare_local::<[u8; 2]>();
+
+    f.storage_live(dest);
+    f.storage_live(left);
+    f.storage_live(right);
+
+    let pointee = layout(size(2), align(1));
+    let ptr_ty = ref_ty(pointee);
+
+    let left_ptr = addr_of(left, ptr_ty);
+    let right_ptr = addr_of(right, ptr_ty);
+
+    f.raw_eq(dest, left_ptr, right_ptr);
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_ub(p, "invalid argument to `RawEq` intrinsic: byte is uninitialized");
+}
+
+#[test]
+fn provenance_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let dest = f.declare_local::<bool>();
+    let left = f.declare_local::<[*const i64; 2]>();
+    let right = f.declare_local::<[*const i64; 2]>();
+
+    let pointee = layout(size(2), align(1));
+    let ptr_ty = ref_ty(pointee);
+
+    let left_ptr = addr_of(left, ptr_ty);
+    let right_ptr = addr_of(right, ptr_ty);
+
+    let int_var = f.declare_local::<i64>();
+    let int_ptr = addr_of(int_var, <*const i64>::get_type());
+
+    f.storage_live(dest);
+    f.storage_live(int_var);
+    f.storage_live(left);
+    f.storage_live(right);
+
+    f.assign(left, array(&[int_ptr; 2], <*const i64>::get_type()));
+    f.raw_eq(dest, left_ptr, right_ptr);
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_ub(p, "invalid argument to `RawEq` intrinsic: byte has provenance");
+}
+
+#[test]
+fn raw_ptr_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let dest = f.declare_local::<bool>();
+    let left = f.declare_local::<[u8; 2]>();
+    let right = f.declare_local::<[u8; 2]>();
+
+    let ptr_ty = raw_ptr_ty();
+
+    let left_ptr = addr_of(left, ptr_ty);
+    let right_ptr = addr_of(right, ptr_ty);
+
+    f.storage_live(dest);
+    f.storage_live(left);
+    f.storage_live(right);
+
+    f.raw_eq(dest, left_ptr, right_ptr);
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_ub(p, "invalid argument to `RawEq` intrinsic: not a reference");
+}
+
+#[test]
+fn invalid_ret_ty_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let dest = f.declare_local::<i64>(); // this is the invalid return type (should be `bool`)
+    let left = f.declare_local::<[u8; 2]>();
+    let right = f.declare_local::<[u8; 2]>();
+
+    let pointee = layout(size(2), align(1));
+    let ptr_ty = ref_ty(pointee);
+
+    let left_ptr = addr_of(left, ptr_ty);
+    let right_ptr = addr_of(right, ptr_ty);
+
+    f.storage_live(dest);
+    f.storage_live(left);
+    f.storage_live(right);
+
+    f.raw_eq(dest, left_ptr, right_ptr);
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_ub(p, "invalid return type for `RawEq` intrinsic");
+}
+
+#[test]
+fn unequal_args_ty_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+    let dest = f.declare_local::<bool>();
+    let left = f.declare_local::<[u8; 2]>();
+    let right = f.declare_local::<[u8; 3]>(); // not the same type as `left`
+
+    let l_pointee = layout(size(2), align(1));
+    let l_ptr_ty = ref_ty(l_pointee);
+
+    let r_pointee = layout(size(3), align(1));
+    let r_ptr_ty = ref_ty(r_pointee);
+
+    let left_ptr = addr_of(left, l_ptr_ty);
+    let right_ptr = addr_of(right, r_ptr_ty);
+
+    f.storage_live(dest);
+    f.storage_live(left);
+    f.storage_live(right);
+
+    f.raw_eq(dest, left_ptr, right_ptr);
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_ub(p, "invalid arguments to `RawEq` intrinsic: types of arguments are not identical");
+}
+
+#[test]
+fn invalid_arg_ty_raw_eq() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+
+    let dest = f.declare_local::<bool>();
+    f.storage_live(dest);
+    f.raw_eq(dest, const_int(8usize), const_int(8usize));
+    f.exit();
+
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_ub(p, "invalid first argument to `RawEq` intrinsic: not a pointer");
+}

--- a/tooling/miniutil/src/build/terminator.rs
+++ b/tooling/miniutil/src/build/terminator.rs
@@ -101,6 +101,12 @@ impl FunctionBuilder {
         self.set_cur_block(next_block)
     }
 
+    pub fn raw_eq(&mut self, dest: PlaceExpr, left_ptr: ValueExpr, right_ptr: ValueExpr) {
+        let next_block = self.declare_block();
+        self.finish_block(raw_eq(dest, left_ptr, right_ptr, bbname_into_u32(next_block)));
+        self.set_cur_block(next_block)
+    }
+
     pub fn atomic_store(&mut self, ptr: ValueExpr, src: ValueExpr) {
         let next_block = self.declare_block();
         self.finish_block(atomic_store(ptr, src, bbname_into_u32(next_block)));
@@ -357,6 +363,15 @@ pub fn join(thread_id: ValueExpr, next: u32) -> Terminator {
         intrinsic: IntrinsicOp::Join,
         arguments: list!(thread_id),
         ret: zst_place(),
+        next_block: Some(BbName(Name::from_internal(next))),
+    }
+}
+
+pub fn raw_eq(ret: PlaceExpr, left_ptr: ValueExpr, right_ptr: ValueExpr, next: u32) -> Terminator {
+    Terminator::Intrinsic {
+        intrinsic: IntrinsicOp::RawEq,
+        arguments: list!(left_ptr, right_ptr),
+        ret,
         next_block: Some(BbName(Name::from_internal(next))),
     }
 }

--- a/tooling/miniutil/src/fmt/function.rs
+++ b/tooling/miniutil/src/fmt/function.rs
@@ -188,6 +188,7 @@ fn fmt_terminator(t: Terminator, comptypes: &mut Vec<CompType>) -> String {
                 IntrinsicOp::Deallocate => "deallocate",
                 IntrinsicOp::Spawn => "spawn",
                 IntrinsicOp::Join => "join",
+                IntrinsicOp::RawEq => "raw_eq",
                 IntrinsicOp::AtomicStore => "atomic_store",
                 IntrinsicOp::AtomicLoad => "atomic_load",
                 IntrinsicOp::AtomicCompareExchange => "atomic_compare_exchange",


### PR DESCRIPTION
This patch fixes https://github.com/minirust/minirust/issues/176.

Specifically, this patch adds support for an operation to determine whether the raw bytes of the two values are equal, 
corresponding to the [`std::intrinsics::raw_eq`](https://doc.rust-lang.org/std/intrinsics/fn.raw_eq.html) in rust standard library.