### PR TITLE
Add GetMetadata to allow a minimize slice test

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -71,7 +71,7 @@ impl<M: Memory> Machine<M> {
 ```rust
 impl<M: Memory> Machine<M> {
     fn eval_un_op(&self, UnOp::GetMetadata: UnOp, (operand, op_ty): (Value<M>, Type)) -> Result<(Value<M>, Type)> {
-        let Value::Ptr(ptr) = operand else { panic!("non pointer get-metadata") };
+        let Value::Ptr(ptr) = operand else { panic!("non-pointer get-metadata") };
 
         if let Some(meta) = ptr.metadata {
             let meta_value = meta.into_value::<M>();

--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -66,6 +66,24 @@ impl<M: Memory> Machine<M> {
 }
 ```
 
+### Wide pointer operators
+
+```rust
+impl<M: Memory> Machine<M> {
+    fn eval_un_op(&self, UnOp::GetMetadata: UnOp, (operand, op_ty): (Value<M>, Type)) -> Result<(Value<M>, Type)> {
+        let Value::Ptr(ptr) = operand else { panic!("non pointer get-metadata") };
+
+        if let Some(meta) = ptr.metadata {
+            let meta_value = meta.into_value::<M>();
+            let meta_ty = meta.meta_kind().ty::<M::T>().expect("meta is not None");
+            ret((meta_value, meta_ty))
+        } else {
+            ret((unit_value::<M>(), unit_type()))
+        }
+    }
+}
+```
+
 ## Binary operators
 
 ```rust

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -116,6 +116,8 @@ pub enum UnOp {
     Int(IntUnOp),
     /// A form of cast; the return type is given by the specific cast operation.
     Cast(CastOp),
+    /// Returns the metadata of a pointer as a value. For a thin pointer this is `()`.
+    GetMetadata,
 }
 
 pub enum IntBinOp {

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -353,6 +353,13 @@ impl ValueExpr {
                             }
                         }
                     }
+                    GetMetadata => {
+                        let Type::Ptr(ptr_ty) = operand else {
+                            throw_ill_formed!("UnOp::GetMetadata: invalid operand: not a pointer");
+                        };
+                        // If the pointer does not have metadata, this will still be well-formed but return the unit type.
+                        ptr_ty.meta_kind().ty::<T>().unwrap_or_else(unit_type)
+                    }
                 }
             }
             BinOp { operator, left, right } => {

--- a/spec/mem/pointer.md
+++ b/spec/mem/pointer.md
@@ -69,13 +69,18 @@ impl<Provenance> ThinPointer<Provenance> {
     }
 }
 
+impl PointerMeta {
+    pub fn meta_kind(self) -> PointerMetaKind {
+        match self {
+            PointerMeta::ElementCount(_) => PointerMetaKind::ElementCount,
+        }
+    }
+}
+
 impl PointerMetaKind {
     pub fn matches(self, meta: Option<PointerMeta>) -> bool {
-        match (self, meta) {
-            (PointerMetaKind::None, None) => true,
-            (PointerMetaKind::ElementCount, Some(PointerMeta::ElementCount(_))) => true,
-            _ => false,
-        }
+        let expected_kind = meta.map(PointerMeta::meta_kind).unwrap_or(PointerMetaKind::None);
+        self == expected_kind
     }
 }
 ```

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -81,13 +81,14 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                     (Neg, Type::Int(_)) => build::neg(operand),
                     (Not, Type::Int(_)) => build::bit_not(operand),
                     (Not, Type::Bool) => build::not(operand),
+                    (PtrMetadata, Type::Ptr(_)) => build::get_metadata(operand),
                     (op, _) =>
                         rs::span_bug!(span, "UnOp {op:?} called with unsupported type {ty_smir}."),
                 }
             }
             smir::Rvalue::Ref(_, bkind, place) => {
                 let ty = place.ty(&self.locals_smir).unwrap();
-                let pointee = self.pointee_info_of_smir(ty);
+                let pointee = self.pointee_info_of_smir(ty, span);
 
                 let place = self.translate_place_smir(place, span);
                 let target = GcCow::new(place);
@@ -120,7 +121,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 let ty = place.ty(&self.locals_smir).unwrap();
                 let place = self.translate_place_smir(place, span);
                 let target = GcCow::new(place);
-                let meta_kind = self.pointee_info_of_smir(ty).size.meta_kind();
+                let meta_kind = self.pointee_info_of_smir(ty, span).size.meta_kind();
 
                 let ptr_ty = PtrType::Raw { meta_kind };
 
@@ -170,12 +171,18 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             smir::Rvalue::CopyForDeref(place) =>
                 ValueExpr::Load { source: GcCow::new(self.translate_place_smir(place, span)) },
             smir::Rvalue::Len(place) => {
-                // as slices are unsupported as of now, we only need to care for arrays.
                 let ty = place.ty(&self.locals_smir).unwrap();
-                let Type::Array { elem: _, count } = self.translate_ty_smir(ty, span) else {
-                    panic!()
-                };
-                ValueExpr::Constant(Constant::Int(count), <usize>::get_type())
+                match self.translate_ty_smir(ty, span) {
+                    Type::Array { elem: _, count } =>
+                        ValueExpr::Constant(Constant::Int(count), <usize>::get_type()),
+                    Type::Slice { .. } =>
+                    // convert the place to a value first, so our `get_metadata` is applicable.
+                        build::get_metadata(build::addr_of(
+                            self.translate_place_smir(place, span),
+                            build::raw_ptr_ty(PointerMetaKind::ElementCount),
+                        )),
+                    _ => rs::span_bug!(span, "RValue::Len only supported for arrays & slices"),
+                }
             }
             smir::Rvalue::Discriminant(place) =>
                 ValueExpr::GetDiscriminant {
@@ -219,8 +226,27 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                             operand: GcCow::new(operand),
                         }
                     }
