### PR TITLE
[minimize] Enable emitting MIR Retag

### DIFF
--- a/tooling/minimize/src/main.rs
+++ b/tooling/minimize/src/main.rs
@@ -94,6 +94,8 @@ pub const DEFAULT_ARGS: &[&str] = &[
     "-Cdebug-assertions=off",
     // This removes Resume and similar stuff.
     "-Cpanic=abort",
+    // This enable emitting MIR `Retag`s.
+    "-Zmir-emit-retag",
 ];
 
 fn show_error(msg: &impl std::fmt::Display) -> ! {


### PR DESCRIPTION
Current test cases in `tooling/minimize/tests` are running without MIR `Retag`, thus there is no `Statement::Validate` generated. So I think it might be helpful to enable this in `minimize` by default?