### PR TITLE
Tree Borrows without protector (Path Provenance)

### DIFF
--- a/spec/mem/basic.md
+++ b/spec/mem/basic.md
@@ -23,9 +23,9 @@ impl<T: Target> Memory for BasicMemory<T> {
 The data tracked by the memory is fairly simple: for each allocation, we track its data contents, its absolute integer address in memory, the alignment it was created with (the size is implicit in the length of the contents), and whether it is still alive (or has already been deallocated).
 
 ```rust
-struct Allocation {
+struct Allocation<Provenance, Extra = ()> {
     /// The data stored in this allocation.
-    data: List<AbstractByte<AllocId>>,
+    data: List<AbstractByte<Provenance>>,
     /// The address where this allocation starts.
     /// This is never 0, and `addr + data.len()` fits into a `usize`.
     addr: Address,
@@ -36,14 +36,16 @@ struct Allocation {
     kind: AllocationKind,
     /// Whether this allocation is still live.
     live: bool,
+    /// Additional information needed for the memory model
+    extra: Extra,
 }
 ```
 
 Memory then consists of a map tracking the allocation for each ID, stored as a list (since we assign IDs consecutively).
 
 ```rust
-pub struct BasicMemory<T: Target> {
-    allocations: List<Allocation>,
+pub struct BasicMemory<T: Target, AllocExtra = ()> {
+    allocations: List<Allocation<AllocId, AllocExtra>>,
 
     // FIXME: specr should add this automatically
     _phantom: std::marker::PhantomData<T>,
@@ -63,7 +65,7 @@ impl<T: Target> Memory for BasicMemory<T> {
 We start with some helper operations.
 
 ```rust
-impl Allocation {
+impl<Provenance, Extra> Allocation<Provenance, Extra> {
     fn size(self) -> Size { Size::from_bytes(self.data.len()).unwrap() }
 
     fn overlaps(self, other_addr: Address, other_size: Size) -> bool {
@@ -80,14 +82,64 @@ impl Allocation {
             true
         }
     }
-}
-```
 
-Then we implement creating and removing allocations.
+    /// Check whether deallocating this allocation is valid.
+    fn deallocation_check(self, ptr_addr: Address, kind: AllocationKind, size: Size, align: Align) -> Result {
+        if !self.live {
+            throw_ub!("double-free");
+        }
+        if ptr_addr != self.addr {
+            throw_ub!("deallocating with pointer not to the beginning of its allocation");
+        }
+        if kind != self.kind {
+            throw_ub!("deallocating {:?} memory with {:?} deallocation operation", self.kind, kind);
+        }
+        if size != self.size() {
+            throw_ub!("deallocating with incorrect size information");
+        }
+        if align != self.align {
+            throw_ub!("deallocating with incorrect alignment information");
+        }
 
-```rust
-impl<T: Target> Memory for BasicMemory<T> {
-    fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<Pointer<AllocId>> {
+        ret(())
+    }
+
+    /// Compute relative offset, and ensure we are in-bounds.
+    /// We don't need a null ptr check, we just have an invariant that no allocation
+    /// contains the null address.
+    fn offset_in_alloc(&self, addr: Address, pointee_size: Size) -> Result<Size> {
+        if !self.live {
+            throw_ub!("dereferencing pointer to dead allocation");
+        }
+
+        let offset_in_alloc = addr - self.addr;
+        if offset_in_alloc < 0 || offset_in_alloc + pointee_size.bytes() > self.size().bytes() {
+            throw_ub!("dereferencing pointer outside the bounds of its allocation");
+        }
+
+        ret(Offset::from_bytes(offset_in_alloc).unwrap())
+    }
+
+    fn load(&self, addr: Address, offset: Size, len: Size, align: Align) -> Result<List<AbstractByte<Provenance>>> {
+        if !align.is_aligned(addr) {
+            throw_ub!("load from a misaligned pointer");
+        }
+
+        ret(self.data.subslice_with_length(offset.bytes(), len.bytes()))
+    }
+
+    fn store(&mut self, addr: Address, offset: Size, bytes: List<AbstractByte<Provenance>>, align: Align) -> Result {
+        if !align.is_aligned(addr) {
+            throw_ub!("store to a misaligned pointer");
+        }
+
+        // Slice into the contents, and put the new bytes there.
+        self.data.write_subslice_at_index(offset.bytes(), bytes);
+
+        ret(())
+    }
+
+    fn pick_base_address<T: Target>(allocations: List<Self>, size: Size, align: Align) -> NdResult<Int> {
         // Reject too large allocations. Size must fit in `isize`.
         if !T::valid_size(size) {
             throw_ub!("asking for a too large allocation");
@@ -98,21 +150,48 @@ impl<T: Target> Memory for BasicMemory<T> {
         // which is not what we want.
         let distr = libspecr::IntDistribution {
             start: Int::ONE,
-            end: Int::from(2).pow(Self::T::PTR_SIZE.bits()),
+            end: Int::from(2).pow(T::PTR_SIZE.bits()),
             divisor: align.bytes(),
         };
+
         let addr = pick(distr, |addr: Address| {
             // Pick a strictly positive integer...
             if addr <= 0 { return false; }
             // ... that is suitably aligned...
             if !align.is_aligned(addr) { return false; }
             // ... such that addr+size is in-bounds of a `usize`...
-            if !(addr+size.bytes()).in_bounds(Unsigned, Self::T::PTR_SIZE) { return false; }
+            if !(addr+size.bytes()).in_bounds(Unsigned, T::PTR_SIZE) { return false; }
             // ... and it does not overlap with any existing live allocation.
-            if self.allocations.any(|a| a.live && a.overlaps(addr, size)) { return false; }
+            if allocations.any(|a| a.live && a.overlaps(addr, size)) { return false; }
             // If all tests pass, we are good!
             true
         })?;
+
+        ret(addr)
+    }
+
+    fn leak_check(allocations: List<Allocation<Provenance, Extra>>) -> Result {
+        for allocation in allocations {
+            if allocation.live {
+                match allocation.kind {
+                    // These should all be gone.
+                    AllocationKind::Heap => throw_memory_leak!(),
+                    // These we can still have at the end.
+                    AllocationKind::Global | AllocationKind::Function | AllocationKind::Stack => {}
+                }
+            }
+        }
+        ret(())
+    }
+}
+```
+
+Then we implement creating and removing allocations.
+
+```rust
+impl<T: Target> Memory for BasicMemory<T> {
+    fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<Pointer<AllocId>> {
+        let addr = Allocation::pick_base_address::<T>(self.allocations, size, align)?;
 
         // Compute allocation.
         let allocation = Allocation {
@@ -121,6 +200,7 @@ impl<T: Target> Memory for BasicMemory<T> {
             kind,
             live: true,
             data: list![AbstractByte::Uninit; size.bytes()],
+            extra: (),
         };
 
         // Insert it into list, and remember where.
@@ -138,22 +218,7 @@ impl<T: Target> Memory for BasicMemory<T> {
         // This lookup will definitely work, since AllocId cannot be faked.
         let allocation = self.allocations[id.0];
 
-        // Check a bunch of things.
-        if !allocation.live {
-            throw_ub!("double-free");
-        }
-        if ptr.addr != allocation.addr {
-            throw_ub!("deallocating with pointer not to the beginning of its allocation");
-        }
-        if kind != allocation.kind {
-            throw_ub!("deallocating {:?} memory with {:?} deallocation operation", allocation.kind, kind);
-        }
-        if size != allocation.size() {
-            throw_ub!("deallocating with incorrect size information");
-        }
-        if align != allocation.align {
-            throw_ub!("deallocating with incorrect alignment information");
-        }
+        allocation.deallocation_check(ptr.addr, kind, size, align)?;
 
         // Mark it as dead. That's it.
         self.allocations.mutate_at(id.0, |allocation| {
@@ -188,49 +253,32 @@ impl<T: Target> BasicMemory<T> {
         };
         let allocation = self.allocations[id.0];
 
-        if !allocation.live {
-            throw_ub!("dereferencing pointer to dead allocation");
-        }
+        // Compute relative offset
+        let offset = allocation.offset_in_alloc(ptr.addr, len)?;
 
-        // Compute relative offset, and ensure we are in-bounds.
-        // We don't need a null ptr check, we just have an invariant that no allocation
-        // contains the null address.
-        let offset_in_alloc = ptr.addr - allocation.addr;
-        if offset_in_alloc < 0 || offset_in_alloc + len.bytes() > allocation.size().bytes() {
-            throw_ub!("dereferencing pointer outside the bounds of its allocation");
-        }
         // All is good!
-        ret(Some((id, Offset::from_bytes(offset_in_alloc).unwrap())))
+        ret(Some((id, offset)))
     }
 }
 
 impl<T: Target> Memory for BasicMemory<T> {
     fn load(&mut self, ptr: Pointer<AllocId>, len: Size, align: Align) -> Result<List<AbstractByte<AllocId>>> {
-        if !align.is_aligned(ptr.addr) {
-            throw_ub!("load from a misaligned pointer");
-        }
         let Some((id, offset)) = self.check_ptr(ptr, len)? else {
             return ret(list![]);
         };
         let allocation = &self.allocations[id.0];
-
-        // Slice into the contents, and copy them to a new list.
-        ret(allocation.data.subslice_with_length(offset.bytes(), len.bytes()))
+        allocation.load(ptr.addr, offset, len, align)
     }
 
     fn store(&mut self, ptr: Pointer<Self::Provenance>, bytes: List<AbstractByte<Self::Provenance>>, align: Align) -> Result {
-        if !align.is_aligned(ptr.addr) {
-            throw_ub!("store to a misaligned pointer");
-        }
         let size = Size::from_bytes(bytes.len()).unwrap();
         let Some((id, offset)) = self.check_ptr(ptr, size)? else {
             return ret(());
         };
 
-        // Slice into the contents, and put the new bytes there.
         self.allocations.mutate_at(id.0, |allocation| {
-            allocation.data.write_subslice_at_index(offset.bytes(), bytes);
-        });
+            allocation.store(ptr.addr, offset, bytes, align)
+        })?;
 
         ret(())
     }
@@ -248,17 +296,7 @@ Stack allocations are fine; they get automatically cleaned up when a function re
 ```rust
 impl<T: Target> Memory for BasicMemory<T> {
     fn leak_check(&self) -> Result {
-        for allocation in self.allocations {
-            if allocation.live {
-                match allocation.kind {
-                    // These should all be gone.
-                    AllocationKind::Heap => throw_memory_leak!(),
-                    // These we can still have at the end.
-                    AllocationKind::Global | AllocationKind::Function | AllocationKind::Stack => {}
-                }
-            }
-        }
-        ret(())
+        Allocation::leak_check(self.allocations)
     }
 }
 ```

--- a/spec/mem/tree_borrows/memory.md
+++ b/spec/mem/tree_borrows/memory.md
@@ -1,0 +1,290 @@
+# MiniRust Tree Borrows
+
+For background on Tree Borrows, see:
+
+1. [Neven's posts on Tree Borrows](https://perso.crans.org/vanille/treebor)
+2. [From Stacks to Trees: A new aliasing model for Rust](https://www.ralfj.de/blog/2023/06/02/tree-borrows.html)
+
+Similar to the [Basic Memory Model](../basic.md), we need to first define some basic data structures:
+the core date structure managing the tree is defined in [tree.md](tree.md), and the core state machine can be found in [state_machine.md](state_machine.md).
+
+The model then tracks a tree for each allocation:
+```rust
+struct TreeBorrowsAllocationExtra {
+    root: Node,
+}
+```
+
+We use a *path* to identify each node and track its location in the tree. A path is represented as a list of indices $[i_1, i_2, ..., i_k]$, where each index indicates which branch to take next.
+Below is an illustrated example:
+```
+Consider the following tree
+      A
+     / \
+    B   C
+   / \   \
+  D  E    F
+The path from A to A is represented as [].
+The path from A to B is represented as [0]
+The path from A to C is represented as [1].
+The path from A to D is represented as [0, 0].
+The path from A to E is represented as [0, 1].
+The path from A to F is represented as [1, 1].
+```
+
+```rust
+/// The index of a child in the list of child nodes.
+type ChildId = Int;
+/// A path from the root of a tree to some node inside the tree.
+type Path = List<ChildId>;
+```
+
+Then we can define the provenance of Tree Borrows as a pair consisting of the path and the allocation ID.
+
+```rust
+type TreeBorrowsProvenance = (AllocId, Path);
+type TreeBorrowsAllocation = Allocation<TreeBorrowsProvenance, TreeBorrowsAllocationExtra>;
+```
+
+
+```rust
+pub struct TreeBorrowsMemory<T: Target> {
+    allocations: List<TreeBorrowsAllocation>,
+    // FIXME: specr should add this automatically
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    type Provenance = TreeBorrowsProvenance;
+    type T = T;
+
+    fn new() -> Self {
+        Self { allocations: List::new(), _phantom: std::marker::PhantomData }
+    }
+}
+```
+
+Here we define some helper methods to implement the memory interface.
+
+```rust
+impl<T: Target> TreeBorrowsMemory<T> {
+    /// create a location state list for an allocation:
+    /// all locations inside the permission have the given permission.
+    fn init_location_states(permission: Permission, alloc_size: Size) -> List<LocationState> {
+        let mut location_states = List::new();
+        for _ in Int::ZERO..alloc_size.bytes() {
+            location_states.push(LocationState {
+                accessed: Accessed::No,
+                permission,
+            });
+        }
+
+        location_states
+    }
+
+    /// Create a new node for a pointer (reborrow)
+    fn reborrow(
+        &mut self, 
+        ptr: Pointer<TreeBorrowsProvenance>,
+        pointee_size: Size,
+        permission: Permission
+    ) -> Result<Pointer<TreeBorrowsProvenance>> {
+        let Some((alloc_id, parent_path, offset)) = self.check_ptr(ptr, pointee_size)? else {
+            return ret(ptr);
+        };
+
+        let child_path = self.allocations.mutate_at(alloc_id.0, |allocation| {
+            // Create the new child node
+            let child_node = Node {
+                children: List::new(),
+                location_states: Self::init_location_states(permission, allocation.size()),
+            };
+
+            // Add the new node to the tree
+            let child_path = allocation.extra.root.add_node(parent_path, child_node)?;
+
+            // Perform read on the new child, updating all nodes accordingly.
+            allocation.extra.root.access(Some(child_path), AccessKind::Read, offset, pointee_size)?;
+
+            ret::<Result<Path>>(child_path)
+        })?;
+
+        // Create the child pointer and return it 
+        ret(Pointer {
+            provenance: Some((alloc_id, child_path)),
+            ..ptr
+        })
+    }
+
+
+    /// Return the borrow tag, allocation ID and offset
+    fn check_ptr(&self, ptr: Pointer<TreeBorrowsProvenance>, len: Size) -> Result<Option<(AllocId, Path, Size)>> {
+        // For zero-sized accesses, there is nothing to check.
+        // (Provenance monotonicity says that if we allow zero-sized accesses
+        // for `None` provenance we have to allow it for all provenance.)
+        if len.is_zero() {
+            return ret(None);
+        }
+        // We do not even have to check for null, since no allocation will ever contain that address.
+        // Now try to access the allocation information.
+        let Some((alloc_id, path)) = ptr.provenance else {
+            // An invalid pointer.
+            throw_ub!("dereferencing pointer without provenance");
+        };
+        let allocation = self.allocations[alloc_id.0];
+
+        // Compute relative offset
+        let offset = allocation.offset_in_alloc(ptr.addr, len)?;
+
+        // All is good!
+        ret(Some((alloc_id, path, offset)))
+    }
+}
+```
+
+# Memory Operations
+Then we implement the memory model interface for the Tree Borrow.
+
+### Allocate and Deallocate
+
+We create a new tree for one allocation
+
+```rust
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<Pointer<Self::Provenance>>  {
+        let addr = Allocation::pick_base_address::<T>(self.allocations, size, align)?;
+
+        // Calculate the proverance for the root node.
+        let alloc_id = AllocId(self.allocations.len());
+
+        // Create the root node for the tree.
+        // Initially, we set the permission as `Active`.
+        let root = Node {
+            children: List::new(),
+            location_states: Self::init_location_states(Permission::Active, size),
+        };
+
+        // Path to the root node
+        let path = List::new();
+
+        let allocation = Allocation {
+            addr,
+            align,
+            kind,
+            live: true,
+            data: list![AbstractByte::Uninit; size.bytes()],
+            extra: TreeBorrowsAllocationExtra { root },
+        };
+
+        self.allocations.push(allocation);
+
+        ret(Pointer { addr, provenance: Some((alloc_id, path)) })
+    }
+}
+
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    fn deallocate(&mut self, ptr: Pointer<Self::Provenance>, kind: AllocationKind, size: Size, align: Align) -> Result {
+        let Some((alloc_id, path)) = ptr.provenance else {
+            throw_ub!("deallocating invalid pointer")
+        };
+        // This lookup will definitely work, since AllocId cannot be faked.
+        let mut allocation = self.allocations[alloc_id.0];
+
+        allocation.deallocation_check(ptr.addr, kind, size, align)?;
+
+        // Check that ptr has the permission to write the entire allocation.
+        allocation.extra.root.access(Some(path), AccessKind::Write, Size::ZERO, size)?;
+
+        // Mark it as dead. That's it.
+        self.allocations.mutate_at(alloc_id.0, |allocation| {
+            allocation.live = false;
+        });
+
+        ret(())
+    }
+}
+```
+
+### Load Operation
+
+```rust
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    fn load(&mut self, ptr: Pointer<Self::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<Self::Provenance>>> {
+       let Some((alloc_id, path, offset)) = self.check_ptr(ptr, len)? else {
+            return ret(list![]);
+        };
+
+        let data = self.allocations.mutate_at(alloc_id.0, |allocation| {
+            // Check for aliasing violations.
+            allocation.extra.root.access(Some(path), AccessKind::Read, offset, len)?;
+
+            // Load the data.
+            allocation.load(ptr.addr, offset, len, align)
+        })?;
+
+        ret(data)
+    }
+}
+```
+
+### Store Operation
+
+```rust
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    fn store(&mut self, ptr: Pointer<Self::Provenance>, bytes: List<AbstractByte<Self::Provenance>>, align: Align) -> Result {
+        let size = Size::from_bytes(bytes.len()).unwrap();
+        let Some((alloc_id, path, offset)) = self.check_ptr(ptr, size)? else {
+            return ret(());
+        };
+
+        self.allocations.mutate_at(alloc_id.0, |allocation| {
+            // Check for aliasing violations.
+            allocation.extra.root.access(Some(path), AccessKind::Write, offset, size)?;
+
+            // Store the data.
+            allocation.store(ptr.addr, offset, bytes, align)
+        })?;
+
+        ret(())
+    }
+}
+```
+
+### Retagging Operation
+
+```rust
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    fn retag_ptr(&mut self, ptr: Pointer<Self::Provenance>, ptr_type: PtrType, _fn_entry: bool) -> Result<Pointer<Self::Provenance>> {
+        match ptr_type {
+            PtrType::Ref { mutbl, pointee } => {
+                let permission = match mutbl {
+                    Mutability::Mutable => Permission::Reserved,
+                    Mutability::Immutable => Permission::Frozen,
+                };
+                self.reborrow(ptr, pointee.size, permission)
+            },
+            PtrType::Box { pointee } => self.reborrow(ptr, pointee.size, Permission::Reserved),
+            _ => ret(ptr),
+        }
+    }
+}
+```
+
+### Checking Operation
+
+```rust
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    fn dereferenceable(&self, ptr: Pointer<Self::Provenance>, len: Size) -> Result {
+        self.check_ptr(ptr, len)?;
+        ret(())
+    }
+}
+```
+
+```rust
+impl<T: Target> Memory for TreeBorrowsMemory<T> {
+    fn leak_check(&self) -> Result {
+        Allocation::leak_check(self.allocations)
+    }
+}
+```

--- a/spec/mem/tree_borrows/state_machine.md
+++ b/spec/mem/tree_borrows/state_machine.md
@@ -1,0 +1,116 @@
+# State Machine for Tree Borrows
+
+The core of Tree Borrows is a state machine for each node and each location.
+
+We first track the *permission* of each node to access each location.
+```rust
+enum Permission {
+    /// Represents a two-phase borrow during its reservation phase
+    Reserved, 
+    /// Represents an activated (written to) mutable reference
+    Active,
+    /// Represents a shared (immutable) reference
+    Frozen,
+    /// Represents a dead reference
+    Disabled,
+}
+```
+
+In addition, we also need to track whether a location has already been accessed with a pointer corresponding to this node.
+
+```rust
+enum Accessed {
+    /// This address has been accessed (read, written, or the initial implicit read upon retag)
+    /// with this borrow tag.
+    Yes,
+    /// This address has not yet been accessed with this borrow tag. We still track how foreign
+    /// accesses affect the current permission so that on the first access, we start in the right state.
+    No,
+}
+```
+
+Then we define the per-location state tracked by Tree Borrows.
+```rust
+struct LocationState {
+    accessed: Accessed,
+    permission: Permission,
+}
+```
+
+Finally, we define the transition table.
+
+```rust
+impl Permission {
+    fn child_read(self) -> Result<Permission> {
+        ret(
+            match self {
+                Permission::Reserved => Permission::Reserved,
+                Permission::Active => Permission::Active,
+                Permission::Frozen => Permission::Frozen,
+                Permission::Disabled => throw_ub!("Tree Borrows: reading from the child of a pointer with Disabled permission"),
+            }
+        )
+    }
+
+    fn child_write(self) -> Result<Permission> {
+        match self {
+            Permission::Reserved => ret(Permission::Active),
+            Permission::Active => ret(Permission::Active),
+            Permission::Frozen => throw_ub!("Tree Borrows: writing to the child of a pointer with Frozen permission"),
+            Permission::Disabled => throw_ub!("Tree Borrows: writing to the child of a pointer with Disabled permission"),
+        }
+    }
+
+    fn foreign_read(self) -> Result<Permission> {
+        ret(
+            match self {
+                Permission::Reserved => Permission::Reserved,
+                Permission::Active => Permission::Frozen,
+                Permission::Frozen => Permission::Frozen,
+                Permission::Disabled => Permission::Disabled,
+            }
+        )
+    }
+
+    // FIXME: consider interior mutability
+    fn foreign_write(self) -> Result<Permission> {
+        ret(Permission::Disabled)
+    }
+
+    fn transition(
+        self,
+        access_kind: AccessKind,
+        node_relation: NodeRelation,
+    ) -> Result<Permission> {
+        match (node_relation, access_kind) {
+            (NodeRelation::Foreign, AccessKind::Write) => self.foreign_write(),
+            (NodeRelation::Foreign, AccessKind::Read) => self.foreign_read(),
+            (NodeRelation::Child, AccessKind::Read) => self.child_read(),
+            (NodeRelation::Child, AccessKind::Write) => self.child_write(),
+        }
+    }
+}
+
+impl Accessed {
+    fn transition(self, node_relation: NodeRelation) -> Accessed {
+        // A node is "accessed" once any of its children gets accessed.
+        match node_relation {
+            NodeRelation::Foreign => self,
+            NodeRelation::Child => Accessed::Yes,
+        }
+    }
+
+}
+
+impl LocationState {
+    fn transition(
+        &mut self,
+        access_kind: AccessKind,
+        node_relation: NodeRelation,
+    ) -> Result {
+        self.permission = self.permission.transition(access_kind, node_relation)?;
+        self.accessed = self.accessed.transition(node_relation);
+        ret(())
+    }
+}
+```

--- a/spec/mem/tree_borrows/tree.md
+++ b/spec/mem/tree_borrows/tree.md
@@ -1,0 +1,134 @@
+# Tree Structure in Tree Borrows
+
+The core data structure of Tree Borrows is a *tree*, with a state machine in each node.
+We use a tree to track reborrows in each allocation; each reborrow adds a new node to the tree.
+The per-node state machine is defined in [state_machine.md](state_machine.md).
+
+Structurally, we use the usual function representation of a tree: we store a list of children.
+
+```rust
+struct Node {
+    children: List<Node>,
+    /// State for each location
+    location_states: List<LocationState>,
+}
+```
+
+During each memory access, we update states according to the state machine.
+When a node is accessed, each node in the tree can be divided into two disjoint sets: *child nodes* and *foreign nodes*, based on its relative position to the accessed node.
+The *child* set includes the node itself and all its descendants, while the *foreign* set contains all other nodes.
+
+```rust
+enum NodeRelation {
+    Child, 
+    Foreign,
+}
+```
+
+The state transition depends on both the node relation and the type of access operation.
+
+```rust
+enum AccessKind {
+    Read, 
+    Write,
+}
+```
+
+Then we implement how to actually update and check states in a Tree during each memory access.
+
+```rust
+impl Node {
+    /// Perform state transition on all locations of `self`.
+    /// The `node_relation` indicates whether the accessed node is a child or foreign
+    /// *from the perspective of `self`*.
+    fn transition(
+        &mut self, 
+        node_relation: NodeRelation,
+        access_kind: AccessKind,
+        offset_in_alloc: Size,
+        size: Size
+    ) -> Result {
+        let offset_start = offset_in_alloc.bytes();
+        for offset in offset_start..offset_start + size.bytes() {
+            self.location_states.mutate_at(offset, |location_state|{
+                location_state.transition(access_kind, node_relation)
+            })?;
+        }
+
+        ret(())
+    }
+
+    /// Recusively do state transition on `self` node and all its descendants.
+    /// `path` is the path from `self` to the accessed node.
+    /// `path` is None when the accessed node is not a descendant of `self`.
+    ///
+    /// This method will throw UBs, representing the undefined behavior captured by Tree Borrows.
+    fn access(
+        &mut self,
+        path: Option<Path>, // self -> child
+        access_kind: AccessKind,
+        offset_in_alloc: Size,
+        size: Size,
+    ) -> Result {
+        // Indicates whether the accessed node is a child or foreign
+        // *from the perspective of `self`*.
+        //
+        // If `self` is an ancestor of the accessed node, the accessed node is a child of `self`.
+        // Otherwise, the accessed node is a `foreign` of `self`.
+        let node_relation = if path.is_some() { NodeRelation::Child } else { NodeRelation::Foreign };
+
+        // Perform state transition on `self`.
+        self.transition(node_relation, access_kind, offset_in_alloc, size)?;
+
+        for child_id in Int::ZERO..self.children.len() {
+            // If the path starts with this child, do a child access with the path shortened by the first element.
+            // Otherwise, do a child access with the path being None (i.e., child is not an ancestor of accessed node)
+            let sub_path = match path.and_then(|p| p.split_first()) {
+                Some((head, tail)) if head == child_id => Some(tail),
+                _ => None,
+            };
+
+            self.children.mutate_at(child_id, |child| {
+                child.access(sub_path, access_kind, offset_in_alloc, size)
+            })?;
+        }
+
+        ret(())
+    }
+}
+```
+
+We also implement some helper methods for manipulating Trees.
+
+```rust
+impl Node {
+    /// Add a new child node to the tree whose root is self
+    /// `path` is the path from `self` to the parent of the `node`.
+    ///
+    /// Return the path from `self` to the `node`
+    fn add_node(&mut self, parent_path: Path, child: Node) -> Result<Path> {
+        // `sub_root_id` indicates which node to access next; call it the sub-root.
+        // `sub_path` is the path from the sub-root to the child
+        let Some((sub_root_id, sub_path)) = parent_path.split_first() else {
+            // If this is where we want to insert, we are done.
+            let child_idx = self.children.len();
+            self.children.push(child);
+            return ret(list![child_idx]);
+        };
+
+        // If `self` is a leaf and the path keeps going, then the path is invalid.
+        if self.children.len() == Int::ZERO {
+            panic!("Node::add_node: invalid parent path");
+        }
+
+        // Find the right child, and add the node there.
+        self.children.mutate_at(sub_root_id, |sub_root| {
+            let mut child_path = sub_root.add_node(sub_path, child)?;
+            // We got a path from `sub_root` to the new child; update it to start at `self`.
+            child_path.push_front(sub_root_id);
+            ret(child_path)
+        })
+    }
+
+}
+```

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Fixed specr-transpile version
-SPECR_VERSION="0.1.29"
+SPECR_VERSION="0.1.30"
 
 # Stricter checks on CI
 if [ -n "$CI" ]; then

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -359,9 +359,9 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libspecr"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251155824410ff2a50f17b2869cf837f98529c3f409fb72198e67e5fcfc5bf88"
+checksum = "e70d0ae6675beecfaa140b8c4a5450926c1f9daa8bbf7be8eeb9768d2f5f2ad6"
 dependencies = [
  "gccompat-derive",
  "im",

--- a/tooling/minimize/tests/pass/tree_borrows/sb_fails.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/sb_fails.rs
@@ -1,0 +1,68 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// The tests were taken from Miri Tree Borrows 
+// https://github.com/rust-lang/miri/blob/6680b2fa09496b60c40c6ce09449f46efbf253d5/tests/pass/tree_borrows/sb_fails.rs
+// FIXME: Some tests in the original test suite are not currently supported by MiniRust 
+// Missing tests:
+// static_memory_modification
+// interior_mut_reborrow
+
+mod fnentry_invalidation {
+    // Copied directly from fail/stacked_borrows/fnentry_invalidation.rs
+    // Version that fails TB: fail/tree_borrows/fnentry_invalidation.rs
+    pub fn main() {
+        let mut x = 0i32;
+        let z = &mut x as *mut i32;
+        x.do_bad();
+        unsafe {
+            let _oof = *z;
+            // In SB this is an error, but in TB the mutable reborrow did
+            // not invalidate z for reading.
+        }
+    }
+
+    trait Bad {
+        fn do_bad(&mut self) {
+            // who knows
+        }
+    }
+
+    impl Bad for i32 {}
+}
+
+mod pass_invalid_mut {
+    // Copied directly from fail/stacked_borrows/pass_invalid_mut.rs
+    // Version that fails TB: fail/tree_borrows/pass_invalid_mut.rs
+    fn foo(_: &mut i32) {}
+
+    pub fn main() {
+        let x = &mut 42;
+        let xraw = x as *mut _;
+        let xref = unsafe { &mut *xraw };
+        let _val = unsafe { *xraw }; // In SB this invalidates xref...
+        foo(xref); // ...which then cannot be reborrowed here.
+        // But in TB xref is Reserved and thus still writeable.
+    }
+}
+
+mod return_invalid_mut {
+    // Copied directly from fail/stacked_borrows/return_invalid_mut.rs
+    // Version that fails TB: fail/tree_borrows/return_invalid_mut.rs
+    fn foo(x: &mut (i32, i32)) -> &mut i32 {
+        let xraw = x as *mut (i32, i32);
+        let ret = unsafe { &mut (*xraw).1 };
+        let _val = unsafe { *xraw }; // In SB this invalidates ret...
+        ret // ...which then cannot be reborrowed here.
+        // But in TB ret is Reserved and thus still writeable.
+    }
+
+    pub fn main() {
+        foo(&mut (1, 2));
+    }
+}
+
+fn main() {
+    fnentry_invalidation::main();
+    pass_invalid_mut::main();
+    return_invalid_mut::main();
+}

--- a/tooling/minimize/tests/pass/tree_borrows/tree_borrows.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/tree_borrows.rs
@@ -1,0 +1,272 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// The tests were taken from Miri Tree Borrows 
+// https://github.com/rust-lang/miri/blob/6680b2fa09496b60c40c6ce09449f46efbf253d5/tests/pass/tree_borrows/tree-borrows.rs
+// FIXME: Some tests in the original test suite are not currently supported by MiniRust 
+// Missing tests:
+// string_as_mut_ptr
+// disjoint_mutable_subborrows
+// raw_ref_to_part
+// wide_raw_ptr_in_tuple
+// not_unpin_not_protected
+
+include!("../../helper/transmute.rs");
+use std::ptr;
+
+fn main() {
+    aliasing_read_only_mutable_refs();
+    two_mut_protected_same_alloc();
+    direct_mut_to_const_raw();
+    local_addr_of_mut();
+    returned_mut_is_usable();
+    read_does_not_invalidate1();
+    read_does_not_invalidate2();
+    mut_raw_then_mut_shr();
+    mut_shr_then_mut_raw();
+    mut_raw_mut();
+    partially_invalidate_mut();
+    two_raw();
+    shr_and_raw();
+    array_casts();
+    mut_below_shr();
+    write_does_not_invalidate_all_aliases();
+    array_overlapping_read_read();
+}
+
+
+// Tree Borrows has no issue with several mutable references existing
+// at the same time, as long as they are used only immutably.
+// I.e. multiple Reserved can coexist.
+fn aliasing_read_only_mutable_refs() {
+    unsafe {
+        let base = &mut 42u64;
+        let r1 = &mut *(base as *mut u64);
+        let r2 = &mut *(base as *mut u64);
+        let _l = *r1;
+        let _l = *r2;
+    }
+}
+
+// This function checks that there is no issue with having two mutable references
+// from the same allocation both under a protector.
+// This is safe code, it must absolutely not be UB.
+// This test failing is a symptom of forgetting to check that only initialized
+// locations can cause protector UB.
+fn two_mut_protected_same_alloc() {
+    fn write_second(_x: &mut u8, y: &mut u8) {
+        // write through `y` will make some locations of `x` (protected)
+        // become Disabled. Those locations are outside of the range on which
+        // `x` is initialized, and the protector must not trigger.
+        *y = 1;
+    }
+
+    let mut data = (0u8, 1u8);
+    write_second(&mut data.0, &mut data.1);
+    assert!(data.1 == 1)
+}
+
+fn direct_mut_to_const_raw() {
+    let x = &mut 0;
+    let y: *const i32 = x;
+    unsafe {
+        *(y as *mut i32) = 1;
+    }
+    assert!(*x == 1);
+}
+
+#[allow(unused_assignments)]
+fn local_addr_of_mut() {
+    let mut local = 0;
+    let ptr = ptr::addr_of_mut!(local);
+    // In SB, `local` and `*ptr` would have different tags, but in TB they have the same tag.
+    local = 1;
+    unsafe { *ptr = 2 };
+    local = 3;
+    unsafe { *ptr = 4 };
+}
+
+// This checks that a reborrowed mutable reference returned from a function
+// is actually writeable.
+// The fact that this is not obvious is due to the addition of
+// implicit reads on function exit that might freeze the return value.
+fn returned_mut_is_usable() {
+    fn reborrow(x: &mut u8) -> &mut u8 {
+        let y = &mut *x;
+        // Activate the reference so that it is vulnerable to foreign reads.
+        *y = *y;
+        y
+        // An implicit read through `x` is inserted here.
+    }
+    let mut data = 0;
+    let x = &mut data;
+    let y = reborrow(x);
+    *y = 1;
+}
+
+
+fn read_does_not_invalidate1() {
+    fn foo(x: &mut (i32, i32)) -> &i32 {
+        let xraw = x as *mut (i32, i32);
+        let ret = unsafe { &(*xraw).1 };
+        let _val = x.1; // we just read, this does NOT invalidate the reborrows.
+        ret
+    }
+    assert!(*foo(&mut (1, 2)) == 2);
+}
+
+// Same as above, but this time we first create a raw, then read from `&mut`
+// and then freeze from the raw.
+fn read_does_not_invalidate2() {
+    fn foo(x: &mut (i32, i32)) -> &i32 {
+        let xraw = x as *mut (i32, i32);
+        let _val = x.1; // we just read, this does NOT invalidate the raw reborrow.
+        let ret = unsafe { &(*xraw).1 };
+        ret
+    }
+    assert!(*foo(&mut (1, 2)) == 2);
+}
+
+// Escape a mut to raw, then share the same mut and use the share, then the raw.
+// That should work.
+fn mut_raw_then_mut_shr() {
+    let mut x = 2;
+    let xref = &mut x;
+    let xraw = &mut *xref as *mut _;
+    let xshr = &*xref;
+    assert!(*xshr == 2);
+    unsafe {
+        *xraw = 4;
+    }
+    assert!(x == 4);
+}
+
+// Create first a shared reference and then a raw pointer from a `&mut`
+// should permit mutation through that raw pointer.
+fn mut_shr_then_mut_raw() {
+    let xref = &mut 2;
+    let _xshr = &*xref;
+    let xraw = xref as *mut _;
+    unsafe {
+        *xraw = 3;
+    }
+    assert!(*xref == 3);
+}
+
+// Ensure that if we derive from a mut a raw, and then from that a mut,
+// and then read through the original mut, that does not invalidate the raw.
+// This shows that the read-exception for `&mut` applies even if the `Shr` item
+// on the stack is not at the top.
+fn mut_raw_mut() {
+    let mut x = 2;
+    {
+        let xref1 = &mut x;
+        let xraw = xref1 as *mut _;
+        let _xref2 = unsafe { &mut *xraw };
+        let _val = *xref1;
+        unsafe {
+            *xraw = 4;
+        }
+        // we can now use both xraw and xref1, for reading
+        assert!(*xref1 == 4);
+        assert!(unsafe { *xraw } == 4);
+        assert!(*xref1 == 4);
+        assert!(unsafe { *xraw } == 4);
+        // we cannot use xref2; see `compile-fail/stacked-borrows/illegal_read4.rs`
+    }
+    assert!(x == 4);
+}
+
+fn partially_invalidate_mut() {
+    let data = &mut (0u8, 0u8);
+    let reborrow = &mut *data as *mut (u8, u8);
+    let shard = unsafe { &mut (*reborrow).0 };
+    data.1 += 1; // the deref overlaps with `shard`, but that is ok; the access does not overlap.
+    *shard += 1; // so we can still use `shard`.
+    assert!(*data == (1, 1));
+}
+
+
+// Make sure that we can create two raw pointers from a mutable reference and use them both.
+fn two_raw() {
+    unsafe {
+        let x = &mut 0;
+        let y1 = x as *mut _;
+        let y2 = x as *mut _;
+        *y1 += 2;
+        *y2 += 1;
+    }
+}
+
+// Make sure that creating a *mut does not invalidate existing shared references.
+fn shr_and_raw() {
+    unsafe {
+        let x = &mut 0;
+        let y1: &i32 = transmute(&*x); // launder lifetimes
+        let y2 = x as *mut _;
+        let _val = *y1;
+        *y2 += 1;
+    }
+}
+
+
+/// When casting an array reference to a raw element ptr, that should cover the whole array.
+fn array_casts() {
+    let mut x: [u8; 2] = [0, 0];
+    let p = &mut x[0] as *mut u8;
+    unsafe {
+        *p.add(1) = 1;
+    }
+
+    let x: [u8; 2] = [0, 1];
+    let p = &x[0] as *const u8;
+    assert!(unsafe { *p.add(1) } == 1);
+}
+
+/// Transmuting &&i32 to &&mut i32 is fine.
+fn mut_below_shr() {
+    let x = 0;
+    let y = &x;
+    let p = unsafe { transmute::<&&i32, &&mut i32>(&y) };
+    let r = &**p;
+    let _val = *r;
+}
+
+fn write_does_not_invalidate_all_aliases() {
+    // In TB there are other ways to do that (`addr_of!(*x)` has the same tag as `x`),
+    // but let's still make sure this SB test keeps working.
+
+    mod other {
+        /// Some private memory to store stuff in.
+        static mut S: *mut i32 = 0 as *mut i32;
+
+        pub fn lib1(x: &&mut i32) {
+            unsafe {
+                S = (x as *const &mut i32).cast::<*mut i32>().read();
+            }
+        }
+
+        pub fn lib2() {
+            unsafe {
+                *S = 1337;
+            }
+        }
+    }
+
+    let x = &mut 0;
+    other::lib1(&x);
+    *x = 42; // a write to x -- invalidates other pointers?
+    other::lib2();
+    assert!(*x == 1337); // oops, the value changed! I guess not all pointers were invalidated
+}
+
+fn array_overlapping_read_read() {
+    unsafe { 
+        let mut data = [42u8, 57]; 
+        let x = &mut data[0] as *mut u8;
+        let y = &mut data[1] as *mut u8;
+        assert!(*x == 42); 
+        assert!(*y == 57); 
+        assert!(*x.add(1) == 57); 
+        assert!(*y.sub(1) == 42); 
+    }
+}

--- a/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_read_disabled.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_read_disabled.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that a foreign write makes an active mutable reference disabled.
+// After that, reading from this mutable reference is UB.
+
+fn main() {
+    let x = &mut 31; // (x, Reserved)   
+    let xraw = x as *mut i32; // (x, Reserved) 
+    let y = unsafe { &mut *xraw }; // (x, Reserved) -> (y, Reserved)
+    *y = 42; // (x, Active) -> (y, Active)
+
+    unsafe { 
+        *xraw = 57; // (x, Active) -> (y, Disabled)
+        assert!(*xraw == 57); // (x, Active) -> (y, Disabled)
+    } 
+
+    assert!(*y == 31); // UB! Child Read from Disabled.
+}

--- a/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_read_disabled.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_read_disabled.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: reading from the child of a pointer with Disabled permission

--- a/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_disabled.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_disabled.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that a foreign write makes an active mutable reference disabled.
+// After that, writing to this mutable reference is UB.
+
+fn main() {
+    let x = &mut 31; // (x, Reserved)   
+    let xraw = x as *mut i32; // (x, Reserved) 
+    let y = unsafe { &mut *xraw }; // (x, Reserved) -> (y, Reserved)
+    *y = 42; // (x, Active) -> (y, Active)
+
+    unsafe { 
+        *xraw = 57; // (x, Active) -> (y, Disabled)
+        assert!(*xraw == 57); // (x, Active) -> (y, Disabled)
+    } 
+
+    *y = 31; // UB! Child Write to Disabled.
+}

--- a/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_disabled.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_disabled.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: writing to the child of a pointer with Disabled permission

--- a/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_frozen.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_frozen.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that a foreign read makes an active mutable reference frozen.
+// After that, writing to this mutable reference is UB.
+
+fn main() {
+    let x = &mut 31; // (x, Reserved)   
+    let xraw = x as *mut i32; // (x, Reserved) 
+    let y = unsafe { &mut *xraw }; // (x, Reserved) -> (y, Reserved)
+    *y = 42; // (x, Active) -> (y, Active)
+    assert!(unsafe { *xraw } == 42); // (x, Active) -> (y, Frozen)
+
+    assert!(*y == 42); // Child read from Frozen is ok.
+    *y = 31; // UB! Child Write to Frozen.
+}

--- a/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_frozen.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/mutable_ref_child_write_frozen.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: writing to the child of a pointer with Frozen permission

--- a/tooling/minimize/tests/ub/tree_borrows/offset_access_child_read_disabled.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/offset_access_child_read_disabled.rs
@@ -1,0 +1,28 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that a foreign write to a location only disables
+// the active mutable reference for that location.
+// After that, reading from this location via this mutable reference is UB.
+// Other locations are not affected.
+
+fn main() {
+    unsafe {
+        let mut data = [0u8, 1, 2, 3];
+        let x = &mut data[0] as *mut u8; // (x, [R, R, R, R])
+        let y = &mut *x; // (x, [R, R, R, R]) -> (y, [R, R, R, R])
+        let yraw = y as *mut u8;
+        // Using x at offset 1 disables y.
+        *x.add(1) = 42; // (x, [R, A, R, R]) -> (y, [R, D, R, R])
+        // y can still be used for all the other offsets
+        *yraw.add(0) = 42;
+        *yraw.add(2) = 42;
+        *yraw.add(3) = 42;
+
+        assert!(*yraw.add(0) == 42);
+        assert!(*yraw.add(2) == 42);
+        assert!(*yraw.add(3) == 42);
+
+        // UB! The write to x has disabled its child, y.
+        assert!(*yraw.add(1) == 42);
+    }
+}

--- a/tooling/minimize/tests/ub/tree_borrows/offset_access_child_read_disabled.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/offset_access_child_read_disabled.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: reading from the child of a pointer with Disabled permission

--- a/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_disabled.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_disabled.rs
@@ -1,0 +1,28 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that a foreign write to a location only disables
+// the active mutable reference at that offset.
+// After that, writing to this location via this mutable reference is UB.
+// Other locations are not affected.
+
+fn main() {
+    unsafe {
+        let mut data = [0u8, 1, 2, 3];
+        let x = &mut data[0] as *mut u8; // (x, [R, R, R, R])
+        let y = &mut *x; // (x, [R, R, R, R]) -> (y, [R, R, R, R])
+        let yraw = y as *mut u8;
+        // Using x at offset 1 disables y.
+        *x.add(1) = 42; // (x, [R, A, R, R]) -> (y, [R, D, R, R])
+        // y can still be used for all the other offsets
+        *yraw.add(0) = 42;
+        *yraw.add(2) = 42;
+        *yraw.add(3) = 42;
+
+        assert!(*yraw.add(0) == 42);
+        assert!(*yraw.add(2) == 42);
+        assert!(*yraw.add(3) == 42);
+
+        // UB! The write to x has disabled its child, y.
+        *yraw.add(1) = 57;
+    }
+}

--- a/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_disabled.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_disabled.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: writing to the child of a pointer with Disabled permission

--- a/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_frozen.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_frozen.rs
@@ -1,0 +1,30 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that a foreign read from a location only freezes
+// the active mutable reference at that offset.
+// After that, writing to this location via this mutable reference is UB.
+// Other locations are not affected.
+
+fn main() {
+    unsafe {
+        let mut data = [0u8, 1, 2, 3];
+        let x = &mut data[0] as *mut u8; // (x, [R, R, R, R])
+        let y = &mut *x; // (x, [R, R, R, R]) -> (y, [R, R, R, R])
+        let yraw = y as *mut u8;
+        // Using y at offset 1 activate x and y.
+        *yraw.add(1) = 42; // (x, [R, A, R, R]) -> (y, [R, A, R, R])
+        // Using x at offset 1 freezes y.
+        assert!(*x.add(1) == 42); // (x, [R, A, R, R]) -> (y, [R, F, R, R])
+        // y can still be used for all the other offsets
+        *yraw.add(0) = 42;
+        *yraw.add(2) = 42;
+        *yraw.add(3) = 42;
+
+        assert!(*yraw.add(0) == 42);
+        assert!(*yraw.add(2) == 42);
+        assert!(*yraw.add(3) == 42);
+
+        // UB! The read from x has frozen its child, y.
+        *yraw.add(1) = 57;
+    }
+}

--- a/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_frozen.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/offset_access_child_write_frozen.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: writing to the child of a pointer with Frozen permission

--- a/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_read_disabled.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_read_disabled.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that writing to a location via a mutable reference can also
+// make reading from this location via another mutable reference UB.
+
+fn main() {
+    unsafe {
+        let mut data = [42u8, 57]; 
+        let x = &mut data[0] as *mut u8; // (x, [R, R]) 
+        let y = &mut data[1] as *mut u8; // (x, [R, R]) (y, [R, R]) 
+        // Using x disables y at data[0].
+        *x = 42; // (x, [A, R]) (y, [D, R]) 
+        // Using y disables x at data[1].
+        *y = 57; // (x, [A, D]) (y, [D, A])
+
+        // UB! The write to y has disabled x at data[1].
+        assert!(*x.add(1) == 57);
+    }
+}

--- a/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_read_disabled.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_read_disabled.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: reading from the child of a pointer with Disabled permission

--- a/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_write_disabled.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_write_disabled.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that writing to a location via a mutable reference can also
+// make writing to this location via another mutable reference UB.
+
+fn main() {
+    unsafe {
+        let mut data = [42u8, 57]; 
+        let x = &mut data[0] as *mut u8; // (x, [R, R]) 
+        let y = &mut data[1] as *mut u8; // (x, [R, R]) (y, [R, R]) 
+        // Using x disables y at data[0].
+        *x = 42; // (x, [A, R]) (y, [D, R]) 
+        // Using y disables x at data[1].
+        *y = 57; // (x, [A, D]) (y, [D, A])
+
+        // UB! The write to y has disabled x at data[1].
+        *x.add(1) = 57;
+    }
+}

--- a/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_write_disabled.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/overlap_access_child_write_disabled.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: writing to the child of a pointer with Disabled permission

--- a/tooling/minimize/tests/ub/tree_borrows/shared_ref_child_read_disabled.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/shared_ref_child_read_disabled.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that a foreign write makes an frozen shared reference disabled.
+// After that, reading from this shared reference is UB.
+
+fn main() {
+    let x = &mut 31; // (x, Reserved)   
+    let xraw = x as *mut i32; // (x, Reserved) 
+    let y = unsafe { &*xraw }; // (x, Reserved) -> (y, Frozen)
+    
+    unsafe { *xraw = 42; } // (x, Active) -> (y, Disable)
+
+    assert!(*y == 42); // UB! Child read from Disabled
+}

--- a/tooling/minimize/tests/ub/tree_borrows/shared_ref_child_read_disabled.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/shared_ref_child_read_disabled.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: reading from the child of a pointer with Disabled permission

--- a/tooling/miniutil/src/lib.rs
+++ b/tooling/miniutil/src/lib.rs
@@ -24,3 +24,4 @@ pub mod run;
 
 pub type DefaultTarget = x86_64;
 pub type BasicMem = BasicMemory<DefaultTarget>;
+pub type TreeBorrowMem = TreeBorrowsMemory<DefaultTarget>;


### PR DESCRIPTION
An alternative to #213, but use the path as the provenance.