+
+                    smir::CastKind::PtrToPtr => {
+                        let operand_ty = operand.ty(&self.locals_smir).unwrap();
+                        let Type::Ptr(old_ptr_ty) = self.translate_ty_smir(operand_ty, span) else {
+                            rs::span_bug!(span, "ptr to ptr cast on non-pointer");
+                        };
+                        let Type::Ptr(new_ptr_ty) = self.translate_ty_smir(*ty, span) else {
+                            rs::span_bug!(span, "ptr to ptr cast to non-pointer");
+                        };
+                        if old_ptr_ty.meta_kind() == new_ptr_ty.meta_kind() {
+                            let operand = self.translate_operand_smir(operand, span);
+                            build::transmute(operand, Type::Ptr(new_ptr_ty))
+                        } else {
+                            // TODO(UnsizedTypes): Implement this for wide to thin pointer casts
+                            rs::span_bug!(
+                                span,
+                                "Unimplemented: casting pointers with different metadata"
+                            );
+                        }
+                    }
                     smir::CastKind::Transmute
-                    | smir::CastKind::PtrToPtr
                     | smir::CastKind::FnPtrToPtr
                     | smir::CastKind::PointerCoercion(smir::PointerCoercion::UnsafeFnPointer) => {
                         let operand = self.translate_operand_smir(operand, span);

--- a/tooling/minimize/tests/pass/slice.rs
+++ b/tooling/minimize/tests/pass/slice.rs
@@ -1,0 +1,31 @@
+/// This should act pretty much exactly like implicit unsizing, including lifetimes.
+fn unsize<'a, T, const N: usize>(arr: &'a [T; N]) -> &'a [T] {
+    #[repr(C)]
+    struct SlicePointerTuple<T> {
+        begin: *const T,
+        len: usize,
+    }
+
+    // We do not have normal unsizing yet, so we cheat.
+    // FIXME(UnsizedTypes): Don't cheat, or at least use `as_ptr()`, which requires unsizing tho.
+    let ptr = SlicePointerTuple { begin: arr as *const T, len: N };
+    // SAFETY: SlicePointerTuple has the same layout as `&[T]` and since arr is only accessible behind
+    // a reference, no mutable reference can exist
+    let slice = unsafe { core::mem::transmute::<SlicePointerTuple<T>, &[T]>(ptr) };
+    slice
+}
+
+// Pass slice reference accross function boundaries
+pub fn assert_some_elements(a: &[i32]) {
+    assert!(a[1] == -40);
+    assert!(a[2] == 30);
+    assert!(a[3] == -20);
+}
+
+fn main() {
+    let x: [i32; 5] = [50, -40, 30, -20, 10];
+    let slice = unsize(&x);
+
+    assert_some_elements(slice);
+    assert!(slice.len() == 5);
+}

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -38,4 +38,5 @@ mod switch;
 mod too_large_alloc;
 mod uninit_read;
 mod unreachable;
+mod wide_ptr;
 mod zst;

--- a/tooling/minitest/src/tests/wide_ptr.rs
+++ b/tooling/minitest/src/tests/wide_ptr.rs
@@ -1,0 +1,40 @@
+use crate::*;
+
+#[test]
+fn get_metadata_non_ptr_ill_formed() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u32>();
+        f.storage_live(x);
+        f.print(get_metadata(load(x)));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "UnOp::GetMetadata: invalid operand: not a pointer");
+}
+
+#[test]
+fn get_metadata_thin_ptr() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u32>();
+        let ptr = f.declare_local::<&u32>();
+        let nop = f.declare_local::<()>();
+        f.storage_live(x);
+        f.storage_live(ptr);
+        f.storage_live(nop);
+        f.assign(ptr, addr_of(x, <&u32>::get_type()));
+        f.assign(nop, get_metadata(load(ptr)));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -103,6 +103,10 @@ pub fn transmute(v: ValueExpr, t: Type) -> ValueExpr {
     ValueExpr::UnOp { operator: UnOp::Cast(CastOp::Transmute(t)), operand: GcCow::new(v) }
 }
 
+pub fn get_metadata(v: ValueExpr) -> ValueExpr {
+    ValueExpr::UnOp { operator: UnOp::GetMetadata, operand: GcCow::new(v) }
+}
+
 fn int_binop(op: IntBinOp, l: ValueExpr, r: ValueExpr) -> ValueExpr {
     ValueExpr::BinOp { operator: BinOp::Int(op), left: GcCow::new(l), right: GcCow::new(r) }
 }

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -150,6 +150,7 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
                     let new_ty = fmt_type(new_ty, comptypes).to_string();
                     FmtExpr::Atomic(format!("transmute<{new_ty}>({operand})"))
                 }
+                UnOp::GetMetadata => FmtExpr::Atomic(format!("get_metadata({operand})")),
             }
         }
         ValueExpr::BinOp { operator: BinOp::Int(int_op), left, right } => {


### PR DESCRIPTION
`RValue::Len` and the `UnOp::PtrMetadata` get translated to the new `GetMetadata` unop, which can infer the return type from the pointer operand type.

This allows slice support in minimize, even if it can't use unsizing or thin pointer casts.