### PR TITLE
Add slice support

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -238,7 +238,7 @@ impl<M: Memory> Machine<M> {
             Value::Bool(b) => if b { Int::from(1) } else { Int::from(0) },
             Value::Ptr(p) if p.metadata.is_none() => p.thin_pointer.addr,
             // TODO(UnsizedTypes): Prepare wide pointer for rel op: `addr * (MAX_META_VALUE+1) + meta_value`
-            Value::Ptr(_) => panic!("metadata does not exist yet"),
+            Value::Ptr(_) => unimplemented!("comparing pointer with metadata"),
             _ => panic!("invalid value for relational operator"),
         }
     }

--- a/tooling/minimize/src/chunks.rs
+++ b/tooling/minimize/src/chunks.rs
@@ -75,6 +75,7 @@ fn mark_used_bytes(ty: Type, markers: &mut [bool]) {
             }
             mark_discriminator(discriminator, markers);
         }
+        Type::Slice { .. } => panic!("unsized types cannot be part of unions"),
     }
 }
 

--- a/tooling/minimize/src/constant.rs
+++ b/tooling/minimize/src/constant.rs
@@ -97,6 +97,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             }
             Type::Union { .. } =>
                 rs::span_bug!(span, "Constant Unions are currently not supported!"),
+            Type::Slice { .. } => rs::span_bug!(span, "constant slices do not exist!"),
         }
     }
 

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -32,6 +32,7 @@ mod ptr_offset;
 mod ptr_offset_from;
 mod raw_eq;
 mod return_;
+mod slice;
 mod spawn_join;
 mod switch;
 mod too_large_alloc;

--- a/tooling/minitest/src/tests/negative_index.rs
+++ b/tooling/minitest/src/tests/negative_index.rs
@@ -12,5 +12,5 @@ fn negative_index() {
 
     let p = small_program(locals, stmts);
     dump_program(p);
-    assert_ub::<BasicMem>(p, "out-of-bounds array access");
+    assert_ub::<BasicMem>(p, "access to out-of-bounds index");
 }

