### PR TITLE
Add support for unsized types

### DIFF
--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -36,8 +36,8 @@ pub struct Machine<M: Memory> {
     /// The Locks
     locks: List<LockState>,
 
-    /// Stores a pointer to each of the global allocations.
-    global_ptrs: Map<GlobalName, Pointer<M::Provenance>>,
+    /// Stores a pointer to each of the global allocations, which are all `Sized`.
+    global_ptrs: Map<GlobalName, ThinPointer<M::Provenance>>,
 
     /// Stores an address for each function name.
     fn_addrs: Map<FnName, mem::Address>,
@@ -54,7 +54,7 @@ struct StackFrame<M: Memory> {
     func: Function,
 
     /// For each live local, the location in memory where its value is stored.
-    locals: Map<LocalName, Pointer<M::Provenance>>,
+    locals: Map<LocalName, ThinPointer<M::Provenance>>,
 
     /// Expresses what happens after the callee (this function) returns.
     return_action: ReturnAction<M>,
@@ -78,7 +78,7 @@ enum ReturnAction<M: Memory> {
         next_block: Option<BbName>,
         /// The location where the caller wants to see the return value.
         /// The caller type already been checked to be suitably compatible with the callee return type.
-        ret_val_ptr: Pointer<M::Provenance>,
+        ret_val_ptr: ThinPointer<M::Provenance>,
     }
 }
 ```

--- a/spec/lang/representation.md
+++ b/spec/lang/representation.md
@@ -476,7 +476,7 @@ impl<M: Memory> ConcurrentMemory<M> {
     }
 
     fn typed_load(&mut self, ptr: Pointer<M::Provenance>, ty: Type, align: Align, atomicity: Atomicity) -> Result<Value<M>> {
-        let bytes = self.load(ptr, ty.size::<M::T>(), align, atomicity)?;
+        let bytes = self.load(ptr.data_pointer, ty.size::<M::T>().resolve(ptr.metadata), align, atomicity)?;
         ret(match ty.decode::<M>(bytes) {
             Some(val) => {
                 assert!(val.check_wf(ty).is_ok(), "decode returned {val:?} which is ill-formed for {:#?}", ty);

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -35,19 +35,19 @@ impl<M: Memory> Machine<M> {
             Constant::Bool(b) => Value::Bool(b),
             Constant::GlobalPointer(relocation) => {
                 let ptr = self.global_ptrs[relocation.name].wrapping_offset::<M::T>(relocation.offset.bytes());
-                Value::Ptr(ptr)
+                Value::Ptr(ptr.widen(None))
             },
             Constant::FnPointer(fn_name) => {
-                Value::Ptr(Pointer {
+                Value::Ptr((ThinPointer {
                     addr: self.fn_addrs[fn_name],
                     provenance: None,
-                })
+                }).widen(None))
             },
             Constant::PointerWithoutProvenance(addr) => {
-                Value::Ptr(Pointer {
+                Value::Ptr((ThinPointer {
                     addr,
                     provenance: None,
-                })
+                }).widen(None))
             }
         })
     }
@@ -112,7 +112,7 @@ impl<M: Memory> Machine<M> {
         // We don't require the variant to be valid,
         // we are only interested in the bytes that the discriminator actually touches.
         let accessor = |idx: Offset, size: Size| {
-            let ptr = self.ptr_offset_inbounds(place.ptr, idx.bytes())?;
+            let ptr = self.ptr_offset_inbounds(place.ptr.thin_pointer, idx.bytes())?;
             // We have ensured that the place is aligned, so no alignment requirement here.
             self.mem.load(ptr, size, Align::ONE, Atomicity::None)
         };
@@ -136,7 +136,7 @@ impl<M: Memory> ConcurrentMemory<M> {
             throw_ub!("loading from a place based on a misaligned pointer");
         }
         // Alignment was already checked.
-        ret(self.typed_load(place.ptr, ty, Align::ONE, Atomicity::None)?)
+        ret(self.typed_load(place.ptr.thin_pointer, ty, Align::ONE, Atomicity::None)?)
     }
 }
 
@@ -160,7 +160,7 @@ impl<M: Memory> Machine<M> {
         let (place, _ty) = self.eval_place(target)?;
         // Make sure the new pointer has a valid address.
         // Remember that places are basically raw pointers so this is not guaranteed!
-        if !ptr_ty.addr_valid(place.ptr.addr) {
+        if !ptr_ty.addr_valid(place.ptr.thin_pointer.addr) {
             throw_ub!("taking the address of an invalid (null, misaligned, or uninhabited) place");
         }
         // Let the aliasing model know. (Will also check dereferenceability if appropriate.)
@@ -224,7 +224,7 @@ impl<M: Memory> Machine<M> {
             throw_ub!("access to a dead local");
         };
 
-        ret((Place { ptr, aligned: true }, ty))
+        ret((Place { ptr: ptr.widen(None), aligned: true }, ty))
     }
 }
 ```
@@ -243,13 +243,13 @@ impl<M: Memory> Machine<M> {
         // We know the pointer is valid for its type, but make sure safe pointers are also dereferenceable.
         // (We don't do a full retag here, this is not considered creating a new pointer.)
         if let Some(layout) = ptr_type.safe_pointee() {
-            assert!(layout.align.is_aligned(ptr.addr)); // this was already checked when the value got created
-            self.mem.dereferenceable(ptr, layout.size)?;
+            assert!(layout.align.is_aligned(ptr.thin_pointer.addr)); // this was already checked when the value got created
+            self.mem.dereferenceable(ptr.thin_pointer, layout.size)?;
         }
         // Check whether this pointer is sufficiently aligned.
         // Don't error immediately though! Unaligned places can still be turned into raw pointers.
         // However, they cannot be loaded from.
-        let aligned = ty.align::<M::T>().is_aligned(ptr.addr);
+        let aligned = ty.align::<M::T>().is_aligned(ptr.thin_pointer.addr);
 
         ret((Place { ptr, aligned }, ty))
     }
@@ -269,8 +269,8 @@ impl<M: Memory> Machine<M> {
         };
         assert!(offset <= ty.size::<M::T>());
 
-        let ptr = self.ptr_offset_inbounds(root.ptr, offset.bytes())?;
-        ret((Place { ptr, ..root }, field_ty))
+        let ptr = self.ptr_offset_inbounds(root.ptr.thin_pointer, offset.bytes())?;
+        ret((Place { ptr: ptr.widen(root.ptr.metadata), ..root }, field_ty))
     }
 
     fn eval_place(&mut self, PlaceExpr::Index { root, index }: PlaceExpr) -> Result<(Place<M>, Type)> {
@@ -290,8 +290,8 @@ impl<M: Memory> Machine<M> {
         };
         assert!(offset <= ty.size::<M::T>());
 
-        let ptr = self.ptr_offset_inbounds(root.ptr, offset.bytes())?;
-        ret((Place { ptr, ..root }, field_ty))
+        let ptr = self.ptr_offset_inbounds(root.ptr.thin_pointer, offset.bytes())?;
+        ret((Place { ptr: ptr.widen(None), ..root }, field_ty))
     }
 
     fn eval_place(&mut self, PlaceExpr::Downcast { root, discriminant }: PlaceExpr) -> Result<(Place<M>, Type)> {

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -287,6 +287,16 @@ impl<M: Memory> Machine<M> {
                     throw_ub!("out-of-bounds array access");
                 }
             }
+            Type::Slice { elem } => {
+                let Some(PointerMeta::ElementCount(count)) = root.ptr.metadata else {
+                    panic!("eval_place should always return a ptr which matches meta for the SizeStrategy of ty");
+                };
+                if index >= 0 && index < count {
+                    (index * elem.size::<M::T>().unwrap_size(), elem)
+                } else {
+                    throw_ub!("out-of-bounds array access");
+                }
+            }
             _ => panic!("index projection on non-indexable type"),
         };
         assert!(offset <= ty.size::<M::T>().resolve(root.ptr.metadata));

--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -67,6 +67,21 @@ impl<M: Memory> Machine<M> {
 }
 ```
 
+### Size of value
+
+```rust
+impl<M: Memory> Machine<M> {
+    fn eval_un_op(&self, UnOp::SizeOfVal: UnOp, (operand, op_ty): (Value<M>, Type)) -> Result<(Value<M>, Type)> {
+        let Type::Ptr(ptr_ty) = op_ty else { panic!("non-pointer input to size of val") };
+        let Value::Ptr(ptr) = operand else { panic!("non-pointer input to size of val") };
+
+        // Calculate the size with the metadata, else it is a zero sized function pointer.
+        let size = ptr_ty.pointee().map(|l| l.size.resolve(ptr.metadata)).unwrap_or(Size::ZERO);
+        ret((Value::Int(size.bytes()), Type::Int(IntType { signed: Unsigned, size: M::T::PTR_SIZE })))
+    }
+}
+```
+
 ## Binary operators
 
 ```rust

--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -234,7 +234,7 @@ impl<M: Memory> Machine<M> {
         match val {
             Value::Int(i) => i,
             Value::Bool(b) => if b { Int::from(1) } else { Int::from(0) },
-            Value::Ptr(p) => p.addr,
+            Value::Ptr(p) => p.thin_pointer.addr,
             _ => panic!("invalid value for relational operator"),
         }
     }
