### PR TITLE
Refactor size constant as a SizeStrategy

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -48,7 +48,9 @@ impl<M: Memory> Machine<M> {
                 ret((Value::Int(result), Type::Int(int_ty)))
             }
             Transmute(new_ty) => {
-                if old_ty.size::<M::T>() != new_ty.size::<M::T>() {
+                if old_ty.size::<M::T>().expect_sized("WF ensures transmutes are sized")
+                    != new_ty.size::<M::T>().expect_sized("WF ensures transmutes are sized")
+                {
                     throw_ub!("transmute between types of different size")
                 }
                 let Some(val) = transmute(operand, old_ty, new_ty) else {

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -125,7 +125,7 @@ pub trait Memory {
         _fn_entry: bool,
     ) -> Result<Pointer<Self::Provenance>> {
         if let Some(layout) = ptr_type.safe_pointee() {
-            self.dereferenceable(ptr.thin_pointer, layout.size)?;
+            self.dereferenceable(ptr.thin_pointer, layout.size.compute(ptr.metadata))?;
         }
         ret(ptr)
     }

--- a/tooling/minimize/src/chunks.rs
+++ b/tooling/minimize/src/chunks.rs
@@ -59,7 +59,8 @@ fn mark_used_bytes(ty: Type, markers: &mut [bool]) {
         Type::Array { elem, count } => {
             let elem = elem.extract();
             for i in Int::ZERO..count {
-                let offset = i * elem.size::<DefaultTarget>();
+                let offset =
+                    i * elem.size::<DefaultTarget>().expect_sized("Array elements should be sized");
                 let offset = offset.bytes().try_to_usize().unwrap();
                 mark_used_bytes(elem, &mut markers[offset..]);
             }

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -120,7 +120,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 let ty = place.ty(&self.locals_smir).unwrap();
                 let place = self.translate_place_smir(place, span);
                 let target = GcCow::new(place);
-                let meta_kind = self.pointee_info_of_smir(ty).meta_kind;
+                let meta_kind = self.pointee_info_of_smir(ty).size.meta_kind();
 
                 let ptr_ty = PtrType::Raw { meta_kind };
 

--- a/tooling/minitest/src/tests/ill_formed.rs
+++ b/tooling/minitest/src/tests/ill_formed.rs
@@ -26,7 +26,7 @@ fn too_large_local() {
     let stmts = &[];
 
     let prog = small_program(locals, stmts);
-    assert_ill_formed::<BasicMem>(prog, "Type: size not valid");
+    assert_ill_formed::<BasicMem>(prog, "SizeStrategy: size not valid");
 }
 
 #[test]

--- a/tooling/minitest/src/tests/spawn_join.rs
+++ b/tooling/minitest/src/tests/spawn_join.rs
@@ -38,7 +38,8 @@ fn thread_spawn_spurious_race() {
     let pp_ptype = <*const *const ()>::get_type(); // Pointer pointer place type.
     let locals = [pp_ptype, <u32>::get_type()];
 
-    let size = const_int_typed::<usize>(<*const ()>::get_size().bytes());
+    let size =
+        const_int_typed::<usize>(<*const ()>::get_size().expect_sized("void ptr is sized").bytes());
     let align = const_int_typed::<usize>(<*const ()>::get_align().bytes());
 
     let b0 = block!(storage_live(0), allocate(size, align, local(0), 1));

--- a/tooling/miniutil/src/build/global.rs
+++ b/tooling/miniutil/src/build/global.rs
@@ -2,7 +2,7 @@ use crate::build::*;
 
 impl ProgramBuilder {
     pub fn declare_global_zero_initialized<T: TypeConv>(&mut self) -> PlaceExpr {
-        let bytes = List::from_elem(Some(0), T::get_size().bytes());
+        let bytes = List::from_elem(Some(0), T::get_size().expect_sized("T is `Sized`").bytes());
         let global = Global { bytes, relocations: list!(), align: <T>::get_align() };
         let name = GlobalName(Name::from_internal(self.next_global));
         self.next_global += 1;
@@ -13,14 +13,15 @@ impl ProgramBuilder {
 
 /// Global Int initialized to zero.
 pub fn global_int<T: TypeConv>() -> Global {
-    let bytes = List::from_elem(Some(0), T::get_size().bytes());
+    let bytes = List::from_elem(Some(0), T::get_size().expect_sized("T is `Sized`").bytes());
 
     Global { bytes, relocations: list!(), align: T::get_align() }
 }
 
 /// Global pointer
-pub fn global_ptr<T: TypeConv>() -> Global {
-    let bytes = List::from_elem(Some(0), <*const T>::get_size().bytes());
+pub fn global_ptr<T: TypeConv + ?Sized>() -> Global {
+    let bytes =
+        List::from_elem(Some(0), <*const T>::get_size().expect_sized("*T is `Sized`").bytes());
 
     Global { bytes, relocations: list!(), align: <*const T>::get_align() }
 }

--- a/tooling/miniutil/src/build/ty_conv.rs
+++ b/tooling/miniutil/src/build/ty_conv.rs
@@ -8,7 +8,7 @@ pub trait TypeConv {
     fn get_type() -> Type;
 
     // Convenience methods, these should not be overridden.
-    fn get_size() -> Size {
+    fn get_size() -> SizeStrategy {
         Self::get_type().size::<DefaultTarget>()
     }
     fn get_align() -> Align {
@@ -72,7 +72,6 @@ impl<T: TypeConv + ?Sized> TypeConv for &T {
             inhabited: true,
             freeze: T::FREEZE,
             unpin: T::UNPIN,
-            meta_kind: T::get_type().meta_kind(),
         })
     }
 }
@@ -85,7 +84,6 @@ impl<T: TypeConv + ?Sized> TypeConv for &mut T {
             inhabited: true,
             freeze: T::FREEZE,
             unpin: T::UNPIN,
-            meta_kind: T::get_type().meta_kind(),
         })
     }
 }

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -56,7 +56,9 @@ fn fmt_meta_kind(kind: PointerMetaKind) -> &'static str {
 }
 
 fn fmt_pointee_info(pointee: PointeeInfo) -> String {
-    let size = pointee.size.bytes();
+    let size_str = match pointee.size {
+        SizeStrategy::Sized(size) => format!("{}", size.bytes()),
+    };
     let align = pointee.align.bytes();
     let uninhab_str = match pointee.inhabited {
         true => "",
@@ -66,10 +68,10 @@ fn fmt_pointee_info(pointee: PointeeInfo) -> String {
         true => ", freeze",
         false => "",
     };
-    let meta_str = match pointee.meta_kind {
+    let meta_str = match pointee.size.meta_kind() {
         PointerMetaKind::None => ", thin",
     };
-    format!("pointee_info(size={size}, align={align}{meta_str}{uninhab_str}{freeze_str})")
+    format!("pointee_info(size={size_str}, align={align}{meta_str}{uninhab_str}{freeze_str})")
 }
 
 /////////////////////


### PR DESCRIPTION
This refactor introduces the `SizeStrategy` that will allow slices in the next step.