### PR TITLE
Assign a unique ID to each stack frame

### DIFF
--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -46,7 +46,13 @@ pub struct Machine<M: Memory> {
     stdout: DynWrite,
     /// This is where the `PrintStderr` intrinsic writes to.
     stderr: DynWrite,
+
+    /// Next unused stack frame id.
+    next_frame_id: FrameId
 }
+
+/// Identifier for each stack frame
+struct FrameId(Int);
 
 /// The data that makes up a stack frame.
 struct StackFrame<M: Memory> {
@@ -66,6 +72,9 @@ struct StackFrame<M: Memory> {
     /// If `next_stmt` is equal to the number of statements in this block (an
     /// out-of-bounds index in the statement list), it refers to the terminator.
     next_stmt: Int,
+
+    /// The *unique* identifier for each stack frame
+    id: FrameId,
 }
 
 enum ReturnAction<M: Memory> {
@@ -166,6 +175,7 @@ impl<M: Memory> Machine<M> {
             synchronized_threads: Set::new(),
             stdout,
             stderr,
+            next_frame_id: FrameId(Int::ZERO),
         };
 
         // Create initial thread.

--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -163,8 +163,9 @@ impl<M: Memory> Machine<M> {
         if !ptr_ty.addr_valid(place.ptr.addr) {
             throw_ub!("taking the address of an invalid (null, misaligned, or uninhabited) place");
         }
+        let frame_id = self.cur_frame().id;
         // Let the aliasing model know. (Will also check dereferenceability if appropriate.)
-        let ptr = self.mem.retag_ptr(place.ptr, ptr_ty, /* fn_entry */ false)?;
+        let ptr = self.mem.retag_ptr(place.ptr, ptr_ty, /* fn_entry */ false, frame_id.0)?;
 
         ret((Value::Ptr(ptr), Type::Ptr(ptr_ty)))
     }

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -83,7 +83,8 @@ impl<M: Memory> Machine<M> {
         let (place, ty) = self.eval_place(place)?;
 
         let val = self.mem.place_load(place, ty)?;
-        let val = self.mem.retag_val(val, ty, fn_entry)?;
+        let frame_id = self.cur_frame().id;
+        let val = self.mem.retag_val(val, ty, fn_entry, frame_id)?;
         self.mem.place_store(place, val, ty)?;
 
         ret(())

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -164,6 +164,13 @@ impl<M: Memory> Machine<M> {
         })
     }
 
+    /// Create a new unused ID for the stack frame
+    fn next_frame_id(&mut self) -> FrameId {
+        let id = FrameId(self.next_frame_id.0);
+        self.next_frame_id = FrameId(self.next_frame_id.0 + Int::ONE);
+        id
+    }
+
     /// Creates a stack frame for the given function, initializes the arguments,
     /// and ensures that calling convention and argument/return value ABIs are all matching up.
     fn create_frame(
@@ -180,6 +187,7 @@ impl<M: Memory> Machine<M> {
             return_action,
             next_block: func.start,
             next_stmt: Int::ZERO,
+            id: self.next_frame_id(),
         };
 
         // Allocate all the initially live locals.

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -258,6 +258,8 @@ impl<M: Memory> Machine<M> {
             arguments,
         )?;
 
+        self.mem.begin_call(frame.id.0)?;
+
         // Push new stack frame, so it is executed next.
         self.mutate_cur_stack(|stack| stack.push(frame));
         ret(())
@@ -312,6 +314,8 @@ impl<M: Memory> Machine<M> {
         while let Some(local) = frame.locals.keys().next() {
             frame.storage_dead(&mut self.mem, local)?;
         }
+
+        self.mem.end_call(frame.id.0)?;
 
         // Perform the return action.
         match frame.return_action {

--- a/spec/mem/concurrent.md
+++ b/spec/mem/concurrent.md
@@ -98,8 +98,8 @@ impl<M: Memory> ConcurrentMemory<M> {
     }
 
     /// Return the retagged pointer.
-    pub fn retag_ptr(&mut self, ptr: Pointer<M::Provenance>, ptr_type: PtrType, fn_entry: bool) -> Result<Pointer<M::Provenance>> {
-        self.memory.retag_ptr(ptr, ptr_type, fn_entry)
+    pub fn retag_ptr(&mut self, ptr: Pointer<M::Provenance>, ptr_type: PtrType, fn_entry: bool, call_id: CallId) -> Result<Pointer<M::Provenance>> {
+        self.memory.retag_ptr(ptr, ptr_type, fn_entry, call_id)
     }
 
     /// Check if there are any memory leaks.

--- a/spec/mem/concurrent.md
+++ b/spec/mem/concurrent.md
@@ -102,6 +102,16 @@ impl<M: Memory> ConcurrentMemory<M> {
         self.memory.retag_ptr(ptr, ptr_type, fn_entry, call_id)
     }
 
+    /// Memory model hook inserted at the beginning of each function call.
+    pub fn begin_call(&mut self, call_id: CallId) -> Result {
+        self.memory.begin_call(call_id)
+    }
+
+    /// Memory model hook inserted at the end of each function call.
+    pub fn end_call(&mut self, call_id: CallId) -> Result {
+        self.memory.end_call(call_id)
+    }
+
     /// Check if there are any memory leaks.
     pub fn leak_check(&self) -> Result {
         self.memory.leak_check()

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -124,11 +124,11 @@ pub trait Memory {
         ret(ptr)
     }
 
-    /// Memory model inserted at the beginning of each function call.
-    fn begin_call(&mut self) -> Result { ret(()) }
+    /// Memory model hook inserted at the beginning of each function call.
+    fn begin_call(&mut self, _call_id: CallId) -> Result { ret(()) }
 
     /// Memory model hook inserted at the end of each function call.
-    fn end_call(&mut self) -> Result { ret(()) }
+    fn end_call(&mut self, _call_id: CallId) -> Result { ret(()) }
 
     /// Check if there are any memory leaks.
     fn leak_check(&self) -> Result;

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -59,6 +59,9 @@ pub enum AllocationKind {
     Function,
 }
 
+/// The ID of each function call (i.e stack frame)
+type CallId = Int;
+
 /// *Note*: All memory operations can be non-deterministic, which means that
 /// executing the same operation on the same memory can have different results.
 /// We also let read operations potentially mutate memory (they actually can
@@ -114,12 +117,18 @@ pub trait Memory {
     // (IOW, it cannot be more defined than the default implementation).
     ///
     /// Return the retagged pointer.
-    fn retag_ptr(&mut self, ptr: Pointer<Self::Provenance>, ptr_type: PtrType, _fn_entry: bool) -> Result<Pointer<Self::Provenance>> {
+    fn retag_ptr(&mut self, ptr: Pointer<Self::Provenance>, ptr_type: PtrType, _fn_entry: bool, _call_id: CallId) -> Result<Pointer<Self::Provenance>> {
         if let Some(layout) = ptr_type.safe_pointee() {
             self.dereferenceable(ptr, layout.size)?;
         }
         ret(ptr)
     }
+
+    /// Memory model inserted at the beginning of each function call.
+    fn begin_call(&mut self) -> Result { ret(()) }
+
+    /// Memory model hook inserted at the end of each function call.
+    fn end_call(&mut self) -> Result { ret(()) }
 
     /// Check if there are any memory leaks.
     fn leak_check(&self) -> Result;


### PR DESCRIPTION
This patch assigns a unique ID to each stack frame and passes the ID to memory models. 
Furthermore, it adds two hook methods to the memory model interface, allowing for call-specific operations at the beginning and end of each function call.