@@ -257,19 +257,20 @@ impl<M: Memory> Machine<M> {
 ```rust
 impl<M: Memory> Machine<M> {
     /// Perform a wrapping offset on the given pointer. (Can never fail.)
-    fn ptr_offset_wrapping(&self, ptr: Pointer<M::Provenance>, offset: Int) -> Pointer<M::Provenance> {
+    fn ptr_offset_wrapping(&self, ptr: ThinPointer<M::Provenance>, offset: Int) -> ThinPointer<M::Provenance> {
         ptr.wrapping_offset::<M::T>(offset)
     }
 
     /// Perform in-bounds arithmetic on the given pointer. This must not wrap,
     /// and the offset must stay in bounds of a single allocation.
-    fn ptr_offset_inbounds(&self, ptr: Pointer<M::Provenance>, offset: Int) -> Result<Pointer<M::Provenance>> {
+    // Question: Do we not care about the size here anymore? Or am I missing something?
+    fn ptr_offset_inbounds(&self, ptr: ThinPointer<M::Provenance>, offset: Int) -> Result<ThinPointer<M::Provenance>> {
         // Ensure dereferenceability. This also ensures that `offset` fits in an `isize`, since no allocation
         // can be bigger than `isize`, and it ensures that the arithmetic does not overflow, since no
         // allocation wraps around the edge of the address space.
         self.mem.signed_dereferenceable(ptr, offset)?;
         // All checked!
-        ret(Pointer { addr: ptr.addr + offset, ..ptr })
+        ret(ThinPointer { addr: ptr.addr + offset, ..ptr })
     }
 
     fn eval_bin_op(
@@ -278,15 +279,17 @@ impl<M: Memory> Machine<M> {
         (left, l_ty): (Value<M>, Type),
         (right, _r_ty): (Value<M>, Type)
     ) -> Result<(Value<M>, Type)> {
-        let Value::Ptr(left) = left else { panic!("non-pointer left input to `PtrOffset`") };
+        let Value::Ptr(Pointer { thin_pointer: left, metadata: left_meta }) = left else {
+            panic!("non-pointer left input to `PtrOffsetFrom`")
+        };
         let Value::Int(right) = right else { panic!("non-integer right input to `PtrOffset`") };
 
-        let result = if inbounds {
+        let offset_ptr = if inbounds {
             self.ptr_offset_inbounds(left, right)?
         } else {
             self.ptr_offset_wrapping(left, right)
         };
-        ret((Value::Ptr(result), l_ty))
+        ret((Value::Ptr(offset_ptr.widen(left_meta)), l_ty))
     }
 
     fn eval_bin_op(
@@ -295,8 +298,12 @@ impl<M: Memory> Machine<M> {
         (left, l_ty): (Value<M>, Type),
         (right, _r_ty): (Value<M>, Type)
     ) -> Result<(Value<M>, Type)> {
-        let Value::Ptr(left) = left else { panic!("non-pointer left input to `PtrOffsetFrom`") };
-        let Value::Ptr(right) = right else { panic!("non-integer right input to `PtrOffsetFrom`") };
+        let Value::Ptr(Pointer { thin_pointer: left, .. }) = left else {
+            panic!("non-pointer left input to `PtrOffsetFrom`")
+        };
+        let Value::Ptr(Pointer { thin_pointer: right, .. }) = right else {
+            panic!("non-pointer right input to `PtrOffsetFrom`")
+        };
 
         let distance = left.addr - right.addr;
         let distance = if inbounds {

--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -51,11 +51,8 @@ impl<M: Memory> Machine<M> {
                 // Question: Why is this not a well-formedness constraint?
                 // `core::intrinsics::transmute` states:
                 // "Both types must have the same size. Compilation will fail if this is not guaranteed."
-                if old_ty.size::<M::T>() != new_ty.size::<M::T>() {
+                if old_ty.size::<M::T>().unwrap_size() != new_ty.size::<M::T>().unwrap_size() {
                     throw_ub!("transmute between types of different size")
-                }
-                if !old_ty.size::<M::T>().is_sized() {
-                    throw_ub!("transmute of unsized types")
                 }
                 let Some(val) = transmute(operand, old_ty, new_ty) else {
                     throw_ub!("transmuted value is not valid at new type")

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -137,7 +137,7 @@ impl<M: Memory> Machine<M> {
         // Make the old value unobservable because the callee might work on it in-place.
         // This also checks that the memory is dereferenceable, and crucially ensures we are aligned
         // *at the given type* -- the callee does not care about packed field projections or things like that!
-        self.mem.deinit(place.ptr.thin_pointer, ty.size::<M::T>(), ty.align::<M::T>())?;
+        self.mem.deinit(place.ptr.thin_pointer, ty.size::<M::T>().unwrap_size(), ty.align::<M::T>())?;
         // FIXME: This also needs aliasing model support.
 
         ret(())

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -201,6 +201,7 @@ pub enum BinOp {
     Rel(RelOp),
 
     /// Add a byte-offset to a pointer (with or without inbounds requirement).
+    /// For non-Sized pointees this leaves the metadata untouched.
     /// Takes a pointer as left operand and an integer as right operand;
     /// returns a pointer.
     PtrOffset { inbounds: bool },

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -201,7 +201,6 @@ pub enum BinOp {
     Rel(RelOp),
 
     /// Add a byte-offset to a pointer (with or without inbounds requirement).
-    /// For non-Sized pointees this leaves the metadata untouched.
     /// Takes a pointer as left operand and an integer as right operand;
     /// returns a pointer.
     PtrOffset { inbounds: bool },

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -116,6 +116,8 @@ pub enum UnOp {
     Int(IntUnOp),
     /// A form of cast; the return type is given by the specific cast operation.
     Cast(CastOp),
+    /// Getting the dynamic size of the pointee behind the argument.
+    SizeOfVal
 }
 
 pub enum IntBinOp {

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -132,14 +132,15 @@ impl IntType {
 }
 
 impl Type {
-    pub fn size<T: Target>(self) -> Size {
+    pub fn size<T: Target>(self) -> SizeStrategy {
         use Type::*;
+        use SizeStrategy::*;
         match self {
-            Int(int_type) => int_type.size,
-            Bool => Size::from_bytes_const(1),
-            Ptr(_) => T::PTR_SIZE, // FIXME: sometimes 2 words
-            Tuple { size, .. } | Union { size, .. } | Enum { size, .. } => size,
-            Array { elem, count } => elem.size::<T>() * count,
+            Int(int_type) => Sized(int_type.size),
+            Bool => Sized(Size::from_bytes_const(1)),
+            Ptr(ptr_type) => Sized(if ptr_type.matches_meta(None) { T::PTR_SIZE } else { T::PTR_SIZE + T::PTR_SIZE }),
+            Tuple { size, .. } | Union { size, .. } | Enum { size, .. } => Sized(size),
+            Array { elem, count } => Sized(elem.size::<T>().unwrap_size() * count),
         }
     }
 

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -132,14 +132,15 @@ impl IntType {
 }
 
 impl Type {
-    pub fn size<T: Target>(self) -> Size {
+    pub fn size<T: Target>(self) -> SizeStrategy {
         use Type::*;
+        use SizeStrategy::*;
         match self {
-            Int(int_type) => int_type.size,
-            Bool => Size::from_bytes_const(1),
-            Ptr(_) => T::PTR_SIZE,
-            Tuple { size, .. } | Union { size, .. } | Enum { size, .. } => size,
-            Array { elem, count } => elem.size::<T>() * count,
+            Int(int_type) => Sized(int_type.size),
+            Bool => Sized(Size::from_bytes_const(1)),
+            Ptr(_) => Sized(T::PTR_SIZE),
+            Tuple { size, .. } | Union { size, .. } | Enum { size, .. } => Sized(size),
+            Array { elem, count } => Sized(elem.size::<T>().unwrap_size() * count),
         }
     }
 
@@ -171,6 +172,41 @@ impl Type {
             size: self.size::<T>(),
             align: self.align::<T>(),
             inhabited: self.inhabited(),
+        }
+    }
+}
+
+pub enum SizeStrategy {
+    /// The type is statically `Sized`.
+    Sized(Size),
+
+    /// The size of the type is given by `min_size + element_size * len`,
+    /// where `len` is found in the wide pointer metadata.
+    FixPlusTail {
+        min_size: Size,
+        element_size: Size,
+    },
+
+    /// TODO
+    VTable,
+}
+
+impl SizeStrategy {
+    /// Returns the size when the type must be statically sized
+    pub fn unwrap_size(self) -> Size {
+        match self {
+            SizeStrategy::Sized(size) => size,
+            _ => panic!("Expected a sized type"), // TODO: is panicing the right thing to do?
+        }
+    }
+
+    // TODO: this needs to access memory for trait objects, support this with function arguments
+    pub fn resolve(self, meta: Option<PointerMeta>) -> Size {
+        match (self, meta) {
+            (SizeStrategySized(size), None) => size,
+            (SizeStrategyFixPlusTail { min_size, element_size }, Some(PointerMeta::ElementCount(num))) => min_size + element_size * num,
+            (SizeStrategy::VTable, PointerMeta::VTable) => unimplemented!("trait object support is missing"),
+            _ => panic!("Pointer meta data does not match type"),
         }
     }
 }

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -203,9 +203,9 @@ impl SizeStrategy {
     // TODO: this needs to access memory for trait objects, support this with function arguments
     pub fn resolve(self, meta: Option<PointerMeta>) -> Size {
         match (self, meta) {
-            (SizeStrategySized(size), None) => size,
-            (SizeStrategyFixPlusTail { min_size, element_size }, Some(PointerMeta::ElementCount(num))) => min_size + element_size * num,
-            (SizeStrategy::VTable, PointerMeta::VTable) => unimplemented!("trait object support is missing"),
+            (SizeStrategy::Sized(size), None) => size,
+            (SizeStrategy::FixPlusTail { min_size, element_size }, Some(PointerMeta::ElementCount(num))) => min_size + element_size * num,
+            (SizeStrategy::VTable, Some(PointerMeta::VTable)) => unimplemented!("trait object support is missing"),
             _ => panic!("Pointer meta data does not match type"),
         }
     }

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -168,7 +168,7 @@ impl Type {
             Ptr(PtrType::Ref { pointee, .. } | PtrType::Box { pointee }) => pointee.inhabited,
             Tuple { fields, .. } => fields.all(|(_offset, ty)| ty.inhabited()),
             Array { elem, count } => count == 0 || elem.inhabited(),
-            Slice { elem } => elem.inhabited(),
+            Slice { .. } => true, // the empty slice always exists
             Union { .. } => true,
             Enum { variants, .. } => variants.values().any(|variant| variant.ty.inhabited()),
         }

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -184,6 +184,24 @@ impl Type {
 }
 ```
 
+```rust
+impl<Provenance> Pointer<Provenance> {
+    pub fn try_unsize(self, pointee_ty: Type, target_ptr_ty: PtrType) -> Option<Pointer<Provenance>> {
+        if self.metadata.is_some() {
+            throw!();
+        }
+        match (pointee_ty, target_ptr_ty.pointee().map(|l| l.size)) {
+            (Type::Array { count, .. }, Some(SizeStrategy::SliceTail { .. })) => {
+                // Layouts and sizes don't have to match
+                ret(self.thin_pointer.widen(Some(PointerMeta::ElementCount(count))))
+            }
+            _ => throw!(),
+        }
+    }
+}
+
+```
+
 ## Integer type convenience functions
 
 ```rust

--- a/spec/lang/values.md
+++ b/spec/lang/values.md
@@ -9,7 +9,7 @@ enum Value<M: Memory> {
     Int(Int),
     /// A Boolean value, used for `bool`.
     Bool(bool),
-    /// A pointer value, used for (thin) references and raw pointers.
+    /// A pointer value, used for references and raw pointers.
     Ptr(Pointer<M::Provenance>),
     /// An n-tuple, used for arrays, structs, tuples (including unit).
     Tuple(List<Value<M>>),

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -324,7 +324,8 @@ impl ValueExpr {
             AddrOf { target, ptr_ty } => {
                 ptr_ty.check_wf::<T>()?;
                 target.check_wf::<T>(locals, prog)?;
-                // FIXME: should I check any sort of place-ptr compatiblity here? Not it is just UB.
+                // FIXME: Here again, there seems to be a need for incompatible layouts
+                // ensure_wf(Some(target.layout::<T>()) == ptr_ty.pointee(), "ValueExpr::AddrOf: incompatible layouts")?;
                 // No check of how the alignment changes here -- that is purely a runtime constraint.
                 Type::Ptr(ptr_ty)
             }

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -662,8 +662,9 @@ impl<M: Memory> Value<M> {
             }
             (Value::Bool(_), Type::Bool) => {},
             (Value::Ptr(ptr), Type::Ptr(ptr_ty)) => {
-                ensure_wf(ptr_ty.addr_valid(ptr.addr), "Value::Ptr: invalid pointer address")?;
-                ensure_wf(ptr.addr.in_bounds(Unsigned, M::T::PTR_SIZE), "Value::Ptr: pointer out-of-bounds")?;
+                // FIXME: Check pointer meta matches ptr_ty expected meta!
+                ensure_wf(ptr_ty.addr_valid(ptr.thin_pointer.addr), "Value::Ptr: invalid pointer address")?;
+                ensure_wf(ptr.thin_pointer.addr.in_bounds(Unsigned, M::T::PTR_SIZE), "Value::Ptr: pointer out-of-bounds")?;
             }
             (Value::Tuple(vals), Type::Tuple { fields, .. }) => {
                 ensure_wf(vals.len() == fields.len(), "Value::Tuple: invalid number of fields")?;

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -353,6 +353,10 @@ impl ValueExpr {
                             }
                         }
                     }
+                    SizeOfVal => {
+                        ensure_wf(matches!(operand, Type::Ptr(_)), "UnOp::SizeOfVal invalid operand")?;
+                        Type::Int(IntType { signed: Unsigned, size: T::PTR_SIZE })
+                    }
                 }
             }
             BinOp { operator, left, right } => {

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -116,6 +116,10 @@ impl Type {
                 ensure_wf(elem.size::<T>().is_sized(), "Type::Array: unsized element type")?;
                 elem.check_wf::<T>()?;
             }
+            Slice { elem } => {
+                ensure_wf(elem.size::<T>().is_sized(), "Type::Slice: unsized element type")?;
+                elem.check_wf::<T>()?;
+            }
             Union { fields, size, chunks, align: _ } => {
                 // The fields may overlap, but they must all fit the size.
                 for (offset, ty) in fields {
@@ -465,8 +469,8 @@ impl PlaceExpr {
                 let index = index.check_wf::<T>(locals, prog)?;
                 ensure_wf(matches!(index, Type::Int(_)), "PlaceExpr::Index: invalid index type")?;
                 match root {
-                    Type::Array { elem, .. } => elem,
-                    _ => throw_ill_formed!("PlaceExpr::Index: expression does not match Array type"),
+                    Type::Array { elem, .. } | Type::Slice { elem } => elem,
+                    _ => throw_ill_formed!("PlaceExpr::Index: expression type is not indexable"),
                 }
             }
             Downcast { root, discriminant } => {

--- a/spec/mem/basic.md
+++ b/spec/mem/basic.md
@@ -205,7 +205,7 @@ impl<T: Target> BasicMemory<T> {
 }
 
 impl<T: Target> Memory for BasicMemory<T> {
-    fn load(&mut self, ptr: Pointer<AllocId>, len: Size, align: Align) -> Result<List<AbstractByte<AllocId>>> {
+    fn load(&mut self, ptr: DataPointer<AllocId>, len: Size, align: Align) -> Result<List<AbstractByte<AllocId>>> {
         if !align.is_aligned(ptr.addr) {
             throw_ub!("load from a misaligned pointer");
         }

--- a/spec/mem/concurrent.md
+++ b/spec/mem/concurrent.md
@@ -74,7 +74,7 @@ impl<M: Memory> ConcurrentMemory<M> {
     }
 
     /// Read some bytes from memory and check for data races.
-    pub fn load(&mut self, ptr: Pointer<M::Provenance>, len: Size, align: Align, atomicity: Atomicity) -> Result<List<AbstractByte<M::Provenance>>> {
+    pub fn load(&mut self, ptr: DataPointer<M::Provenance>, len: Size, align: Align, atomicity: Atomicity) -> Result<List<AbstractByte<M::Provenance>>> {
         let access = Access {
             ty: AccessType::Load,
             atomicity,

--- a/spec/mem/concurrent.md
+++ b/spec/mem/concurrent.md
@@ -51,17 +51,17 @@ impl<M: Memory> ConcurrentMemory<M> {
 
     /// Create a new allocation.
     /// The initial contents of the allocation are `AbstractByte::Uninit`.
-    pub fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<Pointer<M::Provenance>> {
+    pub fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<ThinPointer<M::Provenance>> {
         self.memory.allocate(kind, size, align)
     }
 
     /// Remove an allocation.
-    pub fn deallocate(&mut self, ptr: Pointer<M::Provenance>, kind: AllocationKind, size: Size, align: Align) -> Result {
+    pub fn deallocate(&mut self, ptr: ThinPointer<M::Provenance>, kind: AllocationKind, size: Size, align: Align) -> Result {
         self.memory.deallocate(ptr, kind, size, align)
     }
 
     /// Write some bytes to memory and check for data races.
-    pub fn store(&mut self, ptr: Pointer<M::Provenance>, bytes: List<AbstractByte<M::Provenance>>, align: Align, atomicity: Atomicity) -> Result {
+    pub fn store(&mut self, ptr: ThinPointer<M::Provenance>, bytes: List<AbstractByte<M::Provenance>>, align: Align, atomicity: Atomicity) -> Result {
         let access = Access {
             ty: AccessType::Store,
             atomicity,
@@ -74,7 +74,7 @@ impl<M: Memory> ConcurrentMemory<M> {
     }
 
     /// Read some bytes from memory and check for data races.
-    pub fn load(&mut self, ptr: DataPointer<M::Provenance>, len: Size, align: Align, atomicity: Atomicity) -> Result<List<AbstractByte<M::Provenance>>> {
+    pub fn load(&mut self, ptr: ThinPointer<M::Provenance>, len: Size, align: Align, atomicity: Atomicity) -> Result<List<AbstractByte<M::Provenance>>> {
         let access = Access {
             ty: AccessType::Load,
             atomicity,
@@ -88,12 +88,12 @@ impl<M: Memory> ConcurrentMemory<M> {
 
     /// Test whether the given pointer is dereferenceable for the given size.
     /// Raises UB if that is not the case.
-    pub fn dereferenceable(&self, ptr: Pointer<M::Provenance>, len: Size) -> Result {
+    pub fn dereferenceable(&self, ptr: ThinPointer<M::Provenance>, len: Size) -> Result {
         self.memory.dereferenceable(ptr, len)
     }
 
     /// A derived form of `dereferenceable` that works with a signed notion on "length".
-    pub fn signed_dereferenceable(&self, ptr: Pointer<M::Provenance>, len: Int) -> Result {
+    pub fn signed_dereferenceable(&self, ptr: ThinPointer<M::Provenance>, len: Int) -> Result {
         self.memory.signed_dereferenceable(ptr, len)
     }
 

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -89,7 +89,7 @@ pub trait Memory {
     /// Read some bytes from memory.
     ///
     /// Needs `&mut self` because in the aliasing model, reading changes the machine state.
-    fn load(&mut self, ptr: Pointer<Self::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<Self::Provenance>>>;
+    fn load(&mut self, ptr: DataPointer<Self::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<Self::Provenance>>>;
 
     /// Test whether the given pointer is dereferenceable for the given size.
     fn dereferenceable(&self, ptr: Pointer<Self::Provenance>, len: Size) -> Result;

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -95,8 +95,6 @@ pub trait Memory {
     fn dereferenceable(&self, ptr: ThinPointer<Self::Provenance>, len: Size) -> Result;
 
     /// A derived form of `dereferenceable` that works with a signed notion of "length".
-    // Question: This seems wrong to me, since the the "ranges" check are only
-    // the difference between the two pointers, independent of size ?
     fn signed_dereferenceable(&self, ptr: ThinPointer<Self::Provenance>, len: Int) -> Result {
         if len > 0 {
             self.dereferenceable(ptr, Size::from_bytes(len).unwrap())
@@ -118,7 +116,7 @@ pub trait Memory {
     /// Return the retagged pointer.
     fn retag_ptr(&mut self, ptr: Pointer<Self::Provenance>, ptr_type: PtrType, _fn_entry: bool) -> Result<Pointer<Self::Provenance>> {
         if let Some(layout) = ptr_type.safe_pointee() {
-            self.dereferenceable(ptr.thin_pointer, layout.size)?;
+            self.dereferenceable(ptr.thin_pointer, layout.size.resolve(ptr.metadata))?;
         }
         ret(ptr)
     }

--- a/spec/mem/intptrcast.md
+++ b/spec/mem/intptrcast.md
@@ -20,14 +20,14 @@ impl<Provenance> IntPtrCast<Provenance> {
         Self { exposed: Set::new() }
     }
 
-    pub fn expose(&mut self, ptr: Pointer<Provenance>) {
+    pub fn expose(&mut self, ptr: ThinPointer<Provenance>) {
         if let Some(provenance) = ptr.provenance {
             // Remember this provenance as having been exposed.
             self.exposed.insert(provenance);
         }
     }
 
-    pub fn int2ptr(&self, addr: Int) -> NdResult<Pointer<Provenance>> {
+    pub fn int2ptr(&self, addr: Int) -> NdResult<ThinPointer<Provenance>> {
         // Predict a suitable provenance. It must be either `None` or already exposed.
         let provenance = predict(|prov: Option<Provenance>| {
             prov.map_or(
@@ -37,7 +37,7 @@ impl<Provenance> IntPtrCast<Provenance> {
         })?;
 
         // Construct a pointer with that provenance.
-        ret(Pointer { addr, provenance })
+        ret(ThinPointer { addr, provenance })
     }
 }
 ```

--- a/spec/mem/pointer.md
+++ b/spec/mem/pointer.md
@@ -55,8 +55,9 @@ impl<Provenance> DataPointer<Provenance> {
 ```rust
 // This doesn't make a lot of sense in this file, maybe rather values.md.
 // (Similarly the PtrType is only used for retagging in mem.rs, and it felt out of place when reading ?)
-enum PointerMeta {
-    ElementCount(Size),
+/// The metadata that can be stored in a fat pointer.
+pub enum PointerMeta {
+    ElementCount(Int),
     // TODO
     VTable
 }

--- a/spec/mem/pointer.md
+++ b/spec/mem/pointer.md
@@ -20,22 +20,45 @@ As far as the interface is concerned, this is some opaque extra data that we car
 /// of the address space.
 pub type Address = Int;
 
-/// A "pointer" is an address together with its Provenance.
+/// A "data pointer" is an address together with its Provenance.
 /// Provenance can be absent; those pointers are
 /// invalid for all non-zero-sized accesses.
-pub struct Pointer<Provenance> {
+pub struct DataPointer<Provenance> {
     pub addr: Address,
     pub provenance: Option<Provenance>,
 }
 
-impl<Provenance> Pointer<Provenance> {
+// This naming of "data pointer" as the part without metadata is used in the docs at:
+// <https://doc.rust-lang.org/std/primitive.pointer.html>.
+// An alternative might be calling it `MemPointer`.
+// I believe it is more consistent to call the whole thing `Pointer`, rather than just the data part,
+// as this is how most of Rusts references are written (ignoring any metadata fields).
+
+/// A "pointer" is the data pointer with optionally some metadata.
+/// Corresponds to the rust primitive "pointer", as well as references and boxes.
+pub struct Pointer<Provenance> {
+    pub data_pointer: DataPointer<Provenance>,
+    pub metadata: Option<PointerMeta>
+}
+
+impl<Provenance> DataPointer<Provenance> {
     /// Offsets a pointer in bytes using wrapping arithmetic.
     /// This does not check whether the pointer is still in-bounds of its allocation.
     pub fn wrapping_offset<T: Target>(self, offset: Int) -> Self {
         let addr = self.addr + offset;
         let addr = addr.bring_in_bounds(Unsigned, T::PTR_SIZE);
-        Pointer { addr, ..self }
+        DataPointer { addr, ..self }
     }
+}
+```
+
+```rust
+// This doesn't make a lot of sense in this file, maybe rather values.md.
+// (Similarly the PtrType is only used for retagging in mem.rs, and it felt out of place when reading ?)
+enum PointerMeta {
+    ElementCount(Size),
+    // TODO
+    VTable
 }
 ```
 

--- a/spec/mem/pointer.md
+++ b/spec/mem/pointer.md
@@ -98,7 +98,7 @@ impl SizeStrategy {
     pub fn unwrap_size(self) -> Size {
         match self {
             SizeStrategy::Sized(size) => size,
-            _ => panic!("Expected a sized type"),
+            _ => panic!("unwrap_size called with unsized type"),
         }
     }
 

--- a/spec/prelude/main.md
+++ b/spec/prelude/main.md
@@ -35,6 +35,7 @@ pub enum TerminationInfo {
 
 /// Some macros for convenient yeeting, i.e., return an error from a
 /// `Option`/`Result`-returning function.
+#[macro_export]
 macro_rules! throw {
     ($($tt:tt)*) => {
         do yeet ()

--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -183,7 +183,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 let ty = place.ty(&self.body, self.tcx).ty;
                 let drop_in_place_fn = rs::Instance::resolve_drop_in_place(self.tcx, ty);
                 let place = self.translate_place(place, span);
-                let ptr_to_drop = build::addr_of(place, build::raw_ptr_ty());
+                let ptr_to_drop = build::addr_of(place, build::raw_void_ptr_ty());
 
                 Terminator::Call {
                     callee: build::fn_ptr(self.cx.get_fn_name(drop_in_place_fn)),

--- a/tooling/minimize/src/chunks.rs
+++ b/tooling/minimize/src/chunks.rs
@@ -59,7 +59,7 @@ fn mark_used_bytes(ty: Type, markers: &mut [bool]) {
         Type::Array { elem, count } => {
             let elem = elem.extract();
             for i in Int::ZERO..count {
-                let offset = i * elem.size::<DefaultTarget>();
+                let offset = i * elem.size::<DefaultTarget>().unwrap_size();
                 let offset = offset.bytes().try_to_usize().unwrap();
                 mark_used_bytes(elem, &mut markers[offset..]);
             }

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -98,10 +98,13 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 ValueExpr::AddrOf { target, ptr_ty }
             }
             smir::Rvalue::AddressOf(_mutbl, place) => {
+                let ty = place.ty(&self.locals_smir).unwrap();
+                let pointee = self.layout_of_smir(ty);
+
                 let place = self.translate_place_smir(place, span);
                 let target = GcCow::new(place);
 
-                let ptr_ty = PtrType::Raw;
+                let ptr_ty = PtrType::Raw { pointee };
 
                 ValueExpr::AddrOf { target, ptr_ty }
             }

--- a/tooling/minimize/src/ty.rs
+++ b/tooling/minimize/src/ty.rs
@@ -8,7 +8,7 @@ impl<'tcx> Ctxt<'tcx> {
         let align = translate_align(layout.align().abi);
         let inhabited = !layout.abi().is_uninhabited();
 
-        Layout { size, align, inhabited }
+        Layout { size: SizeStrategy::Sized(size), align, inhabited }
     }
 
     pub fn layout_of_smir(&self, ty: smir::Ty) -> Layout {
@@ -75,8 +75,8 @@ impl<'tcx> Ctxt<'tcx> {
                 Type::Ptr(PtrType::Ref { pointee, mutbl })
             }
             rs::TyKind::RawPtr(ty, _mutbl) => {
-                let _pointee = self.layout_of(*ty); // just to make sure that we can translate this type
-                Type::Ptr(PtrType::Raw)
+                let pointee = self.layout_of(*ty); // just to make sure that we can translate this type
+                Type::Ptr(PtrType::Raw { pointee })
             }
             rs::TyKind::Array(ty, c) => {
                 let count = Int::from(c.eval_target_usize(self.tcx, rs::ParamEnv::reveal_all()));

--- a/tooling/minitest/src/tests/atomic.rs
+++ b/tooling/minitest/src/tests/atomic.rs
@@ -4,7 +4,7 @@ use crate::*;
 fn atomic_store_success() {
     let locals = [<u32>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     // We show that atomic store actually writes by writing 1 to local(0)
 
@@ -49,14 +49,14 @@ fn atomic_store_arg_type1() {
 
     let f = function(Ret::No, 0, &[], &[b0, b1]);
     let p = program(&[f]);
-    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicStore` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicStore` intrinsic: not a thin pointer")
 }
 
 #[test]
 fn atomic_store_arg_type_pow() {
     let locals = [<[u8; 3]>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let arr =
         array(&[const_int::<u8>(0), const_int::<u8>(1), const_int::<u8>(69)], <u8>::get_type());
 
@@ -84,7 +84,7 @@ fn atomic_store_arg_type_pow() {
 fn atomic_store_arg_type_size() {
     let locals = [<[u64; 2]>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let arr = array(&[const_int::<u64>(0), const_int::<u64>(1)], <u64>::get_type());
 
     let b0 = block!(
@@ -107,7 +107,7 @@ fn atomic_store_arg_type_size() {
 fn atomic_store_ret_type() {
     let locals = [<u64>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -129,7 +129,7 @@ fn atomic_store_ret_type() {
 fn atomic_load_success() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     // We show that atomic load actually reads by reading 1 from local(1).
     let b0 = block!(
@@ -184,14 +184,14 @@ fn atomic_load_arg_type() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicLoad` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicLoad` intrinsic: not a thin pointer")
 }
 
 #[test]
 fn atomic_load_ret_type_pow() {
     let locals = [<()>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(storage_live(0), atomic_load(local(0), addr_of(local(0), ptr_ty), 1));
     let b1 = block!(exit());
@@ -209,7 +209,7 @@ fn atomic_load_ret_type_pow() {
 fn atomic_load_ret_type_size() {
     let locals = [<[u64; 2]>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(storage_live(0), atomic_load(local(0), addr_of(local(0), ptr_ty), 1));
     let b1 = block!(exit());

--- a/tooling/minitest/src/tests/atomic_fetch.rs
+++ b/tooling/minitest/src/tests/atomic_fetch.rs
@@ -4,7 +4,7 @@ use crate::*;
 fn atomic_fetch_success() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -66,7 +66,7 @@ fn atomic_fetch_arg_1() {
 
     assert_ub::<BasicMem>(
         p,
-        "invalid first argument to `AtomicFetchAndOp` intrinsic: not a pointer",
+        "invalid first argument to `AtomicFetchAndOp` intrinsic: not a thin pointer",
     );
 }
 
@@ -74,7 +74,7 @@ fn atomic_fetch_arg_1() {
 fn atomic_fetch_arg_2() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -97,7 +97,7 @@ fn atomic_fetch_arg_2() {
 fn atomic_fetch_ret_ty() {
     let locals = [<[u8; 3]>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type());
 
@@ -122,7 +122,7 @@ fn atomic_fetch_ret_ty() {
 fn atomic_fetch_int_size() {
     let locals = [<u128>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -142,7 +142,7 @@ fn atomic_fetch_int_size() {
 fn atomic_fetch_op() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/compare_exchange.rs
+++ b/tooling/minitest/src/tests/compare_exchange.rs
@@ -4,7 +4,7 @@ use crate::*;
 fn compare_exchange_success() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let addr0 = addr_of(local(0), ptr_ty);
 
@@ -52,7 +52,7 @@ fn compare_exchange_success() {
 fn compare_exchange_arg_count() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(
@@ -93,7 +93,7 @@ fn compare_exchange_arg_1_value() {
     let p = program(&[f]);
     assert_ub::<BasicMem>(
         p,
-        "invalid first argument to `AtomicCompareExchange` intrinsic: not a pointer",
+        "invalid first argument to `AtomicCompareExchange` intrinsic: not a thin pointer",
     );
 }
 
@@ -101,7 +101,7 @@ fn compare_exchange_arg_1_value() {
 fn compare_exchange_ret_type() {
     let locals = [<[u8; 3]>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
     let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type());
 
@@ -125,7 +125,7 @@ fn compare_exchange_ret_type() {
 fn compare_exchange_arg_1_type() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(
@@ -148,7 +148,7 @@ fn compare_exchange_arg_1_type() {
 fn compare_exchange_arg_2_type() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(
@@ -171,7 +171,7 @@ fn compare_exchange_arg_2_type() {
 fn compare_exchange_arg_size_max() {
     let locals = [<u128>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(

--- a/tooling/minitest/src/tests/data_race.rs
+++ b/tooling/minitest/src/tests/data_race.rs
@@ -10,7 +10,7 @@ struct AccessPattern(AccessType, Atomicity);
 // A block that does the access pattern on global(0): stores put the value of the "support global"
 // into global(0); loads pit the value of global(0) into the "support global".
 fn access_block(access: AccessPattern, support_global: u32, next: u32) -> BasicBlock {
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr = addr_of(global::<u32>(0), ptr_ty);
     match access {
         AccessPattern(AccessType::Load, Atomicity::Atomic) => {

--- a/tooling/minitest/src/tests/heap_intrinsics.rs
+++ b/tooling/minitest/src/tests/heap_intrinsics.rs
@@ -254,7 +254,7 @@ fn dealloc_wrongarg1() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub::<BasicMem>(p, "invalid first argument to `Deallocate` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(p, "invalid first argument to `Deallocate` intrinsic: not a thin pointer");
 }
 
 #[test]

--- a/tooling/minitest/src/tests/ill_formed.rs
+++ b/tooling/minitest/src/tests/ill_formed.rs
@@ -26,7 +26,7 @@ fn too_large_local() {
     let stmts = &[];
 
     let prog = small_program(locals, stmts);
-    assert_ill_formed::<BasicMem>(prog, "Type: size not valid");
+    assert_ill_formed::<BasicMem>(prog, "SizeStrategy: size not valid");
 }
 
 #[test]

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod ptr_offset;
 mod ptr_offset_from;
 mod raw_eq;
 mod return_;
+mod size_of_val;
 mod slice;
 mod spawn_join;
 mod switch;

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod ptr_offset;
 mod ptr_offset_from;
 mod raw_eq;
 mod return_;
+mod slice;
 mod spawn_join;
 mod switch;
 mod too_large_alloc;

--- a/tooling/minitest/src/tests/raw_eq.rs
+++ b/tooling/minitest/src/tests/raw_eq.rs
@@ -8,7 +8,7 @@ fn true_raw_eq() {
     let left = f.declare_local::<[u8; 2]>();
     let right = f.declare_local::<[u8; 2]>();
 
-    let pointee = layout(size(2), align(1));
+    let pointee = layout(sized_size(2), align(1));
     let ptr_ty = ref_ty(pointee);
 
     let left_ptr = addr_of(left, ptr_ty);
@@ -39,7 +39,7 @@ fn false_raw_eq() {
     let left = f.declare_local::<[u8; 2]>();
     let right = f.declare_local::<[u8; 2]>();
 
-    let pointee = layout(size(2), align(1));
+    let pointee = layout(sized_size(2), align(1));
     let ptr_ty = ref_ty(pointee);
 
     let left_ptr = addr_of(left, ptr_ty);
@@ -74,7 +74,7 @@ fn uninit_raw_eq() {
     f.storage_live(left);
     f.storage_live(right);
 
-    let pointee = layout(size(2), align(1));
+    let pointee = layout(sized_size(2), align(1));
     let ptr_ty = ref_ty(pointee);
 
     let left_ptr = addr_of(left, ptr_ty);
@@ -96,7 +96,7 @@ fn provenance_raw_eq() {
     let left = f.declare_local::<[*const i64; 2]>();
     let right = f.declare_local::<[*const i64; 2]>();
 
-    let pointee = layout(size(2), align(1));
+    let pointee = layout(sized_size(2), align(1));
     let ptr_ty = ref_ty(pointee);
 
     let left_ptr = addr_of(left, ptr_ty);
@@ -127,7 +127,7 @@ fn raw_ptr_raw_eq() {
     let left = f.declare_local::<[u8; 2]>();
     let right = f.declare_local::<[u8; 2]>();
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let left_ptr = addr_of(left, ptr_ty);
     let right_ptr = addr_of(right, ptr_ty);
@@ -152,7 +152,7 @@ fn invalid_ret_ty_raw_eq() {
     let left = f.declare_local::<[u8; 2]>();
     let right = f.declare_local::<[u8; 2]>();
 
-    let pointee = layout(size(2), align(1));
+    let pointee = layout(sized_size(2), align(1));
     let ptr_ty = ref_ty(pointee);
 
     let left_ptr = addr_of(left, ptr_ty);
@@ -178,10 +178,10 @@ fn unequal_args_ty_raw_eq() {
     let left = f.declare_local::<[u8; 2]>();
     let right = f.declare_local::<[u8; 3]>(); // not the same type as `left`
 
-    let l_pointee = layout(size(2), align(1));
+    let l_pointee = layout(sized_size(2), align(1));
     let l_ptr_ty = ref_ty(l_pointee);
 
-    let r_pointee = layout(size(3), align(1));
+    let r_pointee = layout(sized_size(3), align(1));
     let r_ptr_ty = ref_ty(r_pointee);
 
     let left_ptr = addr_of(left, l_ptr_ty);

--- a/tooling/minitest/src/tests/size_of_val.rs
+++ b/tooling/minitest/src/tests/size_of_val.rs
@@ -1,0 +1,225 @@
+use crate::*;
+use miniutil::DefaultTarget;
+use tests::slice::ref_as_slice;
+
+/// Tests size_of_val works with all kinds of different pointer types
+#[test]
+fn different_ptr_types() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+
+        fn for_ptr_ty<F: Fn(Layout) -> Type>(f: &mut FunctionBuilder, reff: F) {
+            let i = f.declare_local::<u32>();
+            f.storage_live(i);
+            f.assume(eq(size_of_val(addr_of(i, reff(<u32>::get_layout()))), const_int(4_usize)));
+        }
+
+        for_ptr_ty(&mut f, ref_ty);
+        for_ptr_ty(&mut f, ref_mut_ty);
+        for_ptr_ty(&mut f, raw_ptr_ty);
+        for_ptr_ty(&mut f, box_ty);
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests size_of_val for integers
+#[test]
+fn size_of_ints() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+
+        assume_size_of_ty_conv::<u8>(&mut f, 1);
+        assume_size_of_ty_conv::<i8>(&mut f, 1);
+        assume_size_of_ty_conv::<u16>(&mut f, 2);
+        assume_size_of_ty_conv::<i16>(&mut f, 2);
+        assume_size_of_ty_conv::<u32>(&mut f, 4);
+        assume_size_of_ty_conv::<i32>(&mut f, 4);
+        assume_size_of_ty_conv::<u64>(&mut f, 8);
+        assume_size_of_ty_conv::<i64>(&mut f, 8);
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests size_of_val for pointers
+#[test]
+fn size_of_ptr() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+
+        assume_size_of_ty_conv::<&u8>(&mut f, 8);
+        assume_size_of_ty_conv::<&bool>(&mut f, 8);
+        assume_size_of_ty_conv::<&()>(&mut f, 8);
+        assume_size_of_ty_conv::<&[u8]>(&mut f, 16);
+        assume_size_of_ty_conv::<&[u8; 2]>(&mut f, 8);
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests size_of_val for zero sized types
+#[test]
+fn size_of_zst() {
+    let mut p = ProgramBuilder::new();
+
+    let dummy_f = {
+        let mut f = p.declare_function();
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let f = {
+        let mut f = p.declare_function();
+
+        assume_size_of_ty(&mut f, 0, <()>::get_type());
+        assume_size_of_ty(&mut f, 0, <[u32; 0]>::get_type());
+
+        // function "values" are zero sized
+        let dummy_p = f.declare_local_with_ty(Type::Ptr(PtrType::FnPtr));
+        f.storage_live(dummy_p);
+        f.assign(dummy_p, fn_ptr(dummy_f));
+        f.assume(eq(size_of_val(load(dummy_p)), const_int(0_usize)));
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests size_of_val for tuple types
+#[test]
+fn size_of_struct() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        assume_size_of_ty(
+            &mut f,
+            16,
+            tuple_ty(
+                &[(size(0), <u64>::get_type()), (size(8), <u32>::get_type())],
+                size(16),
+                align(8),
+            ),
+        );
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests size_of_val for a simple enum type
+#[test]
+fn size_of_enum() {
+    let mut p = ProgramBuilder::new();
+
+    // copied from `enum_representation::simple_two_variant_works`
+    let simple_enum_ty = {
+        let bool_var_ty = enum_variant(Type::Bool, &[]);
+        let empty_var_data_ty = tuple_ty(&[], size(1), align(1)); // unit with size 1
+        let u8_inttype = IntType { signed: Signedness::Unsigned, size: Size::from_bytes_const(1) };
+        let empty_var_ty = enum_variant(empty_var_data_ty, &[(offset(0), (u8_inttype, 2.into()))]);
+        let discriminator = discriminator_branch::<u8>(
+            offset(0),
+            discriminator_invalid(),
+            &[
+                ((0, 1), discriminator_known(0)),
+                ((1, 2), discriminator_known(0)),
+                ((2, 3), discriminator_known(1)),
+            ],
+        );
+        enum_ty::<u8>(&[(0, bool_var_ty), (1, empty_var_ty)], discriminator, size(1), align(1))
+    };
+
+    let f = {
+        let mut f = p.declare_function();
+        assume_size_of_ty(&mut f, 1, simple_enum_ty);
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests size_of_val for slices
+#[test]
+fn size_of_slice() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+
+        // Make arrays, get slice pointers to them and get their size
+        let arr = f.declare_local::<[u32; 3]>();
+        f.storage_live(arr);
+        let slice_ptr = ref_as_slice::<u32>(&mut f, arr, 3);
+        f.print(size_of_val(load(slice_ptr)));
+
+        let arr = f.declare_local::<[u32; 0]>();
+        f.storage_live(arr);
+        let slice_ptr = ref_as_slice::<u32>(&mut f, arr, 0);
+        f.print(size_of_val(load(slice_ptr)));
+
+        let arr = f.declare_local::<[u8; 312]>();
+        f.storage_live(arr);
+        let slice_ptr = ref_as_slice::<u8>(&mut f, arr, 312);
+        f.print(size_of_val(load(slice_ptr)));
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_eq!(get_stdout::<BasicMem>(p).unwrap(), &["12", "0", "312"]);
+}
+
+/// Tests size_of_val only works with pointers
+#[test]
+fn ill_non_ptr() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        f.assume(eq(size_of_val(const_int(8_u64)), const_int(8_usize)));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "UnOp::SizeOfVal invalid operand");
+}
+
+fn assume_size_of_ty(f: &mut FunctionBuilder, size: usize, ty: Type) {
+    let i = f.declare_local_with_ty(ty);
+    f.storage_live(i);
+    f.assume(eq(size_of_val(addr_of(i, ref_ty(ty.layout::<DefaultTarget>()))), const_int(size)));
+}
+
+fn assume_size_of_ty_conv<T: TypeConv>(f: &mut FunctionBuilder, size: usize) {
+    assume_size_of_ty(f, size, T::get_type());
+}

--- a/tooling/minitest/src/tests/slice.rs
+++ b/tooling/minitest/src/tests/slice.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use std::{u32, u8};
 
 /// Tests that slices can occur behind different pointer types
 #[test]
@@ -180,14 +179,14 @@ fn invalid_index_ub() {
     for_index(2);
 }
 
-fn make_slice_ptr_tuple<T: TypeConv>() -> Type {
-    tuple_ty(&[(size(0), <*mut T>::get_type()), (size(8), <u64>::get_type())], size(16), align(1))
-}
-
-fn ref_as_slice<T: TypeConv>(f: &mut FunctionBuilder, arr: PlaceExpr, known_len: u64) -> PlaceExpr {
+pub fn ref_as_slice<T: TypeConv>(
+    f: &mut FunctionBuilder,
+    arr: PlaceExpr,
+    known_len: u64,
+) -> PlaceExpr {
     // construct fake wide ptr
     let arr_ref = addr_of(arr, raw_ptr_ty(T::get_layout()));
-    let fake_ptr = f.declare_local_with_ty(make_slice_ptr_tuple::<T>());
+    let fake_ptr = f.declare_local_with_ty(slice_ptr_tuple_ty::<T>());
     f.storage_live(fake_ptr);
     f.assign(field(fake_ptr, 0), arr_ref);
     f.assign(field(fake_ptr, 1), const_int(known_len));

--- a/tooling/minitest/src/tests/slice.rs
+++ b/tooling/minitest/src/tests/slice.rs
@@ -1,0 +1,98 @@
+use crate::*;
+use std::{u32, u8};
+
+/// Tests that slices can occur behind different pointer types
+#[test]
+fn slice_ref_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let _f = {
+        let mut f = p.declare_function();
+        let _var = f.declare_local::<&[u32]>();
+        let _ret = f.declare_ret::<&mut [u8]>();
+        let _arg = f.declare_arg::<*const [[[u8; 3]; 2]]>();
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let main = {
+        let mut main = p.declare_function();
+        main.exit();
+        p.finish_function(main)
+    };
+
+    let p = p.finish_program(main);
+    dump_program(p);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests that an index operation is well formed
+#[test]
+fn index_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let _f = {
+        let mut f = p.declare_function();
+        let slice = f.declare_arg::<&[u32]>();
+        let var = f.declare_local::<u32>();
+        f.storage_live(var);
+        let elem_place = index(deref(load(slice), <[u32]>::get_type()), const_int(2));
+        f.assign(elem_place, const_int(42_u32));
+        f.assign(var, load(elem_place));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let main = {
+        let mut main = p.declare_function();
+        main.exit();
+        p.finish_function(main)
+    };
+
+    let p = p.finish_program(main);
+    dump_program(p);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests that a wide pointer can be transmuted from a `(&T, usize)`.
+#[test]
+fn wide_pointer_transmute() {
+    fn make_slice_ptr_tuple<T: TypeConv>() -> Type {
+        tuple_ty(&[(size(0), <&T>::get_type()), (size(8), <u64>::get_type())], size(16), align(1))
+    }
+
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        // Make array
+        let arr = f.declare_local::<[u32; 3]>();
+        f.storage_live(arr);
+        f.assign(index(arr, const_int(0)), const_int(42_u32));
+        f.assign(index(arr, const_int(1)), const_int(43_u32));
+        f.assign(index(arr, const_int(2)), const_int(44_u32));
+        // construct fake wide ptr
+        let arr_ref = addr_of(arr, ref_ty(<u32>::get_layout()));
+        let fake_ptr = f.declare_local_with_ty(make_slice_ptr_tuple::<u32>());
+        f.storage_live(fake_ptr);
+        f.assign(field(fake_ptr, 0), arr_ref);
+        f.assign(field(fake_ptr, 1), const_int(3_u64));
+        f.validate(fake_ptr, false);
+        // transmute into slice ref
+        let slice = f.declare_local::<&[u32]>();
+        f.storage_live(slice);
+        f.assign(slice, transmute(load(fake_ptr), <&[u32]>::get_type()));
+        f.validate(slice, false);
+        // Print slice[2]
+        let loaded_val = load(index(deref(load(slice), <[u32]>::get_type()), const_int(1)));
+        f.print(loaded_val);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    dump_program(p);
+    assert_eq!(get_stdout::<BasicMem>(p).unwrap(), &["43"]);
+}
+
+// TODO: ill formed tests & UB

--- a/tooling/minitest/src/tests/slice.rs
+++ b/tooling/minitest/src/tests/slice.rs
@@ -22,7 +22,6 @@ fn slice_ref_wf() {
     };
 
     let p = p.finish_program(main);
-    dump_program(p);
     assert_stop::<BasicMem>(p);
 }
 
@@ -50,17 +49,87 @@ fn index_wf() {
     };
 
     let p = p.finish_program(main);
-    dump_program(p);
     assert_stop::<BasicMem>(p);
 }
 
-/// Tests that a wide pointer can be transmuted from a `(&T, usize)`.
+/// Asserts that the slice element type must be sized
 #[test]
-fn wide_pointer_transmute() {
-    fn make_slice_ptr_tuple<T: TypeConv>() -> Type {
-        tuple_ty(&[(size(0), <&T>::get_type()), (size(8), <u64>::get_type())], size(16), align(1))
-    }
+fn slice_ref_unsized_elem_not_wf() {
+    let mut p = ProgramBuilder::new();
 
+    let f = {
+        let mut f = p.declare_function();
+        let var = f.declare_local_with_ty(ref_ty(<[u32]>::get_layout()));
+        f.storage_live(var);
+        let slice_place = deref(load(var), slice_ty(slice_ty(<u32>::get_type())));
+        f.validate(slice_place, false);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "Type::Slice: unsized element type");
+}
+
+#[test]
+fn local_not_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        // ill formed:
+        f.declare_local_with_ty(slice_ty(<u32>::get_type()));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "Function: unsized local variable");
+}
+
+#[test]
+fn load_not_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let var = f.declare_local_with_ty(ref_ty(<[u32]>::get_layout()));
+        f.storage_live(var);
+        let slice_place = deref(load(var), <[u32]>::get_type());
+        // ill formed load: (also ill formed print, but need some way to use the valueexpr)
+        f.print(load(slice_place));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "ValueExpr::Load: unsized value type");
+}
+
+#[test]
+fn transmute_not_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let arr = f.declare_local::<[u32; 1]>();
+        f.storage_live(arr);
+        f.assign(index(arr, const_int(0)), const_int(42_u32));
+        // ill formed transmute:
+        let slice = transmute(load(arr), <[u32]>::get_type());
+        // (also ill formed print, but need some way to use the valueexpr)
+        f.print(slice);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "Cast::Transmute: unsized target type");
+}
+
+/// Tests that a wide pointer can be transmuted from a `(*T, usize)`.
+#[test]
+fn index_with_transmuted() {
     let mut p = ProgramBuilder::new();
 
     let f = {
@@ -71,28 +140,62 @@ fn wide_pointer_transmute() {
         f.assign(index(arr, const_int(0)), const_int(42_u32));
         f.assign(index(arr, const_int(1)), const_int(43_u32));
         f.assign(index(arr, const_int(2)), const_int(44_u32));
-        // construct fake wide ptr
-        let arr_ref = addr_of(arr, ref_ty(<u32>::get_layout()));
-        let fake_ptr = f.declare_local_with_ty(make_slice_ptr_tuple::<u32>());
-        f.storage_live(fake_ptr);
-        f.assign(field(fake_ptr, 0), arr_ref);
-        f.assign(field(fake_ptr, 1), const_int(3_u64));
-        f.validate(fake_ptr, false);
-        // transmute into slice ref
-        let slice = f.declare_local::<&[u32]>();
-        f.storage_live(slice);
-        f.assign(slice, transmute(load(fake_ptr), <&[u32]>::get_type()));
-        f.validate(slice, false);
-        // Print slice[2]
-        let loaded_val = load(index(deref(load(slice), <[u32]>::get_type()), const_int(1)));
+        let slice_ptr = ref_as_slice::<u32>(&mut f, arr, 3);
+        // Print slice[1]
+        let loaded_val = load(index(deref(load(slice_ptr), <[u32]>::get_type()), const_int(1)));
         f.print(loaded_val);
         f.exit();
         p.finish_function(f)
     };
 
     let p = p.finish_program(f);
-    dump_program(p);
     assert_eq!(get_stdout::<BasicMem>(p).unwrap(), &["43"]);
 }
 
-// TODO: ill formed tests & UB
+/// Tests that indexing into a slice throws UB for invalid indices
+#[test]
+fn invalid_index_ub() {
+    fn for_index(idx: isize) {
+        let mut p = ProgramBuilder::new();
+        let f = {
+            let mut f = p.declare_function();
+            // Make array
+            let arr = f.declare_local::<[u32; 2]>();
+            f.storage_live(arr);
+            f.assign(index(arr, const_int(0)), const_int(42_u32));
+            f.assign(index(arr, const_int(1)), const_int(43_u32));
+            let slice_ptr = ref_as_slice::<u32>(&mut f, arr, 2);
+            // This should UB
+            let loaded_val =
+                load(index(deref(load(slice_ptr), <[u32]>::get_type()), const_int(idx)));
+            f.print(loaded_val);
+            f.exit();
+            p.finish_function(f)
+        };
+        let p = p.finish_program(f);
+        assert_ub::<BasicMem>(p, "out-of-bounds slice access");
+    }
+
+    for_index(-1);
+    for_index(2);
+}
+
+fn make_slice_ptr_tuple<T: TypeConv>() -> Type {
+    tuple_ty(&[(size(0), <*mut T>::get_type()), (size(8), <u64>::get_type())], size(16), align(1))
+}
+
+fn ref_as_slice<T: TypeConv>(f: &mut FunctionBuilder, arr: PlaceExpr, known_len: u64) -> PlaceExpr {
+    // construct fake wide ptr
+    let arr_ref = addr_of(arr, raw_ptr_ty(T::get_layout()));
+    let fake_ptr = f.declare_local_with_ty(make_slice_ptr_tuple::<T>());
+    f.storage_live(fake_ptr);
+    f.assign(field(fake_ptr, 0), arr_ref);
+    f.assign(field(fake_ptr, 1), const_int(known_len));
+    f.validate(fake_ptr, false); // Bad for ZST ?
+    // transmute into slice ref
+    let slice = f.declare_local::<&[T]>();
+    f.storage_live(slice);
+    f.assign(slice, transmute(load(fake_ptr), <&[T]>::get_type()));
+    f.validate(slice, false);
+    slice
+}

--- a/tooling/minitest/src/tests/spawn_join.rs
+++ b/tooling/minitest/src/tests/spawn_join.rs
@@ -38,7 +38,7 @@ fn thread_spawn_spurious_race() {
     let pp_ptype = <*const *const ()>::get_type(); // Pointer pointer place type.
     let locals = [pp_ptype, <u32>::get_type()];
 
-    let size = const_int_typed::<usize>(<*const ()>::get_size().bytes());
+    let size = const_int_typed::<usize>(<*const ()>::get_size().unwrap_size().bytes());
     let align = const_int_typed::<usize>(<*const ()>::get_align().bytes());
 
     let b0 = block!(storage_live(0), allocate(size, align, local(0), 1));

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -74,6 +74,10 @@ pub fn int_cast<T: TypeConv>(v: ValueExpr) -> ValueExpr {
     ValueExpr::UnOp { operator: UnOp::Cast(CastOp::IntToInt(t)), operand: GcCow::new(v) }
 }
 
+pub fn size_of_val(v: ValueExpr) -> ValueExpr {
+    ValueExpr::UnOp { operator: UnOp::SizeOfVal, operand: GcCow::new(v) }
+}
+
 pub fn ptr_addr(v: ValueExpr) -> ValueExpr {
     transmute(v, <usize>::get_type())
 }

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -246,7 +246,7 @@ pub fn local(x: u32) -> PlaceExpr {
 
 pub fn global_by_name<T: TypeConv>(name: GlobalName) -> PlaceExpr {
     let relocation = Relocation { name, offset: Size::ZERO };
-    let ptr_type = Type::Ptr(PtrType::Raw);
+    let ptr_type = Type::Ptr(PtrType::Raw { pointee: T::get_layout() });
     deref(ValueExpr::Constant(Constant::GlobalPointer(relocation), ptr_type), T::get_type())
 }
 

--- a/tooling/miniutil/src/build/global.rs
+++ b/tooling/miniutil/src/build/global.rs
@@ -2,7 +2,7 @@ use crate::build::*;
 
 impl ProgramBuilder {
     pub fn declare_global_zero_initialized<T: TypeConv>(&mut self) -> PlaceExpr {
-        let bytes = List::from_elem(Some(0), T::get_size().bytes());
+        let bytes = List::from_elem(Some(0), T::get_size().unwrap_size().bytes());
         let global = Global { bytes, relocations: list!(), align: <T>::get_align() };
         let name = GlobalName(Name::from_internal(self.next_global));
         self.next_global += 1;
@@ -13,14 +13,14 @@ impl ProgramBuilder {
 
 /// Global Int initialized to zero.
 pub fn global_int<T: TypeConv>() -> Global {
-    let bytes = List::from_elem(Some(0), T::get_size().bytes());
+    let bytes = List::from_elem(Some(0), T::get_size().unwrap_size().bytes());
 
     Global { bytes, relocations: list!(), align: T::get_align() }
 }
 
 /// Global pointer
 pub fn global_ptr<T: TypeConv>() -> Global {
-    let bytes = List::from_elem(Some(0), <*const T>::get_size().bytes());
+    let bytes = List::from_elem(Some(0), <*const T>::get_size().unwrap_size().bytes());
 
     Global { bytes, relocations: list!(), align: <*const T>::get_align() }
 }

--- a/tooling/miniutil/src/build/mod.rs
+++ b/tooling/miniutil/src/build/mod.rs
@@ -223,6 +223,10 @@ pub fn size(bytes: impl Into<Int>) -> Size {
     Size::from_bytes(bytes).unwrap()
 }
 
+pub fn sized_size(bytes: impl Into<Int>) -> SizeStrategy {
+    SizeStrategy::Sized(Size::from_bytes(bytes).unwrap())
+}
+
 pub fn offset(bytes: impl Into<Int>) -> Offset {
     size(bytes)
 }

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -1,9 +1,10 @@
 use crate::build::*;
 
-pub fn layout(size: Size, align: Align) -> Layout {
+pub fn layout(size: SizeStrategy, align: Align) -> Layout {
     Layout {
         size,
         align,
+        // FIXME: enums do exist, is this still good?
         inhabited: true, // currently everything is inhabited (enums don't exist yet).
     }
 }
@@ -28,8 +29,13 @@ pub fn box_ty(pointee: Layout) -> Type {
     Type::Ptr(PtrType::Box { pointee })
 }
 
-pub fn raw_ptr_ty() -> Type {
-    Type::Ptr(PtrType::Raw)
+pub fn raw_ptr_ty(pointee: Layout) -> Type {
+    Type::Ptr(PtrType::Raw { pointee })
+}
+
+pub fn raw_void_ptr_ty() -> Type {
+    let pointee = layout(SizeStrategy::Sized(Size::ZERO), Align::ONE);
+    raw_ptr_ty(pointee)
 }
 
 pub fn tuple_ty(f: &[(Offset, Type)], size: Size, align: Align) -> Type {

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -51,6 +51,10 @@ pub fn array_ty(elem: Type, count: impl Into<Int>) -> Type {
     Type::Array { elem: GcCow::new(elem), count: count.into() }
 }
 
+pub fn slice_ty(elem: Type) -> Type {
+    Type::Slice { elem: GcCow::new(elem) }
+}
+
 pub fn enum_variant(ty: Type, tagger: &[(Offset, (IntType, Int))]) -> Variant {
     Variant { ty, tagger: tagger.iter().copied().collect() }
 }

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -38,6 +38,12 @@ pub fn raw_void_ptr_ty() -> Type {
     raw_ptr_ty(pointee)
 }
 
+/// A type `(*mut T, usize)` that is compatible with `*mut [T]`.
+pub fn slice_ptr_tuple_ty<T: TypeConv>() -> Type {
+    assert_eq!(<usize>::get_size().unwrap_size().bytes(), 8, "Assumes 8 byte pointers");
+    tuple_ty(&[(size(0), <*mut T>::get_type()), (size(8), <usize>::get_type())], size(16), align(1))
+}
+
 pub fn tuple_ty(f: &[(Offset, Type)], size: Size, align: Align) -> Type {
     Type::Tuple { fields: f.iter().copied().collect(), size, align }
 }

--- a/tooling/miniutil/src/build/ty_conv.rs
+++ b/tooling/miniutil/src/build/ty_conv.rs
@@ -8,7 +8,7 @@ pub trait TypeConv {
     fn get_type() -> Type;
 
     // Convenience methods, these should not be overridden.
-    fn get_size() -> Size {
+    fn get_size() -> SizeStrategy {
         Self::get_type().size::<DefaultTarget>()
     }
     fn get_align() -> Align {
@@ -48,13 +48,13 @@ type_conv_int_impl!(isize, Signed, DefaultTarget::PTR_SIZE);
 
 impl<T: TypeConv> TypeConv for *const T {
     fn get_type() -> Type {
-        raw_ptr_ty()
+        raw_ptr_ty(T::get_layout())
     }
 }
 
 impl<T: TypeConv> TypeConv for *mut T {
     fn get_type() -> Type {
-        raw_ptr_ty()
+        raw_ptr_ty(T::get_layout())
     }
 }
 

--- a/tooling/miniutil/src/build/ty_conv.rs
+++ b/tooling/miniutil/src/build/ty_conv.rs
@@ -46,25 +46,25 @@ type_conv_int_impl!(i128, Signed, size(16));
 type_conv_int_impl!(usize, Unsigned, DefaultTarget::PTR_SIZE);
 type_conv_int_impl!(isize, Signed, DefaultTarget::PTR_SIZE);
 
-impl<T: TypeConv> TypeConv for *const T {
+impl<T: TypeConv + ?Sized> TypeConv for *const T {
     fn get_type() -> Type {
         raw_ptr_ty(T::get_layout())
     }
 }
 
-impl<T: TypeConv> TypeConv for *mut T {
+impl<T: TypeConv + ?Sized> TypeConv for *mut T {
     fn get_type() -> Type {
         raw_ptr_ty(T::get_layout())
     }
 }
 
-impl<T: TypeConv> TypeConv for &T {
+impl<T: TypeConv + ?Sized> TypeConv for &T {
     fn get_type() -> Type {
         ref_ty(T::get_layout())
     }
 }
 
-impl<T: TypeConv> TypeConv for &mut T {
+impl<T: TypeConv + ?Sized> TypeConv for &mut T {
     fn get_type() -> Type {
         ref_mut_ty(T::get_layout())
     }
@@ -79,6 +79,12 @@ impl TypeConv for bool {
 impl<T: TypeConv, const N: usize> TypeConv for [T; N] {
     fn get_type() -> Type {
         array_ty(T::get_type(), N)
+    }
+}
+
+impl<T: TypeConv> TypeConv for [T] {
+    fn get_type() -> Type {
+        slice_ty(T::get_type())
     }
 }
 

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -150,6 +150,7 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
                     let new_ty = fmt_type(new_ty, comptypes).to_string();
                     FmtExpr::Atomic(format!("transmute<{new_ty}>({operand})"))
                 }
+                UnOp::SizeOfVal => FmtExpr::NonAtomic(format!("size_of_val({operand})")),
             }
         }
         ValueExpr::BinOp { operator: BinOp::Int(int_op), left, right } => {

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -14,6 +14,10 @@ pub(super) fn fmt_type(t: Type, comptypes: &mut Vec<CompType>) -> FmtExpr {
             let elem = fmt_type(elem.extract(), comptypes).to_string();
             FmtExpr::Atomic(format!("[{elem}; {count}]"))
         }
+        Type::Slice { elem } => {
+            let elem = fmt_type(elem.extract(), comptypes).to_string();
+            FmtExpr::Atomic(format!("[{elem}]"))
+        }
     }
 }
 
@@ -52,7 +56,8 @@ pub(super) fn fmt_ptr_type(ptr_ty: PtrType) -> FmtExpr {
 fn fmt_layout(layout: Layout) -> String {
     let size_str = match layout.size {
         SizeStrategy::Sized(size) => format!("{}", size.bytes()),
-        SizeStrategy::SliceTail { min_size, element_size } => format!("{} + {}*len", min_size.bytes(), element_size.bytes()),
+        SizeStrategy::SliceTail { min_size, element_size } =>
+            format!("{} + {}*len", min_size.bytes(), element_size.bytes()),
     };
     let align = layout.align.bytes();
     let uninhab_str = match layout.inhabited {


### PR DESCRIPTION
Hi, this is my currently best idea to change the types and function signatures to allow for unsized types.

Of course it is very incomplete, specr-transpile only gives 74 errors xD.

I have drawn the abstraction of thin/fat pointers between the `typed_load` and `ConcurrentMemory::load` functions.