### PR TITLE
Modified APIs for running programs to support selecting memory models. 

### DIFF
--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -53,6 +53,7 @@ pub use minirust_rs::prelude::*;
 pub use miniutil::build::{self, zst_place, TypeConv as _};
 pub use miniutil::fmt::dump_program;
 pub use miniutil::run::*;
+pub use miniutil::BasicMem;
 pub use miniutil::DefaultTarget;
 
 // Get back some `std` items
@@ -111,7 +112,7 @@ fn main() {
         if dump {
             dump_program(prog);
         } else {
-            match run_program(prog) {
+            match run_program::<BasicMem>(prog) {
                 // We can't use tcx.dcx().fatal due to <https://github.com/oli-obk/ui_test/issues/226>
                 TerminationInfo::IllFormed(err) =>
                     show_error!(

--- a/tooling/minitest/src/lib.rs
+++ b/tooling/minitest/src/lib.rs
@@ -3,6 +3,7 @@
 pub use miniutil::build::*;
 pub use miniutil::fmt::*;
 pub use miniutil::run::*;
+pub use miniutil::BasicMem;
 
 pub use minirust_rs::libspecr::hidden::*;
 pub use minirust_rs::libspecr::prelude::*;
@@ -19,36 +20,36 @@ pub use std::string::String;
 mod tests;
 
 #[track_caller]
-pub fn assert_stop(prog: Program) {
-    assert_eq!(run_program(prog), TerminationInfo::MachineStop);
+pub fn assert_stop<M: Memory>(prog: Program) {
+    assert_eq!(run_program::<M>(prog), TerminationInfo::MachineStop);
 }
 
 #[track_caller]
-pub fn assert_stop_always(prog: Program, attempts: usize) {
+pub fn assert_stop_always<M: Memory>(prog: Program, attempts: usize) {
     for _ in 0..attempts {
-        assert_eq!(run_program(prog), TerminationInfo::MachineStop);
+        assert_eq!(run_program::<M>(prog), TerminationInfo::MachineStop);
     }
 }
 
 #[track_caller]
-pub fn assert_abort(prog: Program, msg: &str) {
+pub fn assert_abort<M: Memory>(prog: Program, msg: &str) {
     let msg = prelude::String::from_internal(msg.to_string());
-    assert_eq!(run_program(prog), TerminationInfo::Abort(msg));
+    assert_eq!(run_program::<M>(prog), TerminationInfo::Abort(msg));
 }
 
 #[track_caller]
-pub fn assert_ub(prog: Program, msg: &str) {
+pub fn assert_ub<M: Memory>(prog: Program, msg: &str) {
     assert_eq!(
-        run_program(prog),
+        run_program::<M>(prog),
         TerminationInfo::Ub(minirust_rs::prelude::String::from_internal(msg.to_string()))
     );
 }
 
 #[track_caller]
-pub fn assert_ub_eventually(prog: Program, attempts: usize, msg: &str) {
+pub fn assert_ub_eventually<M: Memory>(prog: Program, attempts: usize, msg: &str) {
     let msg = minirust_rs::prelude::String::from_internal(msg.to_string());
     for _ in 0..attempts {
-        match run_program(prog) {
+        match run_program::<M>(prog) {
             TerminationInfo::MachineStop => continue,
             TerminationInfo::Ub(res) if res == msg => {
                 // Got the expected result.
@@ -64,7 +65,7 @@ pub fn assert_ub_eventually(prog: Program, attempts: usize, msg: &str) {
 
 /// Create program that assigns `expr` to local of type T and checks if it causes UB.
 #[track_caller]
-pub fn assert_ub_expr<T: TypeConv>(expr: ValueExpr, msg: &str) {
+pub fn assert_ub_expr<T: TypeConv, M: Memory>(expr: ValueExpr, msg: &str) {
     let mut p = ProgramBuilder::new();
 
     let mut f = p.declare_function();
@@ -76,35 +77,35 @@ pub fn assert_ub_expr<T: TypeConv>(expr: ValueExpr, msg: &str) {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_ub(p, msg);
+    assert_ub::<M>(p, msg);
 }
 
 #[track_caller]
-pub fn assert_ill_formed(prog: Program, msg: &str) {
-    let TerminationInfo::IllFormed(info) = run_program(prog) else {
+pub fn assert_ill_formed<M: Memory>(prog: Program, msg: &str) {
+    let TerminationInfo::IllFormed(info) = run_program::<M>(prog) else {
         panic!("program is not ill formed!")
     };
     assert_eq!(info.get_internal(), msg, "program is ill-formed with a different error message");
 }
 
 #[track_caller]
-pub fn assert_deadlock(prog: Program) {
-    assert_eq!(run_program(prog), TerminationInfo::Deadlock);
+pub fn assert_deadlock<M: Memory>(prog: Program) {
+    assert_eq!(run_program::<M>(prog), TerminationInfo::Deadlock);
 }
 
 #[track_caller]
-pub fn assert_memory_leak(prog: Program) {
-    assert_eq!(run_program(prog), TerminationInfo::MemoryLeak);
+pub fn assert_memory_leak<M: Memory>(prog: Program) {
+    assert_eq!(run_program::<M>(prog), TerminationInfo::MemoryLeak);
 }
 
 /// Run the program multiple times. Checks if we get a data race in some execution
 /// This automatically fails if the program does not terminate correctly if the data race did not occur.
 #[track_caller]
-pub fn has_data_race(prog: Program) -> bool {
+pub fn has_data_race<M: Memory>(prog: Program) -> bool {
     let data_race_string = minirust_rs::prelude::String::from_internal("Data race".to_string());
 
     for _ in 0..32 {
-        match run_program(prog) {
+        match run_program::<M>(prog) {
             TerminationInfo::MachineStop => {}
             TerminationInfo::Ub(ub) if ub == data_race_string => {
                 return true;

--- a/tooling/minitest/src/tests/align.rs
+++ b/tooling/minitest/src/tests/align.rs
@@ -38,7 +38,7 @@ fn manual_align() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn impossible_align() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_stop(p); // will panic!
+    assert_stop::<BasicMem>(p); // will panic!
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn load_place_misaligned() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "loading from a place based on a misaligned pointer");
+    assert_ub::<BasicMem>(p, "loading from a place based on a misaligned pointer");
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn store_place_misaligned() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "storing to a place based on a misaligned pointer");
+    assert_ub::<BasicMem>(p, "storing to a place based on a misaligned pointer");
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn deref_misaligned_ref() {
     );
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "transmuted value is not valid at new type");
+    assert_ub::<BasicMem>(p, "transmuted value is not valid at new type");
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn deref_overaligned() {
     );
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -189,7 +189,10 @@ fn addr_of_misaligned_ref() {
     );
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "taking the address of an invalid (null, misaligned, or uninhabited) place");
+    assert_ub::<BasicMem>(
+        p,
+        "taking the address of an invalid (null, misaligned, or uninhabited) place",
+    );
 }
 
 /// Same test as above, but with a raw pointer it's fine.
@@ -219,5 +222,5 @@ fn addr_of_misaligned_ptr() {
     );
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }

--- a/tooling/minitest/src/tests/assume.rs
+++ b/tooling/minitest/src/tests/assume.rs
@@ -7,7 +7,7 @@ fn assume_true() {
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -17,7 +17,7 @@ fn assume_false() {
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "`Assume` intrinsic called on condition that is violated");
+    assert_ub::<BasicMem>(p, "`Assume` intrinsic called on condition that is violated");
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn assume_wrong_argnum() {
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `Assume` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Assume` intrinsic");
 }
 
 #[test]
@@ -47,5 +47,5 @@ fn assume_wrong_argty() {
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid argument for `Assume` intrinsic: not a Boolean");
+    assert_ub::<BasicMem>(p, "invalid argument for `Assume` intrinsic: not a Boolean");
 }

--- a/tooling/minitest/src/tests/atomic.rs
+++ b/tooling/minitest/src/tests/atomic.rs
@@ -19,7 +19,7 @@ fn atomic_store_success() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn atomic_store_arg_count() {
 
     let f = function(Ret::No, 0, &[], &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `AtomicStore` intrinsic")
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `AtomicStore` intrinsic")
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn atomic_store_arg_type1() {
 
     let f = function(Ret::No, 0, &[], &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid first argument to `AtomicStore` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicStore` intrinsic: not a pointer")
 }
 
 #[test]
@@ -73,7 +73,10 @@ fn atomic_store_arg_type_pow() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid second argument to `AtomicStore` intrinsic: size not power of two")
+    assert_ub::<BasicMem>(
+        p,
+        "invalid second argument to `AtomicStore` intrinsic: size not power of two",
+    )
 }
 
 // This test assumes that we test on a memory with `MAX_ATOMIC_SIZE <= 8 byte`.
@@ -97,7 +100,7 @@ fn atomic_store_arg_type_size() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid second argument to `AtomicStore` intrinsic: size too big")
+    assert_ub::<BasicMem>(p, "invalid second argument to `AtomicStore` intrinsic: size too big")
 }
 
 #[test]
@@ -119,7 +122,7 @@ fn atomic_store_ret_type() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid return type for `AtomicStore` intrinsic")
+    assert_ub::<BasicMem>(p, "invalid return type for `AtomicStore` intrinsic")
 }
 
 #[test]
@@ -141,7 +144,7 @@ fn atomic_load_success() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -161,7 +164,7 @@ fn atomic_load_arg_count() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `AtomicLoad` intrinsic")
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `AtomicLoad` intrinsic")
 }
 
 #[test]
@@ -181,7 +184,7 @@ fn atomic_load_arg_type() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid first argument to `AtomicLoad` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicLoad` intrinsic: not a pointer")
 }
 
 #[test]
@@ -195,7 +198,10 @@ fn atomic_load_ret_type_pow() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid return type for `AtomicLoad` intrinsic: size not power of two")
+    assert_ub::<BasicMem>(
+        p,
+        "invalid return type for `AtomicLoad` intrinsic: size not power of two",
+    )
 }
 
 // This test assumes that we test on a memory with `MAX_ATOMIC_SIZE <= 8 byte`.
@@ -210,5 +216,5 @@ fn atomic_load_ret_type_size() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid return type for `AtomicLoad` intrinsic: size too big")
+    assert_ub::<BasicMem>(p, "invalid return type for `AtomicLoad` intrinsic: size too big")
 }

--- a/tooling/minitest/src/tests/atomic_fetch.rs
+++ b/tooling/minitest/src/tests/atomic_fetch.rs
@@ -26,7 +26,7 @@ fn atomic_fetch_success() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3, b4]);
     let p = program(&[f]);
 
-    let output = get_stdout(p).unwrap();
+    let output = get_stdout::<BasicMem>(p).unwrap();
     assert_eq!(output[0], "4");
     assert_eq!(output[1], "2");
 }
@@ -46,7 +46,7 @@ fn atomic_fetch_arg_count() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid number of arguments for `AtomicFetchAndOp` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `AtomicFetchAndOp` intrinsic");
 }
 
 #[test]
@@ -64,7 +64,10 @@ fn atomic_fetch_arg_1() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid first argument to `AtomicFetchAndOp` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(
+        p,
+        "invalid first argument to `AtomicFetchAndOp` intrinsic: not a pointer",
+    );
 }
 
 #[test]
@@ -84,7 +87,7 @@ fn atomic_fetch_arg_2() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(
+    assert_ub::<BasicMem>(
         p,
         "invalid second argument to `AtomicFetchAndOp` intrinsic: not same type as return value",
     );
@@ -109,7 +112,10 @@ fn atomic_fetch_ret_ty() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid return type for `AtomicFetchAndOp` intrinsic: only works with integers");
+    assert_ub::<BasicMem>(
+        p,
+        "invalid return type for `AtomicFetchAndOp` intrinsic: only works with integers",
+    );
 }
 
 #[test]
@@ -129,7 +135,7 @@ fn atomic_fetch_int_size() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid return type for `AtomicFetchAndOp` intrinsic: size too big");
+    assert_ub::<BasicMem>(p, "invalid return type for `AtomicFetchAndOp` intrinsic: size too big");
 }
 
 #[test]
@@ -154,5 +160,5 @@ fn atomic_fetch_op() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ill_formed(p, "IntrinsicOp::AtomicFetchAndOp: non atomic op");
+    assert_ill_formed::<BasicMem>(p, "IntrinsicOp::AtomicFetchAndOp: non atomic op");
 }

--- a/tooling/minitest/src/tests/bool.rs
+++ b/tooling/minitest/src/tests/bool.rs
@@ -11,7 +11,7 @@ fn false_to_int_works() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// Tests that true to int results in 1.
@@ -25,7 +25,7 @@ fn true_to_int_works() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// Tests that boolean negation works.
@@ -40,7 +40,7 @@ fn not_works_both_ways() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// Test that BoolBinOp::BitAnd works
@@ -59,7 +59,7 @@ fn bit_and_bool_works() {
         block!(unreachable()),
     ];
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 /// Test that BoolBinOp::BitOr works
@@ -76,7 +76,7 @@ fn bool_or_works() {
         block!(unreachable()),
     ];
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 /// Test that BoolBinOp::BitXor works
@@ -93,5 +93,5 @@ fn bool_xor_works() {
         block!(unreachable()),
     ];
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }

--- a/tooling/minitest/src/tests/builder_api.rs
+++ b/tooling/minitest/src/tests/builder_api.rs
@@ -13,7 +13,7 @@ fn global_var() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn local_var() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn arg_and_ret_var() {
     };
 
     let p = p.finish_program(start);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn switch_int() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn while_() {
     f.if_(eq(load(var), const_int(84u32)), |f| f.exit(), |f| f.unreachable());
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -135,7 +135,7 @@ fn double_exit() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn statement_after_exit() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -169,5 +169,5 @@ fn no_exit() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }

--- a/tooling/minitest/src/tests/call.rs
+++ b/tooling/minitest/src/tests/call.rs
@@ -25,7 +25,7 @@ fn call_success() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f, other_f()]);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn call_non_exist() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ill_formed(p, "Constant::FnPointer: invalid function name");
+    assert_ill_formed::<BasicMem>(p, "Constant::FnPointer: invalid function name");
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn call_arg_count() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f, other_f()]);
     dump_program(p);
-    assert_ub(p, "call ABI violation: number of arguments does not agree");
+    assert_ub::<BasicMem>(p, "call ABI violation: number of arguments does not agree");
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn call_arg_abi() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f, other_f()]);
     dump_program(p);
-    assert_ub(p, "call ABI violation: argument types are not compatible");
+    assert_ub::<BasicMem>(p, "call ABI violation: argument types are not compatible");
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn call_ret_abi() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f, other_f()]);
     dump_program(p);
-    assert_ub(p, "call ABI violation: return types are not compatible");
+    assert_ub::<BasicMem>(p, "call ABI violation: return types are not compatible");
 }
 
 #[test]
@@ -134,5 +134,5 @@ fn ret_mismatch() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f, other_f]);
     dump_program(p);
-    assert_ub(p, "call ABI violation: return types are not compatible");
+    assert_ub::<BasicMem>(p, "call ABI violation: return types are not compatible");
 }

--- a/tooling/minitest/src/tests/compare_exchange.rs
+++ b/tooling/minitest/src/tests/compare_exchange.rs
@@ -41,7 +41,7 @@ fn compare_exchange_success() {
     let p = program(&[f]);
 
     // Check that we exchange in the first case but not the second
-    let out = match get_stdout(p) {
+    let out = match get_stdout::<BasicMem>(p) {
         Ok(out) => out,
         Err(err) => panic!("{:?}", err),
     };
@@ -70,7 +70,7 @@ fn compare_exchange_arg_count() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `AtomicCompareExchange` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `AtomicCompareExchange` intrinsic");
 }
 
 #[test]
@@ -91,7 +91,10 @@ fn compare_exchange_arg_1_value() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid first argument to `AtomicCompareExchange` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(
+        p,
+        "invalid first argument to `AtomicCompareExchange` intrinsic: not a pointer",
+    );
 }
 
 #[test]
@@ -112,7 +115,7 @@ fn compare_exchange_ret_type() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(
+    assert_ub::<BasicMem>(
         p,
         "invalid return type for `Intrinis::AtomicCompareExchange`: only works with integers",
     );
@@ -135,7 +138,7 @@ fn compare_exchange_arg_1_type() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(
+    assert_ub::<BasicMem>(
         p,
         "invalid second argument to `AtomicCompareExchange` intrinsic: not same type as return value",
     );
@@ -158,7 +161,7 @@ fn compare_exchange_arg_2_type() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(
+    assert_ub::<BasicMem>(
         p,
         "invalid third argument to `AtomicCompareExchange` intrinsic: not same type as return value",
     );
@@ -181,5 +184,8 @@ fn compare_exchange_arg_size_max() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "invalid return type for `AtomicCompareExchange` intrinsic: size too big");
+    assert_ub::<BasicMem>(
+        p,
+        "invalid return type for `AtomicCompareExchange` intrinsic: size too big",
+    );
 }

--- a/tooling/minitest/src/tests/concurrency.rs
+++ b/tooling/minitest/src/tests/concurrency.rs
@@ -58,7 +58,7 @@ fn arbitrary_order() {
     let mut write_2 = false;
 
     for _ in 0..20 {
-        let out = match get_stdout(p) {
+        let out = match get_stdout::<BasicMem>(p) {
             Ok(out) => out,
             Err(err) => panic!("{:?}", err),
         };

--- a/tooling/minitest/src/tests/data_race.rs
+++ b/tooling/minitest/src/tests/data_race.rs
@@ -59,7 +59,7 @@ fn atomic_load_atomic_load() {
         AccessPattern(AccessType::Load, Atomicity::Atomic),
     );
 
-    assert!(!has_data_race(p))
+    assert!(!has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn atomic_load_atomic_store() {
         AccessPattern(AccessType::Store, Atomicity::Atomic),
     );
 
-    assert!(!has_data_race(p))
+    assert!(!has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn atomic_load_non_atomic_load() {
         AccessPattern(AccessType::Load, Atomicity::None),
     );
 
-    assert!(!has_data_race(p))
+    assert!(!has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn atomic_load_non_atomic_store() {
         AccessPattern(AccessType::Store, Atomicity::None),
     );
 
-    assert!(has_data_race(p))
+    assert!(has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -99,7 +99,7 @@ fn atomic_store_atomic_store() {
         AccessPattern(AccessType::Store, Atomicity::Atomic),
     );
 
-    assert!(!has_data_race(p))
+    assert!(!has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn atomic_store_non_atomic_load() {
         AccessPattern(AccessType::Load, Atomicity::None),
     );
 
-    assert!(has_data_race(p))
+    assert!(has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn atomic_store_non_atomic_store() {
         AccessPattern(AccessType::Store, Atomicity::None),
     );
 
-    assert!(has_data_race(p))
+    assert!(has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn non_atomic_load_non_atomic_load() {
         AccessPattern(AccessType::Load, Atomicity::None),
     );
 
-    assert!(!has_data_race(p))
+    assert!(!has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn non_atomic_load_non_atomic_store() {
         AccessPattern(AccessType::Store, Atomicity::None),
     );
 
-    assert!(has_data_race(p))
+    assert!(has_data_race::<BasicMem>(p))
 }
 
 #[test]
@@ -149,5 +149,5 @@ fn non_atomic_store_non_atomic_store() {
         AccessPattern(AccessType::Store, Atomicity::None),
     );
 
-    assert!(has_data_race(p))
+    assert!(has_data_race::<BasicMem>(p))
 }

--- a/tooling/minitest/src/tests/dereferenceable.rs
+++ b/tooling/minitest/src/tests/dereferenceable.rs
@@ -16,7 +16,7 @@ fn deref_dangling_ref() {
     );
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
-    assert_ub(p, "dereferencing pointer without provenance");
+    assert_ub::<BasicMem>(p, "dereferencing pointer without provenance");
 }
 
 /// Test that handling a dangling reference is allowed as long as we don't dereference it.
@@ -28,7 +28,7 @@ fn assign_dangling_ref() {
     let b0 = block!(storage_live(0), assign(local(0), dangling_ref), exit(),);
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 /// However, when actually *validating* the reference, it will complain.
@@ -44,7 +44,7 @@ fn validate_dangling_ref() {
     );
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
-    assert_ub(p, "dereferencing pointer without provenance");
+    assert_ub::<BasicMem>(p, "dereferencing pointer without provenance");
 }
 
 /// Test that `*dangling_ptr` is allowed as long as we don't do anything with that place.
@@ -59,7 +59,7 @@ fn deref_dangling_ptr() {
     );
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 /// Test that `&*dangling_ptr` is detected.
@@ -78,5 +78,5 @@ fn ref_dangling_ptr() {
     );
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
-    assert_ub(p, "dereferencing pointer without provenance");
+    assert_ub::<BasicMem>(p, "dereferencing pointer without provenance");
 }

--- a/tooling/minitest/src/tests/enum_discriminant.rs
+++ b/tooling/minitest/src/tests/enum_discriminant.rs
@@ -13,7 +13,10 @@ fn ill_formed_invalid_discriminant_set() {
         set_discriminant(local(0), 0), // ill-formed here
     ];
     let program = small_program(&locals, &stmts);
-    assert_ill_formed(program, "Statement::SetDiscriminant: invalid discriminant write");
+    assert_ill_formed::<BasicMem>(
+        program,
+        "Statement::SetDiscriminant: invalid discriminant write",
+    );
 }
 
 /// Tests that both `get_discriminant` and `set_discriminant` generally work.
@@ -47,7 +50,7 @@ fn discriminant_get_and_set_work() {
     ];
     let function = function(Ret::No, 0, &locals, &blocks);
     let program = program(&[function]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// Tests that `set_discriminant` actually sets the right values for all variants.
@@ -101,7 +104,7 @@ fn discriminant_setting_right_value() {
     ];
     let function = function(Ret::No, 0, &locals, &blocks);
     let program = program(&[function]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// Tests the integrity of the enum data after set_discriminant.
@@ -151,7 +154,7 @@ fn discriminant_leaves_data_alone() {
     ];
     let function = function(Ret::No, 0, &locals, &blocks);
     let program = program(&[function]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// Tests that set_discriminant does not init the data byte.
@@ -185,7 +188,7 @@ fn ub_discriminant_does_not_init() {
         block!(unreachable()),
     ];
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_ub(
+    assert_ub::<BasicMem>(
         program,
         "load at type Int(IntType { signed: Unsigned, size: Size(1 bytes) }) but the data in memory violates the validity invariant",
     );
@@ -222,7 +225,7 @@ fn ub_cannot_read_uninit_discriminant() {
         block!(unreachable()),
     ];
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_ub(program, "ValueExpr::GetDiscriminant encountered invalid discriminant.");
+    assert_ub::<BasicMem>(program, "ValueExpr::GetDiscriminant encountered invalid discriminant.");
 }
 
 /// Tests that reading from an invalid discriminant is UB.
@@ -254,7 +257,7 @@ fn ub_cannot_read_invalid_discriminant() {
         block!(unreachable()),
     ];
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_ub(program, "ValueExpr::GetDiscriminant encountered invalid discriminant.");
+    assert_ub::<BasicMem>(program, "ValueExpr::GetDiscriminant encountered invalid discriminant.");
 }
 
 /// Reading discriminant from mis-aligned enum (ptr) is UB.
@@ -281,7 +284,10 @@ fn ub_get_discriminant_on_misaligned_enum() {
         ),
     ];
     let prog = small_program(&locals, &stmts);
-    assert_ub(prog, "Getting the discriminant of a place based on a misaligned pointer.");
+    assert_ub::<BasicMem>(
+        prog,
+        "Getting the discriminant of a place based on a misaligned pointer.",
+    );
 }
 
 /// Setting discriminant of mis-aligned enum (ptr) is UB.
@@ -304,7 +310,10 @@ fn ub_set_discriminant_on_misaligned_enum() {
         ),
     ];
     let prog = small_program(&locals, &stmts);
-    assert_ub(prog, "Setting the discriminant of a place based on a misaligned pointer");
+    assert_ub::<BasicMem>(
+        prog,
+        "Setting the discriminant of a place based on a misaligned pointer",
+    );
 }
 
 /// Ensures that the behaviour of an `Option<NonZeroU8>` of Rust is possible in MiniRust.
@@ -349,5 +358,5 @@ fn space_optimized_enum_works() {
         block!(unreachable()),
     ];
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }

--- a/tooling/minitest/src/tests/enum_downcast.rs
+++ b/tooling/minitest/src/tests/enum_downcast.rs
@@ -16,7 +16,7 @@ fn out_of_bounds_downcast() {
         assign(local(1), load(downcast(local(0), 1))), // ill-formed here, variant 1 doesn't exist
     ];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "PlaceExpr::Downcast: invalid discriminant");
+    assert_ill_formed::<BasicMem>(prog, "PlaceExpr::Downcast: invalid discriminant");
 }
 
 /// Works: Both assigning to and from a downcast.
@@ -37,7 +37,7 @@ fn valid_downcast() {
         assign(local(1), load(downcast(local(0), 0))),
     ];
     let prog = small_program(locals, stmts);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 /// UB: Assigning to first byte of variant 0 doesn't init both data bytes of variant 1.
@@ -74,7 +74,7 @@ fn downcasts_give_different_place() {
         assign(local(1), load(field(downcast(local(0), 1), 0))), // UB here, only the lower byte is initialized
     ];
     let prog = small_program(locals, stmts);
-    assert_ub(
+    assert_ub::<BasicMem>(
         prog,
         "load at type Int(IntType { signed: Unsigned, size: Size(2 bytes) }) but the data in memory violates the validity invariant",
     );
@@ -114,5 +114,5 @@ fn downcasts_give_different_place2() {
         assign(local(1), load(field(downcast(local(0), 0), 0))),
     ];
     let prog = small_program(locals, stmts);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }

--- a/tooling/minitest/src/tests/enum_representation.rs
+++ b/tooling/minitest/src/tests/enum_representation.rs
@@ -15,7 +15,7 @@ fn ill_sized_enum_variant() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Type::Enum: variant size is not the same as enum size");
+    assert_ill_formed::<BasicMem>(prog, "Type::Enum: variant size is not the same as enum size");
 }
 
 /// Ill-formed: the two variants have different sizes
@@ -33,7 +33,7 @@ fn inconsistently_sized_enum_variants() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Type::Enum: variant size is not the same as enum size");
+    assert_ill_formed::<BasicMem>(prog, "Type::Enum: variant size is not the same as enum size");
 }
 
 /// Ill-formed: no variants but discriminator returns variant 1
@@ -43,7 +43,7 @@ fn ill_formed_discriminator() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Discriminator: invalid discriminant");
+    assert_ill_formed::<BasicMem>(prog, "Discriminator: invalid discriminant");
 }
 
 /// Ill-formed: discriminator branch has a case of -1 which is an invalid value for u8.
@@ -73,7 +73,7 @@ fn ill_formed_discriminator_branch() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Discriminator: invalid branch start bound");
+    assert_ill_formed::<BasicMem>(prog, "Discriminator: invalid branch start bound");
 }
 
 /// Ill-formed: the discriminator branch children overlap.
@@ -96,7 +96,7 @@ fn ill_formed_discriminator_overlaps() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Discriminator: branch ranges overlap");
+    assert_ill_formed::<BasicMem>(prog, "Discriminator: branch ranges overlap");
 }
 
 /// Ill-formed: the discriminator branch children overlap.
@@ -119,7 +119,7 @@ fn ill_formed_discriminator_overlaps_2() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Discriminator: branch ranges overlap");
+    assert_ill_formed::<BasicMem>(prog, "Discriminator: branch ranges overlap");
 }
 
 /// Ill-formed: discriminant is of type u8 but variant has discriminant -1.
@@ -135,7 +135,7 @@ fn ill_formed_discriminant_value() {
     let locals = &[enum_ty];
     let stmts = &[];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Type::Enum: invalid value for discriminant");
+    assert_ill_formed::<BasicMem>(prog, "Type::Enum: invalid value for discriminant");
 }
 
 /// Works: simple roundtrip for both variants of an enum like Option<bool>
@@ -166,7 +166,7 @@ fn simple_two_variant_works() {
         storage_dead(0),
     ];
     let prog = small_program(locals, statements);
-    assert_stop(prog)
+    assert_stop::<BasicMem>(prog)
 }
 
 /// UB: Loading an uninhabited enum is UB as such a value is impossible to produce
@@ -180,7 +180,7 @@ fn loading_uninhabited_enum_is_ub() {
         assign(local(0), load(local(0))), // UB here.
     ];
     let prog = small_program(locals, stmts);
-    assert_ub(
+    assert_ub::<BasicMem>(
         prog,
         "load at type Enum { variants: Map({}), discriminant_ty: IntType { signed: Unsigned, size: Size(1 bytes) }, discriminator: Invalid, size: Size(0 bytes), align: Align(1 bytes) } but the data in memory violates the validity invariant",
     );
@@ -196,7 +196,7 @@ fn ill_formed_variant_constant() {
         assign(local(0), variant(0, unit(), enum_ty)), // ill-formed here
     ];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "ValueExpr::Variant: invalid discriminant");
+    assert_ill_formed::<BasicMem>(prog, "ValueExpr::Variant: invalid discriminant");
 }
 
 /// Ill-formed: The data of the variant value does not match the type
@@ -214,7 +214,7 @@ fn ill_formed_variant_constant_data() {
         assign(local(0), variant(1, unit(), enum_ty)), // ill-formed here
     ];
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "ValueExpr::Variant: invalid discriminant");
+    assert_ill_formed::<BasicMem>(prog, "ValueExpr::Variant: invalid discriminant");
 }
 
 /// Ill-formed: Ensures that the enum alignment is at least as big as all the variant alignments.
@@ -229,7 +229,7 @@ fn ill_formed_enum_must_have_maximal_alignment_of_inner() {
     let locals = [enum_ty];
     let stmts = [];
     let prog = small_program(&locals, &stmts);
-    assert_ill_formed(prog, "Type::Enum: invalid align requirement");
+    assert_ill_formed::<BasicMem>(prog, "Type::Enum: invalid align requirement");
 }
 
 const U32_INTTYPE: IntType =
@@ -264,7 +264,7 @@ fn larger_sized_tag_works() {
         storage_dead(0),
     ];
     let prog = small_program(locals, statements);
-    assert_stop(prog)
+    assert_stop::<BasicMem>(prog)
 }
 
 /// Works: Tests that using a tag larger than u8 has no alignment requirements.
@@ -296,7 +296,7 @@ fn larger_tag_has_no_alignment() {
         storage_dead(0),
     ];
     let prog = small_program(locals, statements);
-    assert_stop(prog)
+    assert_stop::<BasicMem>(prog)
 }
 
 /// Works: tests that negative discriminants are valid.
@@ -326,5 +326,5 @@ fn negative_discriminants_work() {
         storage_dead(0),
     ];
     let prog = small_program(locals, statements);
-    assert_stop(prog)
+    assert_stop::<BasicMem>(prog)
 }

--- a/tooling/minitest/src/tests/expose.rs
+++ b/tooling/minitest/src/tests/expose.rs
@@ -17,7 +17,7 @@ fn pointer_works() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// Test if `expose` called with non-pointer is UB
@@ -30,5 +30,8 @@ fn requires_pointer() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_ub(program, "invalid argument for `PointerExposeProvenance` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(
+        program,
+        "invalid argument for `PointerExposeProvenance` intrinsic: not a pointer",
+    );
 }

--- a/tooling/minitest/src/tests/heap_intrinsics.rs
+++ b/tooling/minitest/src/tests/heap_intrinsics.rs
@@ -21,7 +21,7 @@ fn dynamic_memory() {
     let b2 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn alloc_argcount() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid number of arguments for `Allocate` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Allocate` intrinsic");
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn alloc_align_err() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid alignment for `Allocate` intrinsic: not a power of 2");
+    assert_ub::<BasicMem>(p, "invalid alignment for `Allocate` intrinsic: not a power of 2");
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn alloc_size_err() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid size for `Allocate` intrinsic: negative size");
+    assert_ub::<BasicMem>(p, "invalid size for `Allocate` intrinsic: negative size");
 }
 
 #[test]
@@ -105,7 +105,7 @@ fn alloc_wrongarg1() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid first argument to `Allocate` intrinsic: not an integer");
+    assert_ub::<BasicMem>(p, "invalid first argument to `Allocate` intrinsic: not an integer");
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn alloc_wrongarg2() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid second argument to `Allocate` intrinsic: not an integer");
+    assert_ub::<BasicMem>(p, "invalid second argument to `Allocate` intrinsic: not an integer");
 }
 
 #[test]
@@ -148,7 +148,7 @@ fn alloc_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid return type for `Allocate` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid return type for `Allocate` intrinsic");
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn dealloc_success() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn dealloc_argcount() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid number of arguments for `Deallocate` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Deallocate` intrinsic");
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn dealloc_align_err() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid alignment for `Deallocate` intrinsic: not a power of 2");
+    assert_ub::<BasicMem>(p, "invalid alignment for `Deallocate` intrinsic: not a power of 2");
 }
 
 #[test]
@@ -232,7 +232,7 @@ fn dealloc_size_err() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid size for `Deallocate` intrinsic: negative size");
+    assert_ub::<BasicMem>(p, "invalid size for `Deallocate` intrinsic: negative size");
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn dealloc_wrongarg1() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid first argument to `Deallocate` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(p, "invalid first argument to `Deallocate` intrinsic: not a pointer");
 }
 
 #[test]
@@ -276,7 +276,7 @@ fn dealloc_wrongarg2() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid second argument to `Deallocate` intrinsic: not an integer");
+    assert_ub::<BasicMem>(p, "invalid second argument to `Deallocate` intrinsic: not an integer");
 }
 
 #[test]
@@ -298,7 +298,7 @@ fn dealloc_wrongarg3() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid third argument to `Deallocate` intrinsic: not an integer");
+    assert_ub::<BasicMem>(p, "invalid third argument to `Deallocate` intrinsic: not an integer");
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn dealloc_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid return type for `Deallocate` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid return type for `Deallocate` intrinsic");
 }
 
 #[test]
@@ -342,7 +342,7 @@ fn mem_dealloc_wrong_size() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "deallocating with incorrect size information");
+    assert_ub::<BasicMem>(p, "deallocating with incorrect size information");
 }
 
 #[test]
@@ -364,7 +364,7 @@ fn mem_dealloc_wrong_align() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "deallocating with incorrect alignment information");
+    assert_ub::<BasicMem>(p, "deallocating with incorrect alignment information");
 }
 
 #[test]
@@ -394,7 +394,7 @@ fn mem_dealloc_inv_ptr() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "deallocating invalid pointer");
+    assert_ub::<BasicMem>(p, "deallocating invalid pointer");
 }
 
 #[test]
@@ -414,7 +414,7 @@ fn mem_dealloc_not_beginning() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "deallocating with pointer not to the beginning of its allocation");
+    assert_ub::<BasicMem>(p, "deallocating with pointer not to the beginning of its allocation");
 }
 
 #[test]
@@ -427,7 +427,7 @@ fn double_free() {
     let b3 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3]);
     let p = program(&[f]);
-    assert_ub(p, "double-free");
+    assert_ub::<BasicMem>(p, "double-free");
 }
 
 #[test]
@@ -446,7 +446,7 @@ fn use_after_free() {
     );
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
-    assert_ub(p, "dereferencing pointer to dead allocation");
+    assert_ub::<BasicMem>(p, "dereferencing pointer to dead allocation");
 }
 
 #[test]
@@ -466,7 +466,7 @@ fn memory_leak() {
     let main = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[main]);
-    assert_memory_leak(p);
+    assert_memory_leak::<BasicMem>(p);
 }
 
 #[test]
@@ -478,5 +478,5 @@ fn mem_dealloc_stack() {
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub(p, "deallocating Stack memory with Heap deallocation operation");
+    assert_ub::<BasicMem>(p, "deallocating Stack memory with Heap deallocation operation");
 }

--- a/tooling/minitest/src/tests/ill_formed.rs
+++ b/tooling/minitest/src/tests/ill_formed.rs
@@ -9,13 +9,13 @@ fn neg_count_array() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_ill_formed(p, "Type::Array: negative amount of elements");
+    assert_ill_formed::<BasicMem>(p, "Type::Array: negative amount of elements");
 }
 
 #[test]
 fn no_main() {
     let p = program(&[]);
-    assert_ill_formed(p, "Program: start function does not exist");
+    assert_ill_formed::<BasicMem>(p, "Program: start function does not exist");
 }
 
 #[test]
@@ -26,7 +26,7 @@ fn too_large_local() {
     let stmts = &[];
 
     let prog = small_program(locals, stmts);
-    assert_ill_formed(prog, "Type: size not valid");
+    assert_ill_formed::<BasicMem>(prog, "Type: size not valid");
 }
 
 #[test]
@@ -34,5 +34,5 @@ fn type_mismatch() {
     let locals = &[<i32>::get_type()];
     let stmts = &[storage_live(0), assign(local(0), const_int::<u32>(0))];
     let p = small_program(locals, stmts);
-    assert_ill_formed(p, "Statement::Assign: destination and source type differ");
+    assert_ill_formed::<BasicMem>(p, "Statement::Assign: destination and source type differ");
 }

--- a/tooling/minitest/src/tests/int.rs
+++ b/tooling/minitest/src/tests/int.rs
@@ -27,7 +27,7 @@ fn arith_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn div_zero() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "division by zero");
+    assert_ub::<BasicMem>(p, "division by zero");
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn rem_zero() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "modulus of remainder is zero");
+    assert_ub::<BasicMem>(p, "modulus of remainder is zero");
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn div_overflow() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "overflow in division");
+    assert_ub::<BasicMem>(p, "overflow in division");
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn rem_overflow() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "overflow in remainder");
+    assert_ub::<BasicMem>(p, "overflow in remainder");
 }
 
 /// Test that IntBinOp::BitAnd works for ints
@@ -111,7 +111,7 @@ fn bit_and_int_works() {
     ];
 
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 // Test that IntBinOp::BitAnd fails with non-int/non-bool
@@ -126,7 +126,7 @@ fn bit_and_requires_int() {
         exit(),
     );
     let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
-    assert_ill_formed(prog, "BinOp::Int: invalid left type");
+    assert_ill_formed::<BasicMem>(prog, "BinOp::Int: invalid left type");
 }
 
 // Test that IntBinOp::BitAnd fails with bool
@@ -140,7 +140,7 @@ fn bit_and_no_int_bool_mixing() {
         exit(),
     );
     let prog = program(&[function(Ret::No, 0, &locals, &[b0])]);
-    assert_ill_formed(prog, "BinOp::Int: invalid left type");
+    assert_ill_formed::<BasicMem>(prog, "BinOp::Int: invalid left type");
 }
 
 /// Test that IntBinOp::BitOr works for ints
@@ -160,7 +160,7 @@ fn bit_or_int_works() {
     ];
 
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 /// Test that IntBinOp::BitXor works for ints
@@ -180,7 +180,7 @@ fn bit_xor_int_works() {
     ];
 
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 /// Test that BinUnOp::Not works for ints
@@ -198,7 +198,7 @@ fn bit_int_not_works() {
     ];
 
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 #[test]
@@ -227,7 +227,7 @@ fn shl_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -263,17 +263,17 @@ fn shr_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
 fn unchecked_add_ub() {
-    assert_ub_expr::<i8>(
+    assert_ub_expr::<i8, BasicMem>(
         add_unchecked(const_int(i8::MAX), const_int(1_i8)),
         "overflow in unchecked add",
     );
 
-    assert_ub_expr::<i8>(
+    assert_ub_expr::<i8, BasicMem>(
         add_unchecked(const_int(i8::MIN), const_int(-1i8)),
         "overflow in unchecked add",
     );
@@ -291,17 +291,17 @@ fn unchecked_add_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
 fn unchecked_sub_ub() {
-    assert_ub_expr::<i8>(
+    assert_ub_expr::<i8, BasicMem>(
         sub_unchecked(const_int(i8::MIN), const_int(1_i8)),
         "overflow in unchecked sub",
     );
 
-    assert_ub_expr::<i8>(
+    assert_ub_expr::<i8, BasicMem>(
         sub_unchecked(const_int(0_i8), const_int(i8::MIN)),
         "overflow in unchecked sub",
     );
@@ -319,16 +319,16 @@ fn unchecked_sub_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
 fn unchecked_mul_ub() {
-    assert_ub_expr::<i8>(
+    assert_ub_expr::<i8, BasicMem>(
         mul_unchecked(const_int(i8::MIN), const_int(-1_i8)),
         "overflow in unchecked mul",
     );
-    assert_ub_expr::<i8>(
+    assert_ub_expr::<i8, BasicMem>(
         mul_unchecked(const_int(56_i8), const_int(3_i8)),
         "overflow in unchecked mul",
     );
@@ -346,21 +346,21 @@ fn unchecked_mul_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
 fn unchecked_shl_ub() {
     // If left side is `u8` every right side not in range `0..8` causes UB
-    assert_ub_expr::<u8>(
+    assert_ub_expr::<u8, BasicMem>(
         shl_unchecked(const_int(1u8), const_int(8)),
         "overflow in unchecked shift",
     );
-    assert_ub_expr::<u8>(
+    assert_ub_expr::<u8, BasicMem>(
         shl_unchecked(const_int(1u8), const_int(9)),
         "overflow in unchecked shift",
     );
-    assert_ub_expr::<u8>(
+    assert_ub_expr::<u8, BasicMem>(
         shl_unchecked(const_int(1u8), const_int(-1)),
         "overflow in unchecked shift",
     );
@@ -384,25 +384,25 @@ fn unchecked_shl_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
 fn unchecked_shr_ub() {
     // If left side is `u8` every right side not in range `0..8` causes UB
-    assert_ub_expr::<u8>(
+    assert_ub_expr::<u8, BasicMem>(
         shr_unchecked(const_int(1u8), const_int(8)),
         "overflow in unchecked shift",
     );
-    assert_ub_expr::<u8>(
+    assert_ub_expr::<u8, BasicMem>(
         shr_unchecked(const_int(2u8), const_int(9)),
         "overflow in unchecked shift",
     );
-    assert_ub_expr::<u8>(
+    assert_ub_expr::<u8, BasicMem>(
         shr_unchecked(const_int(2u8), const_int(9)),
         "overflow in unchecked shift",
     );
-    assert_ub_expr::<u8>(
+    assert_ub_expr::<u8, BasicMem>(
         shr_unchecked(const_int(u8::MAX), const_int(-1)),
         "overflow in unchecked shift",
     );
@@ -433,7 +433,7 @@ fn unchecked_shr_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -453,7 +453,7 @@ fn cmp_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -468,7 +468,7 @@ fn cmp_ill_formed_left() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_ill_formed(p, "BinOp::IntCmp: invalid left type");
+    assert_ill_formed::<BasicMem>(p, "BinOp::IntCmp: invalid left type");
 }
 
 #[test]
@@ -483,7 +483,7 @@ fn cmp_ill_formed_right() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_ill_formed(p, "BinOp::IntCmp: invalid right type");
+    assert_ill_formed::<BasicMem>(p, "BinOp::IntCmp: invalid right type");
 }
 
 #[test]
@@ -512,7 +512,7 @@ fn overflow_add_works() {
     f.exit();
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -541,7 +541,7 @@ fn overflow_sub_works() {
     f.exit();
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -571,7 +571,7 @@ fn overflow_mul_works() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -588,7 +588,7 @@ fn overflow_ill_formed_left() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_ill_formed(p, "BinOp::IntWithOverflow: invalid left type");
+    assert_ill_formed::<BasicMem>(p, "BinOp::IntWithOverflow: invalid left type");
 }
 
 #[test]
@@ -605,5 +605,5 @@ fn overflow_ill_formed_right() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_ill_formed(p, "BinOp::IntWithOverflow: invalid right type");
+    assert_ill_formed::<BasicMem>(p, "BinOp::IntWithOverflow: invalid right type");
 }

--- a/tooling/minitest/src/tests/locals.rs
+++ b/tooling/minitest/src/tests/locals.rs
@@ -5,7 +5,7 @@ fn dead_before_live() {
     let locals = vec![<bool>::get_type()];
     let stmts = vec![storage_dead(0)];
     let p = small_program(&locals, &stmts);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -13,7 +13,7 @@ fn double_live() {
     let locals = vec![<bool>::get_type()];
     let stmts = vec![storage_live(0), storage_live(0)];
     let p = small_program(&locals, &stmts);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -27,5 +27,5 @@ fn assign_dead() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_ub(p, "access to a dead local");
+    assert_ub::<BasicMem>(p, "access to a dead local");
 }

--- a/tooling/minitest/src/tests/locks.rs
+++ b/tooling/minitest/src/tests/locks.rs
@@ -56,7 +56,7 @@ fn lock_handover() {
     }
 
     let p = p.finish_program(main);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn lock_handover_data_race() {
     }
 
     let p = p.finish_program(main);
-    assert_stop_always(p, 10);
+    assert_stop_always::<BasicMem>(p, 10);
 }
 
 // UB Tests for Acquire
@@ -146,7 +146,7 @@ fn acquire_arg_count() {
     let f = function(Ret::No, 0, &[], &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `Acquire` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Acquire` lock intrinsic")
 }
 
 #[test]
@@ -158,7 +158,7 @@ fn acquire_arg_value() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid first argument to `Acquire` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid first argument to `Acquire` lock intrinsic")
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn acquire_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid return type for `Acquire` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid return type for `Acquire` lock intrinsic")
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn acquire_non_existent() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "acquiring non-existing lock")
+    assert_ub::<BasicMem>(p, "acquiring non-existing lock")
 }
 
 // UB Tests for Release
@@ -213,7 +213,7 @@ fn release_arg_count() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `Release` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Release` lock intrinsic")
 }
 
 #[test]
@@ -225,7 +225,7 @@ fn release_arg_value() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid first argument to `Release` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid first argument to `Release` lock intrinsic")
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn release_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid return type for `Release` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid return type for `Release` lock intrinsic")
 }
 
 #[test]
@@ -261,7 +261,7 @@ fn release_non_existent() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "releasing non-existing lock")
+    assert_ub::<BasicMem>(p, "releasing non-existing lock")
 }
 
 #[test]
@@ -274,7 +274,7 @@ fn release_non_owned() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
 
     let p = program(&[f]);
-    assert_ub(p, "releasing non-acquired lock")
+    assert_ub::<BasicMem>(p, "releasing non-acquired lock")
 }
 
 // UB on Create lock
@@ -296,7 +296,7 @@ fn create_arg_count() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `Create` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Create` lock intrinsic")
 }
 
 #[test]
@@ -316,7 +316,7 @@ fn create_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid return type for `Create` lock intrinsic")
+    assert_ub::<BasicMem>(p, "invalid return type for `Create` lock intrinsic")
 }
 
 // Other errors
@@ -357,5 +357,5 @@ fn deadlock() {
     }
 
     let p = p.finish_program(main);
-    assert_deadlock(p);
+    assert_deadlock::<BasicMem>(p);
 }

--- a/tooling/minitest/src/tests/main.rs
+++ b/tooling/minitest/src/tests/main.rs
@@ -5,5 +5,5 @@ fn main_returns() {
     let b0 = block!(return_(),);
     let f = function(Ret::No, 0, &[], &[b0]);
     let p = program(&[f]);
-    assert_ub(p, "the start function must not return");
+    assert_ub::<BasicMem>(p, "the start function must not return");
 }

--- a/tooling/minitest/src/tests/negative_index.rs
+++ b/tooling/minitest/src/tests/negative_index.rs
@@ -12,5 +12,5 @@ fn negative_index() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_ub(p, "out-of-bounds array access");
+    assert_ub::<BasicMem>(p, "out-of-bounds array access");
 }

--- a/tooling/minitest/src/tests/no_preserve_padding.rs
+++ b/tooling/minitest/src/tests/no_preserve_padding.rs
@@ -38,7 +38,7 @@ fn no_preserve_padding() {
 
     let p = small_program(&locals, &stmts);
     dump_program(p);
-    assert_ub(
+    assert_ub::<BasicMem>(
         p,
         "load at type Int(IntType { signed: Unsigned, size: Size(1 bytes) }) but the data in memory violates the validity invariant",
     );

--- a/tooling/minitest/src/tests/no_preserve_prov.rs
+++ b/tooling/minitest/src/tests/no_preserve_prov.rs
@@ -39,5 +39,5 @@ fn no_preserve_prov() {
 
     let p = small_program(&locals, &stmts);
     dump_program(p);
-    assert_ub(p, "dereferencing pointer without provenance");
+    assert_ub::<BasicMem>(p, "dereferencing pointer without provenance");
 }

--- a/tooling/minitest/src/tests/null.rs
+++ b/tooling/minitest/src/tests/null.rs
@@ -24,7 +24,7 @@ fn ptr_null() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "dereferencing pointer without provenance");
+    assert_ub::<BasicMem>(p, "dereferencing pointer without provenance");
 }
 
 #[test]
@@ -51,5 +51,5 @@ fn ptr_null_zst() {
 
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }

--- a/tooling/minitest/src/tests/packed.rs
+++ b/tooling/minitest/src/tests/packed.rs
@@ -16,7 +16,7 @@ fn packed_works() {
     );
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn packed_is_not_aligned() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_ub_eventually(
+    assert_ub_eventually::<BasicMem>(
         p,
         16,
         "taking the address of an invalid (null, misaligned, or uninhabited) place",

--- a/tooling/minitest/src/tests/panic.rs
+++ b/tooling/minitest/src/tests/panic.rs
@@ -9,5 +9,5 @@ fn panic() {
     let start = prog.finish_function(start);
 
     let prog = prog.finish_program(start);
-    assert_abort(prog, "we panicked");
+    assert_abort::<BasicMem>(prog, "we panicked");
 }

--- a/tooling/minitest/src/tests/print.rs
+++ b/tooling/minitest/src/tests/print.rs
@@ -12,7 +12,7 @@ fn print_success() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_eq!(get_stdout(p).unwrap(), &["42"]);
+    assert_eq!(get_stdout::<BasicMem>(p).unwrap(), &["42"]);
 }
 
 #[test]
@@ -27,7 +27,7 @@ fn print_fail() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "unsupported value for printing");
+    assert_ub::<BasicMem>(p, "unsupported value for printing");
 }
 
 #[test]
@@ -48,5 +48,5 @@ fn print_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "invalid return type for `PrintStdout` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid return type for `PrintStdout` intrinsic");
 }

--- a/tooling/minitest/src/tests/ptr_offset.rs
+++ b/tooling/minitest/src/tests/ptr_offset.rs
@@ -16,7 +16,7 @@ fn ptr_offset_success() {
     let f = function(Ret::No, 0, locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn ptr_offset_inbounds() {
     let f = function(Ret::No, 0, locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "dereferencing pointer outside the bounds of its allocation");
+    assert_ub::<BasicMem>(p, "dereferencing pointer outside the bounds of its allocation");
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn ptr_offset_no_inbounds() {
     let f = function(Ret::No, 0, locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -90,7 +90,7 @@ fn ptr_offset_out_of_bounds() {
     let f = function(Ret::No, 0, locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "dereferencing pointer outside the bounds of its allocation");
+    assert_ub::<BasicMem>(p, "dereferencing pointer outside the bounds of its allocation");
 }
 
 #[test]
@@ -123,5 +123,5 @@ fn invalid_offset() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_ub(p, "dereferencing pointer without provenance");
+    assert_ub::<BasicMem>(p, "dereferencing pointer without provenance");
 }

--- a/tooling/minitest/src/tests/ptr_offset_from.rs
+++ b/tooling/minitest/src/tests/ptr_offset_from.rs
@@ -21,7 +21,7 @@ fn inbounds_success() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn oob_success() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn inbounds_cross_alloc() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_ub(p, "dereferencing pointer outside the bounds of its allocation");
+    assert_ub::<BasicMem>(p, "dereferencing pointer outside the bounds of its allocation");
 }
 
 #[test]
@@ -87,5 +87,5 @@ fn inbounds_cross_alloc_same_addr() {
     let f = p.finish_function(f);
 
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }

--- a/tooling/minitest/src/tests/ptr_partial_overwrite.rs
+++ b/tooling/minitest/src/tests/ptr_partial_overwrite.rs
@@ -20,5 +20,5 @@ fn pointer_partial_overwrite() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_ub(p, "dereferencing pointer without provenance");
+    assert_ub::<BasicMem>(p, "dereferencing pointer without provenance");
 }

--- a/tooling/minitest/src/tests/raw_eq.rs
+++ b/tooling/minitest/src/tests/raw_eq.rs
@@ -28,7 +28,7 @@ fn true_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn false_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn uninit_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_ub(p, "invalid argument to `RawEq` intrinsic: byte is uninitialized");
+    assert_ub::<BasicMem>(p, "invalid argument to `RawEq` intrinsic: byte is uninitialized");
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn provenance_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_ub(p, "invalid argument to `RawEq` intrinsic: byte has provenance");
+    assert_ub::<BasicMem>(p, "invalid argument to `RawEq` intrinsic: byte has provenance");
 }
 
 #[test]
@@ -141,7 +141,7 @@ fn raw_ptr_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_ub(p, "invalid argument to `RawEq` intrinsic: not a reference");
+    assert_ub::<BasicMem>(p, "invalid argument to `RawEq` intrinsic: not a reference");
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn invalid_ret_ty_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_ub(p, "invalid return type for `RawEq` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid return type for `RawEq` intrinsic");
 }
 
 #[test]
@@ -196,7 +196,10 @@ fn unequal_args_ty_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_ub(p, "invalid arguments to `RawEq` intrinsic: types of arguments are not identical");
+    assert_ub::<BasicMem>(
+        p,
+        "invalid arguments to `RawEq` intrinsic: types of arguments are not identical",
+    );
 }
 
 #[test]
@@ -211,5 +214,5 @@ fn invalid_arg_ty_raw_eq() {
 
     let f = p.finish_function(f);
     let p = p.finish_program(f);
-    assert_ub(p, "invalid first argument to `RawEq` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(p, "invalid first argument to `RawEq` intrinsic: not a pointer");
 }

--- a/tooling/minitest/src/tests/return_.rs
+++ b/tooling/minitest/src/tests/return_.rs
@@ -17,7 +17,7 @@ fn return_success() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f, other_f]);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn return_no_next() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f, other_f]);
     dump_program(p);
-    assert_ub(p, "return from a function where caller did not specify next block");
+    assert_ub::<BasicMem>(p, "return from a function where caller did not specify next block");
 }
 
 #[test]
@@ -56,5 +56,5 @@ fn return_intrinsic_no_next() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "return from an intrinsic where caller did not specify next block");
+    assert_ub::<BasicMem>(p, "return from an intrinsic where caller did not specify next block");
 }

