### PR TITLE
Add operations to construct and destruct wide pointers

### DIFF
--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -116,6 +116,9 @@ pub enum UnOp {
     Int(IntUnOp),
     /// A form of cast; the return type is given by the specific cast operation.
     Cast(CastOp),
+    // The following 2 operations correspond to the two parts of `<*const T>::to_raw_parts()`.
+    /// Returns a raw pointer with same thin pointer of the operand, but without the metadata.
+    GetThinPointer,
     /// Returns the metadata of a pointer as a value. For a thin pointer this is `()`.
     GetMetadata,
 }
@@ -215,6 +218,10 @@ pub enum BinOp {
     /// Takes two pointers; returns a signed pointer-sized integer.
     /// If `nonneg` is true, it is UB for the result to be negative.
     PtrOffsetFrom { inbounds: bool, nonneg: bool },
+    /// This corresponds to `core::ptr::from_raw_parts`
+    /// and takes a thin pointer and matching metadata to construct a pointer of the given type.
+    /// When the target type is a thin pointer and the metadata is `()`, this is just a pointer cast.
+    ConstructWidePointer(PtrType),
 }
 ```
 

--- a/tooling/minimize/tests/pass/slice.rs
+++ b/tooling/minimize/tests/pass/slice.rs
@@ -1,20 +1,3 @@
-/// This should act pretty much exactly like implicit unsizing, including lifetimes.
-fn unsize<'a, T, const N: usize>(arr: &'a [T; N]) -> &'a [T] {
-    #[repr(C)]
-    struct SlicePointerTuple<T> {
-        begin: *const T,
-        len: usize,
-    }
-
-    // We do not have normal unsizing yet, so we cheat.
-    // FIXME(UnsizedTypes): Don't cheat, or at least use `as_ptr()`, which requires unsizing tho.
-    let ptr = SlicePointerTuple { begin: arr as *const T, len: N };
-    // SAFETY: SlicePointerTuple has the same layout as `&[T]` and since arr is only accessible behind
-    // a reference, no mutable reference can exist
-    let slice = unsafe { core::mem::transmute::<SlicePointerTuple<T>, &[T]>(ptr) };
-    slice
-}
-
 // Pass slice reference accross function boundaries
 pub fn assert_some_elements(a: &[i32]) {
     assert!(a[1] == -40);
@@ -22,10 +5,38 @@ pub fn assert_some_elements(a: &[i32]) {
     assert!(a[3] == -20);
 }
 
+pub fn change_some_elements(a: &mut [u8]) {
+    a[0] += 1;
+    a[1] -= 1;
+}
+
 fn main() {
     let x: [i32; 5] = [50, -40, 30, -20, 10];
-    let slice = unsize(&x);
+    let slice: &[i32] = &x;
 
+    // Check indexablity
     assert_some_elements(slice);
+
+    let mut a2 = [1, 2, 3, 4];
+    change_some_elements(&mut a2);
+    assert!(a2[0] == 2);
+
     assert!(slice.len() == 5);
+    assert!(slice.iter().count() == 5);
+
+    // Check the iterator in a for loop, checking alternating signs
+    let mut sign = 1;
+    for elem in slice {
+        assert!(sign * elem > 0);
+        sign *= -1;
+    }
+    assert!(sign == -1);
+
+    // This is currently broken:
+    // // Check subslicing, which uses `from_raw_parts`
+    // let sub_slice = unsafe { core::slice::from_raw_parts::<'_, i32>(&slice[1] as *const i32, 4) };
+    // // let sub_slice = &slice[1..];
+    // assert!(sub_slice.len() == 4);
+    // assert!(sub_slice[0] == -40);
+    // let x = slice;
 }

--- a/tooling/minitest/src/tests/wide_ptr.rs
+++ b/tooling/minitest/src/tests/wide_ptr.rs
@@ -18,6 +18,95 @@ fn get_metadata_non_ptr_ill_formed() {
 }
 
 #[test]
+fn get_thin_non_ptr_ill_formed() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u32>();
+        f.storage_live(x);
+        f.print(get_thin_pointer(load(x)));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(p, "UnOp::GetThinPointer: invalid operand: not a pointer");
+}
+
+#[test]
+fn construct_wide_non_ptr_ill_formed() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u32>();
+        f.storage_live(x);
+        f.print(construct_wide_pointer(load(x), load(x), <&[u32]>::get_type()));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(
+        p,
+        "BinOp::ConstructWidePointer: invalid left type: not a pointer",
+    );
+}
+
+#[test]
+fn construct_wide_from_wide_ptr_ill_formed() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        // Construct a wide pointer
+        let arr = f.declare_local::<[u32; 3]>();
+        f.storage_live(arr);
+        let arr_ref = addr_of(arr, <&[u32; 3]>::get_type());
+        let slice_ref_v = construct_wide_pointer(arr_ref, const_int(3_usize), <&[u32]>::get_type());
+
+        // Try to use the wide ptr to construct another wide ptr
+        f.print(construct_wide_pointer(slice_ref_v, const_int(3_usize), <&[u32]>::get_type()));
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(
+        p,
+        "BinOp::ConstructWidePointer: invalid left type: not a thin pointer",
+    );
+}
+
+#[test]
+fn construct_wide_mismatched_meta_ill_formed() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u32>();
+        f.storage_live(x);
+        f.print(construct_wide_pointer(
+            addr_of(x, <&u32>::get_type()),
+            const_int(0_u32), // not `usize` as expected
+            <&[u32]>::get_type(),
+        ));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_ill_formed::<BasicMem>(
+        p,
+        "BinOp::ConstructWidePointer: invalid right type: not metadata of target",
+    );
+}
+
+// PASS below
+
+#[test]
 fn get_metadata_thin_ptr() {
     let mut p = ProgramBuilder::new();
 
@@ -31,6 +120,85 @@ fn get_metadata_thin_ptr() {
         f.storage_live(nop);
         f.assign(ptr, addr_of(x, <&u32>::get_type()));
         f.assign(nop, get_metadata(load(ptr)));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+#[test]
+fn get_thin_of_thin_ptr() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u32>();
+        let ptr = f.declare_local::<&u32>();
+        let nop = f.declare_local::<*const ()>();
+        f.storage_live(x);
+        f.storage_live(ptr);
+        f.storage_live(nop);
+        f.assign(x, const_int(12_u32));
+        f.assign(ptr, addr_of(x, <&u32>::get_type()));
+        f.assign(nop, get_thin_pointer(load(ptr)));
+        // Make sure the new pointer still has the same provenance
+        f.assume(eq(load(deref(load(nop), <u32>::get_type())), const_int(12_u32)));
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+#[test]
+fn construct_slice() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        // Make array
+        let arr = f.declare_local::<[u32; 3]>();
+        f.storage_live(arr);
+        f.assign(index(arr, const_int(0)), const_int(42_u32));
+        f.assign(index(arr, const_int(1)), const_int(43_u32));
+        f.assign(index(arr, const_int(2)), const_int(44_u32));
+        let arr_ref = addr_of(arr, <&[u32; 3]>::get_type());
+
+        // Construct the slice
+        let slice_ref = f.declare_local::<&[u32]>();
+        let slice_ref_v = construct_wide_pointer(arr_ref, const_int(3_usize), <&[u32]>::get_type());
+        f.storage_live(slice_ref);
+        f.assign(slice_ref, slice_ref_v);
+
+        // Assert slice[1] == 43
+        let loaded_val = load(index(deref(load(slice_ref), <[u32]>::get_type()), const_int(1)));
+        f.assume(eq(loaded_val, const_int(43_u32)));
+
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
+}
+
+#[test]
+fn construct_thin() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u8>();
+        f.storage_live(x);
+        f.assign(x, const_int(0xff_u8));
+        let cast_ptr =
+            construct_wide_pointer(addr_of(x, <&u8>::get_type()), unit(), <&i8>::get_type());
+
+        f.assume(eq(load(deref(cast_ptr, <i8>::get_type())), const_int(-1_i8)));
+
         f.exit();
         p.finish_function(f)
     };

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -103,8 +103,24 @@ pub fn transmute(v: ValueExpr, t: Type) -> ValueExpr {
     ValueExpr::UnOp { operator: UnOp::Cast(CastOp::Transmute(t)), operand: GcCow::new(v) }
 }
 
+pub fn get_thin_pointer(v: ValueExpr) -> ValueExpr {
+    ValueExpr::UnOp { operator: UnOp::GetThinPointer, operand: GcCow::new(v) }
+}
+
 pub fn get_metadata(v: ValueExpr) -> ValueExpr {
     ValueExpr::UnOp { operator: UnOp::GetMetadata, operand: GcCow::new(v) }
+}
+
+pub fn construct_wide_pointer(ptr: ValueExpr, meta: ValueExpr, ptr_ty: Type) -> ValueExpr {
+    let Type::Ptr(ptr_ty) = ptr_ty else {
+        panic!("construct_wide_pointer requires Type::Ptr argument!");
+    };
+
+    ValueExpr::BinOp {
+        operator: BinOp::ConstructWidePointer(ptr_ty),
+        left: GcCow::new(ptr),
+        right: GcCow::new(meta),
+    }
 }
 
 fn int_binop(op: IntBinOp, l: ValueExpr, r: ValueExpr) -> ValueExpr {

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -150,6 +150,7 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
                     let new_ty = fmt_type(new_ty, comptypes).to_string();
                     FmtExpr::Atomic(format!("transmute<{new_ty}>({operand})"))
                 }
+                UnOp::GetThinPointer => FmtExpr::Atomic(format!("get_thin_ptr({operand})")),
                 UnOp::GetMetadata => FmtExpr::Atomic(format!("get_metadata({operand})")),
             }
         }
@@ -224,6 +225,12 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             let l = fmt_value_expr(left.extract(), comptypes).to_string();
             let r = fmt_value_expr(right.extract(), comptypes).to_string();
             FmtExpr::Atomic(format!("{offset_name}({l}, {r})"))
+        }
+        ValueExpr::BinOp { operator: BinOp::ConstructWidePointer(ptr_ty), left, right } => {
+            let l = fmt_value_expr(left.extract(), comptypes).to_string();
+            let r = fmt_value_expr(right.extract(), comptypes).to_string();
+            let ptr_ty_str = fmt_ptr_type(ptr_ty).to_string();
+            FmtExpr::Atomic(format!("construct_ptr<{ptr_ty_str}>({l}, {r})"))
         }
     }
 }


### PR DESCRIPTION
In particular, `GetThinPointer` is the pairing to the first part of `ptr::to_raw_parts`.
`ConstructWidePointer` is analogous to `core::ptr::from_raw_parts, altho it also works on references.

This PR is stacked on #236, the first commit being from there.

A discussion question for now is maybe, whether we want to allow the construction of a thin pointer by giving a unit value as metadata. Rust does it this way and it would be easy to also allow this. However, it seems unnecessary and kind of contradicts the current `PointerMetaKind::ty()` function which returns `None` and not the unit type, which was a decision to help prevent accidental recursion of the en/decode functions.