--- a/tooling/minitest/src/tests/slice.rs
+++ b/tooling/minitest/src/tests/slice.rs
@@ -1,0 +1,206 @@
+use crate::*;
+
+/// This helper is a workaround for the missing unsizing coercion.
+///
+/// It builds code to create a `&[T]` place from an `[T; known_len]` place.
+pub fn ref_as_slice<T: TypeConv>(
+    f: &mut FunctionBuilder,
+    arr: PlaceExpr,
+    known_len: u64,
+) -> PlaceExpr {
+    // construct fake wide ptr
+    let arr_ref = addr_of(arr, <*const T>::get_type());
+    let pair_ty = PtrType::Raw { meta_kind: PointerMetaKind::ElementCount }
+        .as_wide_pair::<miniutil::DefaultTarget>()
+        .expect("PtrType is wide");
+    let fake_ptr = f.declare_local_with_ty(pair_ty);
+    f.storage_live(fake_ptr);
+    f.assign(field(fake_ptr, 0), arr_ref);
+    f.assign(field(fake_ptr, 1), const_int(known_len));
+    f.validate(fake_ptr, false); // Bad for ZST ?
+    // transmute into slice ref
+    let slice = f.declare_local::<&[T]>();
+    f.storage_live(slice);
+    f.assign(slice, transmute(load(fake_ptr), <&[T]>::get_type()));
+    f.validate(slice, false);
+    slice
+}
+
+/// Tests that slices can occur behind different pointer types
+#[test]
+fn slice_ref_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let _f = {
+        let mut f = p.declare_function();
+        let _var = f.declare_local::<&[u32]>();
+        let _ret = f.declare_ret::<&mut [u8]>();
+        let _arg = f.declare_arg::<*const [[[u8; 3]; 2]]>();
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let main = {
+        let mut main = p.declare_function();
+        main.exit();
+        p.finish_function(main)
+    };
+
+    let p = p.finish_program(main);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests that an index operation is well formed
+#[test]
+fn index_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let _f = {
+        let mut f = p.declare_function();
+        let slice = f.declare_arg::<&[u32]>();
+        let var = f.declare_local::<u32>();
+        f.storage_live(var);
+        let elem_place = index(deref(load(slice), <[u32]>::get_type()), const_int(2));
+        f.assign(elem_place, const_int(42_u32));
+        f.assign(var, load(elem_place));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let main = {
+        let mut main = p.declare_function();
+        main.exit();
+        p.finish_function(main)
+    };
+
+    let p = p.finish_program(main);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Asserts that the slice element type must be sized
+#[test]
+fn slice_ref_unsized_elem_not_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let var = f.declare_local_with_ty(<&[u32]>::get_type());
+        f.storage_live(var);
+        let slice_place = deref(load(var), slice_ty(slice_ty(<u32>::get_type())));
+        f.validate(slice_place, false);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "Type::Slice: unsized element type");
+}
+
+#[test]
+fn local_not_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        // ill formed:
+        f.declare_local_with_ty(slice_ty(<u32>::get_type()));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "Function: unsized local variable");
+}
+
+#[test]
+fn load_not_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let var = f.declare_local_with_ty(<&[u32]>::get_type());
+        f.storage_live(var);
+        let slice_place = deref(load(var), <[u32]>::get_type());
+        // ill formed load: (also ill formed print, but need some way to use the valueexpr)
+        f.print(load(slice_place));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "ValueExpr::Load: unsized value type");
+}
+
+#[test]
+fn transmute_not_wf() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let arr = f.declare_local::<[u32; 1]>();
+        f.storage_live(arr);
+        f.assign(index(arr, const_int(0)), const_int(42_u32));
+        // ill formed transmute:
+        let slice = transmute(load(arr), <[u32]>::get_type());
+        // (also ill formed print, but need some way to use the valueexpr)
+        f.print(slice);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "Cast::Transmute: unsized target type");
+}
+
+/// Tests that a wide pointer can be transmuted from a `(*T, usize)`.
+#[test]
+fn index_with_transmuted() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        // Make array
+        let arr = f.declare_local::<[u32; 3]>();
+        f.storage_live(arr);
+        f.assign(index(arr, const_int(0)), const_int(42_u32));
+        f.assign(index(arr, const_int(1)), const_int(43_u32));
+        f.assign(index(arr, const_int(2)), const_int(44_u32));
+        let slice_ptr = ref_as_slice::<u32>(&mut f, arr, 3);
+        // Print slice[1]
+        let loaded_val = load(index(deref(load(slice_ptr), <[u32]>::get_type()), const_int(1)));
+        f.print(loaded_val);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_eq!(get_stdout::<BasicMem>(p).unwrap(), &["43"]);
+}
+
+/// Tests that indexing into a slice throws UB for invalid indices
+#[test]
+fn invalid_index_ub() {
+    fn for_index(idx: isize) {
+        let mut p = ProgramBuilder::new();
+        let f = {
+            let mut f = p.declare_function();
+            // Make array
+            let arr = f.declare_local::<[u32; 2]>();
+            f.storage_live(arr);
+            f.assign(index(arr, const_int(0)), const_int(42_u32));
+            f.assign(index(arr, const_int(1)), const_int(43_u32));
+            let slice_ptr = ref_as_slice::<u32>(&mut f, arr, 2);
+            // This should UB
+            let loaded_val =
+                load(index(deref(load(slice_ptr), <[u32]>::get_type()), const_int(idx)));
+            f.print(loaded_val);
+            f.exit();
+            p.finish_function(f)
+        };
+        let p = p.finish_program(f);
+        assert_ub::<BasicMem>(p, "access to out-of-bounds index");
+    }
+
+    for_index(-1);
+    for_index(2);
+}

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -41,6 +41,10 @@ pub fn array_ty(elem: Type, count: impl Into<Int>) -> Type {
     Type::Array { elem: GcCow::new(elem), count: count.into() }
 }
 
+pub fn slice_ty(elem: Type) -> Type {
+    Type::Slice { elem: GcCow::new(elem) }
+}
+
 pub fn enum_variant(ty: Type, tagger: &[(Offset, (IntType, Int))]) -> Variant {
     Variant { ty, tagger: tagger.iter().copied().collect() }
 }

--- a/tooling/miniutil/src/build/ty_conv.rs
+++ b/tooling/miniutil/src/build/ty_conv.rs
@@ -94,6 +94,12 @@ impl<T: TypeConv, const N: usize> TypeConv for [T; N] {
     }
 }
 
+impl<T: TypeConv> TypeConv for [T] {
+    fn get_type() -> Type {
+        slice_ty(T::get_type())
+    }
+}
+
 impl TypeConv for () {
     fn get_type() -> Type {
         tuple_ty(&[], size(0), align(1))


### PR DESCRIPTION
This PR will add slice support to minirust, which includes a new SizeStrategy, MetaKind and the Type itself.

This currently includes a broken minimize test and therefore is still a draft.