### PR TITLE
Better slice support

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -48,7 +48,7 @@ impl<M: Memory> Machine<M> {
 }
 ```
 
-`CountOnes` aka `ctpop` is a rust intrinsic on integer types that always returns a `u32`.
+`CountOnes` aka `ctpop` is a Rust intrinsic on integer types that always returns a `u32`.
 This is not a pure function on mathematical integers,
 since the bit representation for non-negative values has infinite zeros,
 and infinite ones for negatives values.

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -102,6 +102,8 @@ pub enum IntUnOp {
     Neg,
     /// Bitwise-invert an integer value
     BitNot,
+    /// Used for the intrinsic ˋctpopˋ.
+    CountOnes,
 }
 pub enum CastOp {
     /// Argument can be any integer type; returns the given integer type.

--- a/spec/lang/types.md
+++ b/spec/lang/types.md
@@ -45,6 +45,7 @@ pub enum Type {
         // TODO: store whether this is a (SIMD) vector, and something about alignment?
     },
     /// Slices, i.e. `[T]` are unsized types which therefore cannot be represented as values.
+    /// This type is also used for strings: `str` are treated as `[u8]`.
     Slice {
         #[specr::indirection]
         elem: Type,

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -333,11 +333,17 @@ impl ValueExpr {
 
                 let operand = operand.check_wf::<T>(locals, prog)?;
                 match operator {
-                    Int(_int_op) => {
+                    Int(int_op) => {
                         let Type::Int(int_ty) = operand else {
                             throw_ill_formed!("UnOp::Int: invalid operand");
                         };
-                        Type::Int(int_ty)
+
+                        let ret_ty = match int_op {
+                            IntUnOp::CountOnes => IntType { signed: Unsigned, size: Size::from_bytes(4).unwrap() },
+                            _ => int_ty,
+                        };
+
+                        Type::Int(ret_ty)
                     }
                     Cast(cast_op) => {
                         use lang::CastOp::*;

--- a/tooling/minimize/tests/pass/slice.rs
+++ b/tooling/minimize/tests/pass/slice.rs
@@ -10,7 +10,10 @@ pub fn change_some_elements(a: &mut [u8]) {
     a[1] -= 1;
 }
 
+const THE_SLICE: &'static [u16] = &[1, 2, 3, 4, 5, 6, 7, 8];
+
 fn main() {
+    // Check unsizing
     let x: [i32; 5] = [50, -40, 30, -20, 10];
     let slice: &[i32] = &x;
 
@@ -22,9 +25,15 @@ fn main() {
     assert!(a2[0] == 2);
 
     assert!(slice.len() == 5);
+
+    // Check constant slices
+    assert!(THE_SLICE.len() == 8);
+    assert!(THE_SLICE[3] == 4);
+
+    // Check iterators
     assert!(slice.iter().count() == 5);
 
-    // Check the iterator in a for loop, checking alternating signs
+    // check the iterator in a for loop, checking alternating signs
     let mut sign = 1;
     for elem in slice {
         assert!(sign * elem > 0);
@@ -32,11 +41,29 @@ fn main() {
     }
     assert!(sign == -1);
 
-    // This is currently broken:
-    // // Check subslicing, which uses `from_raw_parts`
-    // let sub_slice = unsafe { core::slice::from_raw_parts::<'_, i32>(&slice[1] as *const i32, 4) };
-    // // let sub_slice = &slice[1..];
-    // assert!(sub_slice.len() == 4);
-    // assert!(sub_slice[0] == -40);
-    // let x = slice;
+    // Check `from_raw_parts`
+    let elem1_ptr = unsafe { slice.as_ptr().add(1) };
+    let sub_slice = unsafe { core::slice::from_raw_parts::<'_, i32>(elem1_ptr, 4) };
+    assert!(sub_slice.len() == 4);
+    assert!(sub_slice[0] == -40);
+
+    // Check subslicing
+    let sub_slice = &slice[1..];
+    assert!(sub_slice.len() == 4);
+    assert!(sub_slice[0] == -40);
+
+    let sub_slice = &slice[1..4];
+    assert!(sub_slice.len() == 3);
+    assert!(sub_slice[0] == -40);
+
+    let sub_slice = &slice[..4];
+    assert!(sub_slice.len() == 4);
+    assert!(sub_slice[0] == 50);
+
+    // Check equality
+    assert!(&slice[1..4] == &[-40, 30, -20]);
+    assert!(slice[1..4] == [-40, 30, -20]);
+    // This fails, since it uses the `compare_bytes` intrinsic.
+    // let u8_slice: &[u8] = b"ABCABC";
+    // assert!(&u8_slice[..2] == &u8_slice[2..4]);
 }

--- a/tooling/minimize/tests/pass/str.rs
+++ b/tooling/minimize/tests/pass/str.rs
@@ -1,0 +1,20 @@
+const HELLO: &'static str = "Hello strings";
+
+fn id(x: &str) -> &str {
+    x
+}
+
+fn main() {
+    assert!(id(HELLO).len() == 13);
+
+    let name = &"Hej Björn!"[4..9];
+    assert!(name.len() == 5);
+
+    // TODO:
+    // Comparing strings does not work yet in part due to lack of the `compare_bytes` intrinsic.
+    // assert!(name == "Björn");
+
+    // Indexing does not work due to lack of chars.
+    // Various pattern based functions don't work because of lack of closures.
+    // Various other things don't work because of missing MIR.
+}

--- a/tooling/minitest/src/tests/int.rs
+++ b/tooling/minitest/src/tests/int.rs
@@ -215,7 +215,7 @@ fn bit_xor_int_works() {
     assert_stop::<BasicMem>(prog);
 }
 
-/// Test that BinUnOp::Not works for ints
+/// Test that IntUnOp::Not works for ints
 #[test]
 fn bit_int_not_works() {
     let locals = [];
@@ -231,6 +231,27 @@ fn bit_int_not_works() {
 
     let prog = program(&[function(Ret::No, 0, &locals, &blocks)]);
     assert_stop::<BasicMem>(prog);
+}
+
+#[test]
+fn count_ones_works() {
+    let mut p = ProgramBuilder::new();
+    let mut f = p.declare_function();
+
+    fn check<T: TypeConv + Into<Int>>(f: &mut FunctionBuilder, val: T, expect: u32) {
+        f.assume(eq(count_ones(const_int(val)), const_int(expect)));
+    }
+
+    check(&mut f, 0_u8, 0_u8.count_ones());
+    check(&mut f, -128_i8, (-128_i8).count_ones());
+    check(&mut f, 2934823_i32, 2934823_i32.count_ones());
+    check(&mut f, -90238485_i32, (-90238485_i32).count_ones());
+    check(&mut f, 98238923898093_u64, 98238923898093_u64.count_ones());
+
+    f.exit();
+    let f = p.finish_function(f);
+    let p = p.finish_program(f);
+    assert_stop::<BasicMem>(p);
 }
 
 #[test]

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -66,6 +66,10 @@ pub fn bit_not(v: ValueExpr) -> ValueExpr {
     ValueExpr::UnOp { operator: UnOp::Int(IntUnOp::BitNot), operand: GcCow::new(v) }
 }
 
+pub fn count_ones(v: ValueExpr) -> ValueExpr {
+    ValueExpr::UnOp { operator: UnOp::Int(IntUnOp::CountOnes), operand: GcCow::new(v) }
+}
+
 #[track_caller]
 pub fn int_cast<T: TypeConv>(v: ValueExpr) -> ValueExpr {
     let Type::Int(t) = T::get_type() else {

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -142,6 +142,8 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
             match operator {
                 UnOp::Int(IntUnOp::Neg) => FmtExpr::NonAtomic(format!("-({operand})")),
                 UnOp::Int(IntUnOp::BitNot) => FmtExpr::NonAtomic(format!("!({operand}")),
+                UnOp::Int(IntUnOp::CountOnes) =>
+                    FmtExpr::NonAtomic(format!("count_ones({operand}")),
                 UnOp::Cast(CastOp::IntToInt(int_ty)) => {
                     let int_ty = fmt_int_type(int_ty);
                     FmtExpr::Atomic(format!("int2int<{int_ty}>({operand})"))


### PR DESCRIPTION
This PR contains multiple changes to make various minimized code using slices compile properly.

This includes:
- Adding various bounds check failure functions to the `is_panic_fn` hack. This is was sufficient to allow safe subslicing.
- Add the `IntUnOp::CountOnes` operation to support the `ctpop` intrinsic. It was used by `slice::from_raw_parts`.
- Convert the `str` type to a `[u8]`. It was used by `panic_fmt` in `slice::from_raw_parts`. Now this can be called aswell.
- Allow minimize to handle unsized const pointers. This allows for literal strings.
- Some tests that the same things also work for strings.

There are still several things outstanding that hinder widespread use of slices and strings:
- #243
- #234 
- #191 
- #175 
- the `compare_bytes` intrinsic is not implemented, which is used for `[u8]` and `str`.
- closures aren't implemented.
