### PR TITLE
Introduce wide and thin pointer distinction

### DIFF
--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -36,8 +36,8 @@ pub struct Machine<M: Memory> {
     /// The Locks
     locks: List<LockState>,
 
-    /// Stores a pointer to each of the global allocations.
-    global_ptrs: Map<GlobalName, Pointer<M::Provenance>>,
+    /// Stores a pointer to each of the global allocations, which are all `Sized`.
+    global_ptrs: Map<GlobalName, ThinPointer<M::Provenance>>,
 
     /// Stores an address for each function name.
     fn_addrs: Map<FnName, mem::Address>,
@@ -54,7 +54,7 @@ struct StackFrame<M: Memory> {
     func: Function,
 
     /// For each live local, the location in memory where its value is stored.
-    locals: Map<LocalName, Pointer<M::Provenance>>,
+    locals: Map<LocalName, ThinPointer<M::Provenance>>,
 
     /// Expresses what happens after the callee (this function) returns.
     return_action: ReturnAction<M>,
@@ -81,7 +81,7 @@ enum ReturnAction<M: Memory> {
         next_block: Option<BbName>,
         /// The location where the caller wants to see the return value.
         /// The caller type already been checked to be suitably compatible with the callee return type.
-        ret_val_ptr: Pointer<M::Provenance>,
+        ret_val_ptr: ThinPointer<M::Provenance>,
     }
 }
 ```

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -25,7 +25,7 @@ impl<M: Memory> ConcurrentMemory<M> {
             throw_ub!("storing to a place based on a misaligned pointer");
         }
         // Alignment was already checked.
-        self.typed_store(place.ptr, val, ty, Align::ONE, Atomicity::None)?;
+        self.typed_store(place.ptr.thin_pointer, val, ty, Align::ONE, Atomicity::None)?;
         ret(())
     }
 }
@@ -77,7 +77,7 @@ impl<M: Memory> Machine<M> {
         // Write the tag directly into memory.
         // This should be fine as we don't allow encoded data and the tag to overlap for valid enum variants.
         let accessor = |offset: Offset, bytes| {
-            let ptr = self.ptr_offset_inbounds(place.ptr, offset.bytes())?;
+            let ptr = self.ptr_offset_inbounds(place.ptr.thin_pointer, offset.bytes())?;
             // We have ensured that the place is aligned, so no alignment requirement here
             self.mem.store(ptr, bytes, Align::ONE, Atomicity::None)
         };
@@ -114,7 +114,7 @@ This statement replaces the contents of a place with `Uninit`.
 
 ```rust
 impl<M: Memory> ConcurrentMemory<M> {
-    fn deinit(&mut self, ptr: Pointer<M::Provenance>, len: Size, align: Align) -> Result {
+    fn deinit(&mut self, ptr: ThinPointer<M::Provenance>, len: Size, align: Align) -> Result {
         self.store(ptr, list![AbstractByte::Uninit; len.bytes()], align, Atomicity::None)?;
         ret(())
     }
@@ -127,7 +127,7 @@ impl<M: Memory> Machine<M> {
             throw_ub!("de-initializing a place based on a misaligned pointer");
         }
         // Alignment was already checked.
-        self.mem.deinit(p.ptr, ty.size::<M::T>(), Align::ONE)?;
+        self.mem.deinit(p.ptr.thin_pointer, ty.size::<M::T>(), Align::ONE)?;
 
         ret(())
     }

--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -137,7 +137,7 @@ impl<M: Memory> Machine<M> {
         // Make the old value unobservable because the callee might work on it in-place.
         // This also checks that the memory is dereferenceable, and crucially ensures we are aligned
         // *at the given type* -- the callee does not care about packed field projections or things like that!
-        self.mem.deinit(place.ptr, ty.size::<M::T>(), ty.align::<M::T>())?;
+        self.mem.deinit(place.ptr.thin_pointer, ty.size::<M::T>(), ty.align::<M::T>())?;
         // FIXME: This also needs aliasing model support.
 
         ret(())
@@ -228,7 +228,7 @@ impl<M: Memory> Machine<M> {
         self.prepare_for_inplace_passing(caller_ret_place, caller_ret_ty)?;
 
         // Then evaluate the function that will be called.
-        let (Value::Ptr(ptr), Type::Ptr(PtrType::FnPtr)) = self.eval_value(callee)? else {
+        let (Value::Ptr(Pointer { thin_pointer: ptr, .. }), Type::Ptr(PtrType::FnPtr)) = self.eval_value(callee)? else {
             panic!("call on a non-pointer")
         };
         let func = self.fn_from_addr(ptr.addr)?;
@@ -241,7 +241,7 @@ impl<M: Memory> Machine<M> {
         // Set up the stack frame.
         let return_action = ReturnAction::ReturnToCaller {
             next_block,
-            ret_val_ptr: caller_ret_place.ptr,
+            ret_val_ptr: caller_ret_place.ptr.thin_pointer,
         };
         let frame = self.create_frame(
             func,

--- a/spec/lang/values.md
+++ b/spec/lang/values.md
@@ -9,7 +9,7 @@ enum Value<M: Memory> {
     Int(Int),
     /// A Boolean value, used for `bool`.
     Bool(bool),
-    /// A pointer value, used for (thin) references and raw pointers.
+    /// A pointer value, used for references and raw pointers.
     Ptr(Pointer<M::Provenance>),
     /// An n-tuple, used for arrays, structs, tuples (including unit).
     Tuple(List<Value<M>>),

--- a/spec/mem/concurrent.md
+++ b/spec/mem/concurrent.md
@@ -51,17 +51,17 @@ impl<M: Memory> ConcurrentMemory<M> {
 
     /// Create a new allocation.
     /// The initial contents of the allocation are `AbstractByte::Uninit`.
-    pub fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<Pointer<M::Provenance>> {
+    pub fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<ThinPointer<M::Provenance>> {
         self.memory.allocate(kind, size, align)
     }
 
     /// Remove an allocation.
-    pub fn deallocate(&mut self, ptr: Pointer<M::Provenance>, kind: AllocationKind, size: Size, align: Align) -> Result {
+    pub fn deallocate(&mut self, ptr: ThinPointer<M::Provenance>, kind: AllocationKind, size: Size, align: Align) -> Result {
         self.memory.deallocate(ptr, kind, size, align)
     }
 
     /// Write some bytes to memory and check for data races.
-    pub fn store(&mut self, ptr: Pointer<M::Provenance>, bytes: List<AbstractByte<M::Provenance>>, align: Align, atomicity: Atomicity) -> Result {
+    pub fn store(&mut self, ptr: ThinPointer<M::Provenance>, bytes: List<AbstractByte<M::Provenance>>, align: Align, atomicity: Atomicity) -> Result {
         let access = Access {
             ty: AccessType::Store,
             atomicity,
@@ -74,7 +74,7 @@ impl<M: Memory> ConcurrentMemory<M> {
     }
 
     /// Read some bytes from memory and check for data races.
-    pub fn load(&mut self, ptr: Pointer<M::Provenance>, len: Size, align: Align, atomicity: Atomicity) -> Result<List<AbstractByte<M::Provenance>>> {
+    pub fn load(&mut self, ptr: ThinPointer<M::Provenance>, len: Size, align: Align, atomicity: Atomicity) -> Result<List<AbstractByte<M::Provenance>>> {
         let access = Access {
             ty: AccessType::Load,
             atomicity,
@@ -88,12 +88,12 @@ impl<M: Memory> ConcurrentMemory<M> {
 
     /// Test whether the given pointer is dereferenceable for the given size.
     /// Raises UB if that is not the case.
-    pub fn dereferenceable(&self, ptr: Pointer<M::Provenance>, len: Size) -> Result {
+    pub fn dereferenceable(&self, ptr: ThinPointer<M::Provenance>, len: Size) -> Result {
         self.memory.dereferenceable(ptr, len)
     }
 
     /// A derived form of `dereferenceable` that works with a signed notion on "length".
-    pub fn signed_dereferenceable(&self, ptr: Pointer<M::Provenance>, len: Int) -> Result {
+    pub fn signed_dereferenceable(&self, ptr: ThinPointer<M::Provenance>, len: Int) -> Result {
         self.memory.signed_dereferenceable(ptr, len)
     }
 

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -81,29 +81,29 @@ pub trait Memory {
     /// The initial contents of the allocation are `AbstractByte::Uninit`.
     ///
     /// This is the only non-deterministic operation in the memory interface.
-    fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<Pointer<Self::Provenance>>;
+    fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<ThinPointer<Self::Provenance>>;
 
     /// Remove an allocation.
-    fn deallocate(&mut self, ptr: Pointer<Self::Provenance>, kind: AllocationKind, size: Size, align: Align) -> Result;
+    fn deallocate(&mut self, ptr: ThinPointer<Self::Provenance>, kind: AllocationKind, size: Size, align: Align) -> Result;
 
     /// Write some bytes to memory.
-    fn store(&mut self, ptr: Pointer<Self::Provenance>, bytes: List<AbstractByte<Self::Provenance>>, align: Align) -> Result;
+    fn store(&mut self, ptr: ThinPointer<Self::Provenance>, bytes: List<AbstractByte<Self::Provenance>>, align: Align) -> Result;
 
     /// Read some bytes from memory.
     ///
     /// Needs `&mut self` because in the aliasing model, reading changes the machine state.
-    fn load(&mut self, ptr: Pointer<Self::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<Self::Provenance>>>;
+    fn load(&mut self, ptr: ThinPointer<Self::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<Self::Provenance>>>;
 
     /// Test whether the given pointer is dereferenceable for the given size.
-    fn dereferenceable(&self, ptr: Pointer<Self::Provenance>, len: Size) -> Result;
+    fn dereferenceable(&self, ptr: ThinPointer<Self::Provenance>, len: Size) -> Result;
 
     /// A derived form of `dereferenceable` that works with a signed notion of "length".
-    fn signed_dereferenceable(&self, ptr: Pointer<Self::Provenance>, len: Int) -> Result {
+    fn signed_dereferenceable(&self, ptr: ThinPointer<Self::Provenance>, len: Int) -> Result {
         if len > 0 {
             self.dereferenceable(ptr, Size::from_bytes(len).unwrap())
         } else {
             // Compute a pointer to the beginning of the range, and check `dereferenceable` from there.
-            let begin_ptr = Pointer { addr: ptr.addr + len, ..ptr };
+            let begin_ptr = ThinPointer { addr: ptr.addr + len, ..ptr };
             // `ptr.addr + len` might be negative, but then `dereferenceable` will surely fail.
             self.dereferenceable(begin_ptr, Size::from_bytes(-len).unwrap())
         }
@@ -125,7 +125,7 @@ pub trait Memory {
         _fn_entry: bool,
     ) -> Result<Pointer<Self::Provenance>> {
         if let Some(layout) = ptr_type.safe_pointee() {
-            self.dereferenceable(ptr, layout.size)?;
+            self.dereferenceable(ptr.thin_pointer, layout.size)?;
         }
         ret(ptr)
     }

--- a/spec/mem/intptrcast.md
+++ b/spec/mem/intptrcast.md
@@ -20,14 +20,14 @@ impl<Provenance> IntPtrCast<Provenance> {
         Self { exposed: Set::new() }
     }
 
-    pub fn expose(&mut self, ptr: Pointer<Provenance>) {
+    pub fn expose(&mut self, ptr: ThinPointer<Provenance>) {
         if let Some(provenance) = ptr.provenance {
             // Remember this provenance as having been exposed.
             self.exposed.insert(provenance);
         }
     }
 
-    pub fn int2ptr(&self, addr: Int) -> NdResult<Pointer<Provenance>> {
+    pub fn int2ptr(&self, addr: Int) -> NdResult<ThinPointer<Provenance>> {
         // Predict a suitable provenance. It must be either `None` or already exposed.
         let provenance = predict(|prov: Option<Provenance>| {
             prov.map_or(
@@ -37,7 +37,7 @@ impl<Provenance> IntPtrCast<Provenance> {
         })?;
 
         // Construct a pointer with that provenance.
-        ret(Pointer { addr, provenance })
+        ret(ThinPointer { addr, provenance })
     }
 }
 ```

--- a/spec/mem/pointer.md
+++ b/spec/mem/pointer.md
@@ -7,11 +7,16 @@ The memory model hence takes the stance that a pointer consists of the *address*
 What exactly [provenance] *is* is up to the memory model.
 As far as the interface is concerned, this is some opaque extra data that we carry around with our pointers and that places restrictions on which pointers may be used to do what when.
 
+On top of this basic concept of a pointer, Rust also knows pointers with metadata (such as `*const [i32]`).
+We therefore use the term *thin pointer* for what has been described above, and *pointer* for a pointer that optionally carries some metadata.
+
 [pointers-complicated]: https://www.ralfj.de/blog/2018/07/24/pointers-and-bytes.html
 [pointers-complicated-2]: https://www.ralfj.de/blog/2020/12/14/provenance.html
 [pointers-complicated-3]: https://www.ralfj.de/blog/2022/04/11/provenance-exposed.html
 [provenance]: https://github.com/rust-lang/unsafe-code-guidelines/blob/master/reference/src/glossary.md#pointer-provenance
 [Stacked Borrows]: https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md
+
+## Pointer Types
 
 ```rust
 /// An "address" is a location in memory. This corresponds to the actual
@@ -20,31 +25,56 @@ As far as the interface is concerned, this is some opaque extra data that we car
 /// of the address space.
 pub type Address = Int;
 
-/// A "pointer" is an address together with its Provenance.
+/// A "thin pointer" is an address together with its Provenance.
 /// Provenance can be absent; those pointers are
 /// invalid for all non-zero-sized accesses.
-pub struct Pointer<Provenance> {
+pub struct ThinPointer<Provenance> {
     pub addr: Address,
     pub provenance: Option<Provenance>,
 }
 
-impl<Provenance> Pointer<Provenance> {
+/// The runtime metadata that can be stored in a wide pointer.
+pub enum PointerMeta {}
+
+/// A "pointer" is the thin pointer with optionally some metadata, making it a wide pointer.
+/// This corresponds to the Rust raw pointer types, as well as references and boxes.
+pub struct Pointer<Provenance> {
+    pub thin_pointer: ThinPointer<Provenance>,
+    pub metadata: Option<PointerMeta>,
+}
+
+/// The statically known kind of metadata stored with a pointer.
+/// This has a one-to-one corresponcence with the variants of `Option<PointerMeta>`
+pub enum PointerMetaKind {
+    None,
+}
+
+impl<Provenance> ThinPointer<Provenance> {
     /// Offsets a pointer in bytes using wrapping arithmetic.
     /// This does not check whether the pointer is still in-bounds of its allocation.
     pub fn wrapping_offset<T: Target>(self, offset: Int) -> Self {
         let addr = self.addr + offset;
         let addr = addr.bring_in_bounds(Unsigned, T::PTR_SIZE);
-        Pointer { addr, ..self }
+        ThinPointer { addr, ..self }
+    }
+
+    pub fn widen(self, metadata: Option<PointerMeta>) -> Pointer<Provenance> {
+        Pointer {
+            thin_pointer: self,
+            metadata,
+        }
     }
 }
 ```
 
+## Pointee
 
 We sometimes need information what it is that a pointer points to, this is captured in a "pointer type".
 
 ```rust
 /// Describes what we know about data behind a pointer.
 pub struct PointeeInfo {
+    pub meta_kind: PointerMetaKind,
     pub size: Size,
     pub align: Align,
     pub inhabited: bool,
@@ -61,7 +91,10 @@ pub enum PtrType {
     Box {
         pointee: PointeeInfo,
     },
-    Raw,
+    Raw {
+        /// Indicates what kind of metadata this pointer carries.
+        meta_kind: PointerMetaKind,
+    },
     FnPtr,
 }
 
@@ -70,7 +103,7 @@ impl PtrType {
     pub fn safe_pointee(self) -> Option<PointeeInfo> {
         match self {
             PtrType::Ref { pointee, .. } | PtrType::Box { pointee, .. } => Some(pointee),
-            PtrType::Raw | PtrType::FnPtr => None,
+            PtrType::Raw { .. } | PtrType::FnPtr => None,
         }
     }
 
@@ -81,6 +114,23 @@ impl PtrType {
             addr != 0 && layout.align.is_aligned(addr) && layout.inhabited
         } else {
             true
+        }
+    }
+
+    pub fn meta_kind(self) -> PointerMetaKind {
+        match self {
+            PtrType::Ref { pointee, .. } | PtrType::Box { pointee, .. } => pointee.meta_kind,
+            PtrType::Raw { meta_kind, .. } => meta_kind,
+            PtrType::FnPtr => PointerMetaKind::None,
+        }
+    }
+}
+
+impl PointerMetaKind {
+    pub fn matches(self, meta: Option<PointerMeta>) -> bool {
+        match (self, meta) {
+            (PointerMetaKind::None, None) => true,
+            _ => false,
         }
     }
 }

--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -187,7 +187,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 let ty = place.ty(&self.body, self.tcx).ty;
                 let drop_in_place_fn = rs::Instance::resolve_drop_in_place(self.tcx, ty);
                 let place = self.translate_place(place, span);
-                let ptr_to_drop = build::addr_of(place, build::raw_ptr_ty());
+                let ptr_to_drop = build::addr_of(place, build::raw_void_ptr_ty());
 
                 Terminator::Call {
                     callee: build::fn_ptr(self.cx.get_fn_name(drop_in_place_fn)),

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -98,10 +98,12 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 ValueExpr::AddrOf { target, ptr_ty }
             }
             smir::Rvalue::AddressOf(_mutbl, place) => {
+                let ty = place.ty(&self.locals_smir).unwrap();
                 let place = self.translate_place_smir(place, span);
                 let target = GcCow::new(place);
+                let meta_kind = self.pointee_info_of_smir(ty).meta_kind;
 
-                let ptr_ty = PtrType::Raw;
+                let ptr_ty = PtrType::Raw { meta_kind };
 
                 ValueExpr::AddrOf { target, ptr_ty }
             }

--- a/tooling/minitest/src/tests/atomic.rs
+++ b/tooling/minitest/src/tests/atomic.rs
@@ -4,7 +4,7 @@ use crate::*;
 fn atomic_store_success() {
     let locals = [<u32>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     // We show that atomic store actually writes by writing 1 to local(0)
 
@@ -49,14 +49,17 @@ fn atomic_store_arg_type1() {
 
     let f = function(Ret::No, 0, &[], &[b0, b1]);
     let p = program(&[f]);
-    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicStore` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(
+        p,
+        "invalid first argument to `AtomicStore` intrinsic: not a thin pointer",
+    )
 }
 
 #[test]
 fn atomic_store_arg_type_pow() {
     let locals = [<[u8; 3]>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let arr =
         array(&[const_int::<u8>(0), const_int::<u8>(1), const_int::<u8>(69)], <u8>::get_type());
 
@@ -84,7 +87,7 @@ fn atomic_store_arg_type_pow() {
 fn atomic_store_arg_type_size() {
     let locals = [<[u64; 2]>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let arr = array(&[const_int::<u64>(0), const_int::<u64>(1)], <u64>::get_type());
 
     let b0 = block!(
@@ -107,7 +110,7 @@ fn atomic_store_arg_type_size() {
 fn atomic_store_ret_type() {
     let locals = [<u64>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -129,7 +132,7 @@ fn atomic_store_ret_type() {
 fn atomic_load_success() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     // We show that atomic load actually reads by reading 1 from local(1).
     let b0 = block!(
@@ -184,14 +187,14 @@ fn atomic_load_arg_type() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicLoad` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(p, "invalid first argument to `AtomicLoad` intrinsic: not a thin pointer")
 }
 
 #[test]
 fn atomic_load_ret_type_pow() {
     let locals = [<()>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(storage_live(0), atomic_load(local(0), addr_of(local(0), ptr_ty), 1));
     let b1 = block!(exit());
@@ -209,7 +212,7 @@ fn atomic_load_ret_type_pow() {
 fn atomic_load_ret_type_size() {
     let locals = [<[u64; 2]>::get_type()];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(storage_live(0), atomic_load(local(0), addr_of(local(0), ptr_ty), 1));
     let b1 = block!(exit());

--- a/tooling/minitest/src/tests/atomic_fetch.rs
+++ b/tooling/minitest/src/tests/atomic_fetch.rs
@@ -4,7 +4,7 @@ use crate::*;
 fn atomic_fetch_success() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -66,7 +66,7 @@ fn atomic_fetch_arg_1() {
 
     assert_ub::<BasicMem>(
         p,
-        "invalid first argument to `AtomicFetchAndOp` intrinsic: not a pointer",
+        "invalid first argument to `AtomicFetchAndOp` intrinsic: not a thin pointer",
     );
 }
 
@@ -74,7 +74,7 @@ fn atomic_fetch_arg_1() {
 fn atomic_fetch_arg_2() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -97,7 +97,7 @@ fn atomic_fetch_arg_2() {
 fn atomic_fetch_ret_ty() {
     let locals = [<[u8; 3]>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type());
 
@@ -122,7 +122,7 @@ fn atomic_fetch_ret_ty() {
 fn atomic_fetch_int_size() {
     let locals = [<u128>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),
@@ -142,7 +142,7 @@ fn atomic_fetch_int_size() {
 fn atomic_fetch_op() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/compare_exchange.rs
+++ b/tooling/minitest/src/tests/compare_exchange.rs
@@ -4,7 +4,7 @@ use crate::*;
 fn compare_exchange_success() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let addr0 = addr_of(local(0), ptr_ty);
 
@@ -52,7 +52,7 @@ fn compare_exchange_success() {
 fn compare_exchange_arg_count() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(
@@ -93,7 +93,7 @@ fn compare_exchange_arg_1_value() {
     let p = program(&[f]);
     assert_ub::<BasicMem>(
         p,
-        "invalid first argument to `AtomicCompareExchange` intrinsic: not a pointer",
+        "invalid first argument to `AtomicCompareExchange` intrinsic: not a thin pointer",
     );
 }
 
@@ -101,7 +101,7 @@ fn compare_exchange_arg_1_value() {
 fn compare_exchange_ret_type() {
     let locals = [<[u8; 3]>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
     let const_arr = array(&[const_int::<u8>(0); 3], <u8>::get_type());
 
@@ -125,7 +125,7 @@ fn compare_exchange_ret_type() {
 fn compare_exchange_arg_1_type() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(
@@ -148,7 +148,7 @@ fn compare_exchange_arg_1_type() {
 fn compare_exchange_arg_2_type() {
     let locals = [<u32>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(
@@ -171,7 +171,7 @@ fn compare_exchange_arg_2_type() {
 fn compare_exchange_arg_size_max() {
     let locals = [<u128>::get_type(); 2];
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
 
     let b0 = block!(

--- a/tooling/minitest/src/tests/data_race.rs
+++ b/tooling/minitest/src/tests/data_race.rs
@@ -10,7 +10,7 @@ struct AccessPattern(AccessType, Atomicity);
 // A block that does the access pattern on global(0): stores put the value of the "support global"
 // into global(0); loads pit the value of global(0) into the "support global".
 fn access_block(access: AccessPattern, support_global: u32, next: u32) -> BasicBlock {
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
     let addr = addr_of(global::<u32>(0), ptr_ty);
     match access {
         AccessPattern(AccessType::Load, Atomicity::Atomic) => {

--- a/tooling/minitest/src/tests/expose.rs
+++ b/tooling/minitest/src/tests/expose.rs
@@ -32,6 +32,6 @@ fn requires_pointer() {
     let program = program(&[function(Ret::No, 0, &locals, &blocks)]);
     assert_ub::<BasicMem>(
         program,
-        "invalid argument for `PointerExposeProvenance` intrinsic: not a pointer",
+        "invalid argument for `PointerExposeProvenance` intrinsic: not a thin pointer",
     );
 }

--- a/tooling/minitest/src/tests/heap_intrinsics.rs
+++ b/tooling/minitest/src/tests/heap_intrinsics.rs
@@ -254,7 +254,10 @@ fn dealloc_wrongarg1() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub::<BasicMem>(p, "invalid first argument to `Deallocate` intrinsic: not a pointer");
+    assert_ub::<BasicMem>(
+        p,
+        "invalid first argument to `Deallocate` intrinsic: not a thin pointer",
+    );
 }
 
 #[test]

--- a/tooling/minitest/src/tests/raw_eq.rs
+++ b/tooling/minitest/src/tests/raw_eq.rs
@@ -93,7 +93,7 @@ fn raw_ptr_raw_eq() {
     let left = f.declare_local::<[u8; 2]>();
     let right = f.declare_local::<[u8; 2]>();
 
-    let ptr_ty = raw_ptr_ty();
+    let ptr_ty = raw_void_ptr_ty();
 
     let left_ptr = addr_of(left, ptr_ty);
     let right_ptr = addr_of(right, ptr_ty);

--- a/tooling/minitest/src/tests/spawn_join.rs
+++ b/tooling/minitest/src/tests/spawn_join.rs
@@ -91,7 +91,7 @@ fn spawn_arg_value() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f]);
-    assert_ub::<BasicMem>(p, "invalid first argument to `Spawn` intrinsic: not a pointer")
+    assert_ub::<BasicMem>(p, "invalid first argument to `Spawn` intrinsic: not a thin pointer")
 }
 
 fn no_args() -> Function {

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -246,7 +246,7 @@ pub fn local(x: u32) -> PlaceExpr {
 
 pub fn global_by_name<T: TypeConv>(name: GlobalName) -> PlaceExpr {
     let relocation = Relocation { name, offset: Size::ZERO };
-    let ptr_type = Type::Ptr(PtrType::Raw);
+    let ptr_type = Type::Ptr(PtrType::Raw { meta_kind: PointerMetaKind::None });
     deref(ValueExpr::Constant(Constant::GlobalPointer(relocation), ptr_type), T::get_type())
 }
 

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -20,8 +20,12 @@ pub fn box_ty(pointee: PointeeInfo) -> Type {
     Type::Ptr(PtrType::Box { pointee })
 }
 
-pub fn raw_ptr_ty() -> Type {
-    Type::Ptr(PtrType::Raw)
+pub fn raw_ptr_ty(meta_kind: PointerMetaKind) -> Type {
+    Type::Ptr(PtrType::Raw { meta_kind })
+}
+
+pub fn raw_void_ptr_ty() -> Type {
+    raw_ptr_ty(PointerMetaKind::None)
 }
 
 pub fn tuple_ty(f: &[(Offset, Type)], size: Size, align: Align) -> Type {

--- a/tooling/miniutil/src/build/ty_conv.rs
+++ b/tooling/miniutil/src/build/ty_conv.rs
@@ -45,15 +45,15 @@ type_conv_int_impl!(i128, Signed, size(16));
 type_conv_int_impl!(usize, Unsigned, DefaultTarget::PTR_SIZE);
 type_conv_int_impl!(isize, Signed, DefaultTarget::PTR_SIZE);
 
-impl<T: TypeConv> TypeConv for *const T {
+impl<T: TypeConv + ?Sized> TypeConv for *const T {
     fn get_type() -> Type {
-        raw_ptr_ty()
+        raw_ptr_ty(T::get_type().meta_kind())
     }
 }
 
-impl<T: TypeConv> TypeConv for *mut T {
+impl<T: TypeConv + ?Sized> TypeConv for *mut T {
     fn get_type() -> Type {
-        raw_ptr_ty()
+        raw_ptr_ty(T::get_type().meta_kind())
     }
 }
 
@@ -63,24 +63,26 @@ impl TypeConv for bool {
     }
 }
 
-impl<T: TypeConv> TypeConv for &T {
+impl<T: TypeConv + ?Sized> TypeConv for &T {
     fn get_type() -> Type {
         ref_ty(PointeeInfo {
             size: T::get_size(),
             align: T::get_align(),
             inhabited: true,
             freeze: T::FREEZE,
+            meta_kind: T::get_type().meta_kind(),
         })
     }
 }
 
-impl<T: TypeConv> TypeConv for &mut T {
+impl<T: TypeConv + ?Sized> TypeConv for &mut T {
     fn get_type() -> Type {
         ref_mut_ty(PointeeInfo {
             size: T::get_size(),
             align: T::get_align(),
             inhabited: true,
             freeze: T::FREEZE,
+            meta_kind: T::get_type().meta_kind(),
         })
     }
 }

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -41,8 +41,17 @@ pub(super) fn fmt_ptr_type(ptr_ty: PtrType) -> FmtExpr {
             let pointee_info_str = fmt_pointee_info(pointee);
             FmtExpr::Atomic(format!("Box<{pointee_info_str}>"))
         }
-        PtrType::Raw => FmtExpr::NonAtomic(format!("*raw")),
+        PtrType::Raw { meta_kind } => {
+            let meta_kind_str = fmt_meta_kind(meta_kind);
+            FmtExpr::NonAtomic(format!("*raw{meta_kind_str}"))
+        }
         PtrType::FnPtr => FmtExpr::Atomic(format!("fn()")),
+    }
+}
+
+fn fmt_meta_kind(kind: PointerMetaKind) -> &'static str {
+    match kind {
+        PointerMetaKind::None => "(thin)",
     }
 }
 
@@ -57,7 +66,10 @@ fn fmt_pointee_info(pointee: PointeeInfo) -> String {
         true => ", freeze",
         false => "",
     };
-    format!("pointee_info(size={size}, align={align}{uninhab_str}{freeze_str})")
+    let meta_str = match pointee.meta_kind {
+        PointerMetaKind::None => ", thin",
+    };
+    format!("pointee_info(size={size}, align={align}{meta_str}{uninhab_str}{freeze_str})")
 }
 
 /////////////////////


### PR DESCRIPTION
This PR creates a new Pointer type which can hold metadata.
This required a large refactor in the memory interface and other places, since the pointer without metadata is now called a `ThinPointer`.

The tests pass like this and before I continue to rebase the SizeStrategy changes onto this, I would like this to be approved, as to avoid duplicate work.