--- a/tooling/minitest/src/tests/spawn_join.rs
+++ b/tooling/minitest/src/tests/spawn_join.rs
@@ -16,7 +16,7 @@ fn spawn_success() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
 
     let p = program(&[f, dummy_function()]);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 /// The program written out:
@@ -58,7 +58,7 @@ fn thread_spawn_spurious_race() {
 
     let prog = program(&[main, second]);
 
-    assert_stop(prog);
+    assert_stop::<BasicMem>(prog);
 }
 
 // UB
@@ -75,7 +75,7 @@ fn spawn_arg_count() {
     let f = function(Ret::No, 0, &[], &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid number of arguments for `Spawn` intrinsic")
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Spawn` intrinsic")
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn spawn_arg_value() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub(p, "invalid first argument to `Spawn` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(p, "invalid first argument to `Spawn` intrinsic: not a pointer")
 }
 
 fn no_args() -> Function {
@@ -108,7 +108,7 @@ fn spawn_func_no_args() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f, no_args()]);
-    assert_ub(p, "call ABI violation: number of arguments does not agree")
+    assert_ub::<BasicMem>(p, "call ABI violation: number of arguments does not agree")
 }
 
 fn returns() -> Function {
@@ -126,7 +126,7 @@ fn spawn_func_returns() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f, returns()]);
-    assert_ub(p, "call ABI violation: return types are not compatible")
+    assert_ub::<BasicMem>(p, "call ABI violation: return types are not compatible")
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn spawn_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
 
     let p = program(&[f, dummy_function()]);
-    assert_ub(p, "invalid return type for `Spawn` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid return type for `Spawn` intrinsic");
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn spawn_data_ptr() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
 
     let p = program(&[f, dummy_function()]);
-    assert_ub(p, "invalid second argument to `Spawn` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(p, "invalid second argument to `Spawn` intrinsic: not a pointer");
 }
 
 fn wrongarg() -> Function {
@@ -171,7 +171,7 @@ fn spawn_wrongarg() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
 
     let p = program(&[f, wrongarg()]);
-    assert_ub(p, "call ABI violation: argument types are not compatible");
+    assert_ub::<BasicMem>(p, "call ABI violation: argument types are not compatible");
 }
 
 #[test]
@@ -189,7 +189,7 @@ fn join_arg_count() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid number of arguments for `Join` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid number of arguments for `Join` intrinsic");
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn join_arg_value() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid first argument to `Join` intrinsic: not an integer");
+    assert_ub::<BasicMem>(p, "invalid first argument to `Join` intrinsic: not an integer");
 }
 
 #[test]
@@ -223,7 +223,7 @@ fn join_wrongreturn() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid return type for `Join` intrinsic");
+    assert_ub::<BasicMem>(p, "invalid return type for `Join` intrinsic");
 }
 
 #[test]
@@ -241,5 +241,5 @@ fn join_no_thread() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "`Join` intrinsic: join non existing thread");
+    assert_ub::<BasicMem>(p, "`Join` intrinsic: join non existing thread");
 }

--- a/tooling/minitest/src/tests/switch.rs
+++ b/tooling/minitest/src/tests/switch.rs
@@ -8,7 +8,7 @@ fn if_works() {
     let blocks = [block!(if_(const_bool(true), 1, 2)), block!(exit()), block!(unreachable())];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// tests that the else case can be reached.
@@ -19,7 +19,7 @@ fn else_works() {
     let blocks = [block!(if_(const_bool(false), 1, 2)), block!(unreachable()), block!(exit())];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 /// tests that an integer switch that switches on a boolean is ill-formed.
@@ -32,7 +32,7 @@ fn boolean_switch_is_ill_formed() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_ill_formed(program, "Terminator::Switch: switch is not Int");
+    assert_ill_formed::<BasicMem>(program, "Terminator::Switch: switch is not Int");
 }
 
 /// tests that switch_int can access an arbitrary case and the fallback case.
@@ -47,7 +47,7 @@ fn switch_int_works() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }
 
 const U8_INTTYPE: IntType =
@@ -93,5 +93,5 @@ fn switch_enum_works() {
     ];
 
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
-    assert_stop(program);
+    assert_stop::<BasicMem>(program);
 }

--- a/tooling/minitest/src/tests/too_large_alloc.rs
+++ b/tooling/minitest/src/tests/too_large_alloc.rs
@@ -10,5 +10,5 @@ fn too_large_alloc() {
     let b2 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b, b2]);
     let p = program(&[f]);
-    assert_ub(p, "asking for a too large allocation");
+    assert_ub::<BasicMem>(p, "asking for a too large allocation");
 }

--- a/tooling/minitest/src/tests/uninit_read.rs
+++ b/tooling/minitest/src/tests/uninit_read.rs
@@ -5,5 +5,8 @@ fn uninit_read() {
     let locals = vec![<bool>::get_type(); 2];
     let stmts = vec![storage_live(0), storage_live(1), assign(local(0), load(local(1)))];
     let p = small_program(&locals, &stmts);
-    assert_ub(p, "load at type Bool but the data in memory violates the validity invariant");
+    assert_ub::<BasicMem>(
+        p,
+        "load at type Bool but the data in memory violates the validity invariant",
+    );
 }

--- a/tooling/minitest/src/tests/unreachable.rs
+++ b/tooling/minitest/src/tests/unreachable.rs
@@ -9,5 +9,5 @@ fn reach_unreachable() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "reached unreachable code");
+    assert_ub::<BasicMem>(p, "reached unreachable code");
 }

--- a/tooling/minitest/src/tests/zst.rs
+++ b/tooling/minitest/src/tests/zst.rs
@@ -9,7 +9,7 @@ fn zst_array() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -21,7 +21,7 @@ fn zst_tuple() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn zst_tuple2() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]
@@ -45,5 +45,5 @@ fn zst_enum() {
     let stmts = &[storage_live(0), assign(local(0), load(local(0)))];
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_stop(p);
+    assert_stop::<BasicMem>(p);
 }

--- a/tooling/miniutil/src/lib.rs
+++ b/tooling/miniutil/src/lib.rs
@@ -23,3 +23,4 @@ pub mod mock_write;
 pub mod run;
 
 pub type DefaultTarget = x86_64;
+pub type BasicMem = BasicMemory<DefaultTarget>;

--- a/tooling/miniutil/src/run.rs
+++ b/tooling/miniutil/src/run.rs
@@ -2,11 +2,11 @@ use crate::{mock_write::MockWrite, *};
 
 /// Run the program and return its TerminationInfo.
 /// Stdout/stderr are just forwarded to the host.
-pub fn run_program(prog: Program) -> TerminationInfo {
+pub fn run_program<M: Memory>(prog: Program) -> TerminationInfo {
     let out = std::io::stdout();
     let err = std::io::stderr();
 
-    let res: Result<!, TerminationInfo> = run(prog, out, err);
+    let res: Result<!, TerminationInfo> = run::<M>(prog, out, err);
     match res {
         Ok(never) => never,
         Err(t) => t,
@@ -15,11 +15,11 @@ pub fn run_program(prog: Program) -> TerminationInfo {
 
 /// Run the program and return stdout as a `Vec<String>`  or a termination info
 /// if it did not terminate correctly. Stderr is just forwarded to the host.
-pub fn get_stdout(prog: Program) -> Result<Vec<String>, TerminationInfo> {
+pub fn get_stdout<M: Memory>(prog: Program) -> Result<Vec<String>, TerminationInfo> {
     let out = MockWrite::new();
     let err = std::io::stderr();
 
-    let res = run(prog, out.clone(), err);
+    let res = run::<M>(prog, out.clone(), err);
     match res {
         Ok(never) => never,
         Err(TerminationInfo::MachineStop) => Ok(out.into_strings()),
@@ -30,13 +30,13 @@ pub fn get_stdout(prog: Program) -> Result<Vec<String>, TerminationInfo> {
 /// Run the program to completion using the given writers for stdout/stderr.
 ///
 /// We fix `BasicMemory` as a memory for now.
-fn run(prog: Program, stdout: impl GcWrite, stderr: impl GcWrite) -> Result<!, TerminationInfo> {
+fn run<M: Memory>(
+    prog: Program,
+    stdout: impl GcWrite,
+    stderr: impl GcWrite,
+) -> Result<!, TerminationInfo> {
     let res: NdResult<!> = try {
-        let mut machine = Machine::<BasicMemory<DefaultTarget>>::new(
-            prog,
-            DynWrite::new(stdout),
-            DynWrite::new(stderr),
-        )?;
+        let mut machine = Machine::<M>::new(prog, DynWrite::new(stdout), DynWrite::new(stderr))?;
 
         loop {
             machine.step()?;


### PR DESCRIPTION
This patch modified APIs for running programs to support selecting memory models. Currently NFC, but might be useful for implementing different memory models besides the `BasicMemory`.