### PR TITLE
Refactor size and alignment into layoutstrategy

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -83,8 +83,8 @@ impl<M: Memory> Machine<M> {
                 ret((Value::Int(result), Type::Int(int_ty)))
             }
             Transmute(new_ty) => {
-                if old_ty.size::<M::T>().expect_sized("WF ensures transmutes are sized")
-                    != new_ty.size::<M::T>().expect_sized("WF ensures transmutes are sized")
+                if old_ty.layout::<M::T>().expect_size("WF ensures transmutes are sized")
+                    != new_ty.layout::<M::T>().expect_size("WF ensures transmutes are sized")
                 {
                     throw_ub!("transmute between types of different size")
                 }
@@ -133,7 +133,7 @@ impl<M: Memory> Machine<M> {
         let Type::Ptr(PtrType::Ref { pointee, .. }) = op_ty else { panic!("non-reference input to SizeOfVal") };
         let Value::Ptr(ptr) = operand else { panic!("non-pointer input to SizeOfVal") };
 
-        let size = pointee.size.compute(ptr.metadata);
+        let size = pointee.layout.compute_size(ptr.metadata);
         ret((Value::Int(size.bytes()), Type::Int(IntType { signed: Unsigned, size: M::T::PTR_SIZE })))
     }
 }

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -151,7 +151,7 @@ impl<M: Memory> Machine<M> {
             throw_ub!("de-initializing a place based on a misaligned pointer");
         }
         // Alignment was already checked.
-        self.mem.deinit(p.ptr.thin_pointer, ty.size::<M::T>().expect_sized("WF ensures deinits are sized"), Align::ONE)?;
+        self.mem.deinit(p.ptr.thin_pointer, ty.layout::<M::T>().expect_size("WF ensures deinits are sized"), Align::ONE)?;
 
         ret(())
     }
@@ -169,16 +169,16 @@ impl<M: Memory> StackFrame<M> {
         // This means the same address may be re-used for the new stoage.
         self.storage_dead(mem, local)?;
         // Then allocate the new storage.
-        let pointee_size = self.func.locals[local].size::<M::T>().expect_sized("WF ensures all locals are sized");
-        let pointee_align = self.func.locals[local].align::<M::T>();
+        let pointee_size = self.func.locals[local].layout::<M::T>().expect_size("WF ensures all locals are sized");
+        let pointee_align = self.func.locals[local].layout::<M::T>().expect_align("WF ensures all locals are sized");
         let ptr = mem.allocate(AllocationKind::Stack, pointee_size, pointee_align)?;
         self.locals.insert(local, ptr);
         ret(())
     }
 
     fn storage_dead(&mut self, mem: &mut ConcurrentMemory<M>, local: LocalName) -> NdResult {
-        let pointee_size = self.func.locals[local].size::<M::T>().expect_sized("WF ensures all locals are sized");
-        let pointee_align = self.func.locals[local].align::<M::T>();
+        let pointee_size = self.func.locals[local].layout::<M::T>().expect_size("WF ensures all locals are sized");
+        let pointee_align = self.func.locals[local].layout::<M::T>().expect_align("WF ensures all locals are sized");
         if let Some(ptr) = self.locals.remove(local) {
             mem.deallocate(ptr, AllocationKind::Stack, pointee_size, pointee_align)?;
         }

--- a/tooling/minimize/src/chunks.rs
+++ b/tooling/minimize/src/chunks.rs
@@ -59,8 +59,9 @@ fn mark_used_bytes(ty: Type, markers: &mut [bool]) {
         Type::Array { elem, count } => {
             let elem = elem.extract();
             for i in Int::ZERO..count {
-                let offset =
-                    i * elem.size::<DefaultTarget>().expect_sized("Array elements should be sized");
+                let offset = i * elem
+                    .layout::<DefaultTarget>()
+                    .expect_size("Array elements should be sized");
                 let offset = offset.bytes().try_to_usize().unwrap();
                 mark_used_bytes(elem, &mut markers[offset..]);
             }

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -136,7 +136,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                 let ty = place.ty(&self.locals_smir).unwrap();
                 let place = self.translate_place_smir(place, span);
                 let target = GcCow::new(place);
-                let meta_kind = self.pointee_info_of_smir(ty, span).size.meta_kind();
+                let meta_kind = self.pointee_info_of_smir(ty, span).layout.meta_kind();
 
                 let ptr_ty = PtrType::Raw { meta_kind };
 

--- a/tooling/minitest/src/tests/ill_formed.rs
+++ b/tooling/minitest/src/tests/ill_formed.rs
@@ -26,7 +26,7 @@ fn too_large_local() {
     let stmts = &[];
 
     let prog = small_program(locals, stmts);
-    assert_ill_formed::<BasicMem>(prog, "SizeStrategy: size not valid");
+    assert_ill_formed::<BasicMem>(prog, "LayoutStrategy: size not valid");
 }
 
 #[test]

--- a/tooling/minitest/src/tests/size_of_val.rs
+++ b/tooling/minitest/src/tests/size_of_val.rs
@@ -5,8 +5,7 @@ use miniutil::DefaultTarget;
 fn assume_size_of_ty(f: &mut FunctionBuilder, size: usize, ty: Type) {
     // This is now kind of ugly, but there is no way to get a minirust reference type for a given minirust type anymore.
     let pointee = PointeeInfo {
-        size: ty.size::<DefaultTarget>(),
-        align: ty.align::<DefaultTarget>(),
+        layout: ty.layout::<DefaultTarget>(),
         inhabited: true,
         freeze: false,
         unpin: false,

--- a/tooling/minitest/src/tests/spawn_join.rs
+++ b/tooling/minitest/src/tests/spawn_join.rs
@@ -1,3 +1,5 @@
+use miniutil::DefaultTarget;
+
 use crate::*;
 
 fn dummy_function() -> Function {
@@ -38,9 +40,8 @@ fn thread_spawn_spurious_race() {
     let pp_ptype = <*const *const ()>::get_type(); // Pointer pointer place type.
     let locals = [pp_ptype, <u32>::get_type()];
 
-    let size =
-        const_int_typed::<usize>(<*const ()>::get_size().expect_sized("void ptr is sized").bytes());
-    let align = const_int_typed::<usize>(<*const ()>::get_align().bytes());
+    let size = const_int_typed::<usize>(DefaultTarget::PTR_SIZE.bytes());
+    let align = const_int_typed::<usize>(DefaultTarget::PTR_ALIGN.bytes());
 
     let b0 = block!(storage_live(0), allocate(size, align, local(0), 1));
     let b1 = block!(

--- a/tooling/miniutil/src/build/global.rs
+++ b/tooling/miniutil/src/build/global.rs
@@ -2,7 +2,7 @@ use crate::build::*;
 
 impl ProgramBuilder {
     pub fn declare_global_zero_initialized<T: TypeConv>(&mut self) -> PlaceExpr {
-        let bytes = List::from_elem(Some(0), T::get_size().expect_sized("T is `Sized`").bytes());
+        let bytes = List::from_elem(Some(0), T::get_size().bytes());
         let global = Global { bytes, relocations: list!(), align: <T>::get_align() };
         let name = GlobalName(Name::from_internal(self.next_global));
         self.next_global += 1;
@@ -13,7 +13,7 @@ impl ProgramBuilder {
 
 /// Global Int initialized to zero.
 pub fn global_int<T: TypeConv>() -> Global {
-    let bytes = List::from_elem(Some(0), T::get_size().expect_sized("T is `Sized`").bytes());
+    let bytes = List::from_elem(Some(0), T::get_size().bytes());
 
     Global { bytes, relocations: list!(), align: T::get_align() }
 }
@@ -21,7 +21,7 @@ pub fn global_int<T: TypeConv>() -> Global {
 /// Global pointer
 pub fn global_ptr<T: TypeConv + ?Sized>() -> Global {
     let bytes =
-        List::from_elem(Some(0), <*const T>::get_size().expect_sized("*T is `Sized`").bytes());
+        List::from_elem(Some(0), <*const T>::get_layout().expect_size("*T is `Sized`").bytes());
 
     Global { bytes, relocations: list!(), align: <*const T>::get_align() }
 }

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -61,11 +61,12 @@ fn fmt_meta_kind(kind: PointerMetaKind) -> &'static str {
 }
 
 fn fmt_pointee_info(pointee: PointeeInfo) -> String {
-    let size_str = match pointee.size {
-        SizeStrategy::Sized(size) => format!("{}", size.bytes()),
-        SizeStrategy::Slice(size) => format!("{}*len", size.bytes()),
+    let layout_str = match pointee.layout {
+        LayoutStrategy::Sized(size, align) =>
+            format!("size={}, align={}", size.bytes(), align.bytes()),
+        LayoutStrategy::Slice(size, align) =>
+            format!("size={}*len, align={}", size.bytes(), align.bytes()),
     };
-    let align = pointee.align.bytes();
     let uninhab_str = match pointee.inhabited {
         true => "",
         false => ", uninhabited",
@@ -74,8 +75,8 @@ fn fmt_pointee_info(pointee: PointeeInfo) -> String {
         true => ", freeze",
         false => "",
     };
-    let meta_str = fmt_meta_kind(pointee.size.meta_kind());
-    format!("pointee_info({meta_str}, size={size_str}, align={align}{uninhab_str}{freeze_str})")
+    let meta_str = fmt_meta_kind(pointee.layout.meta_kind());
+    format!("pointee_info({meta_str}, {layout_str}{uninhab_str}{freeze_str})")
 }
 
 /////////////////////


### PR DESCRIPTION
Since for structs with a trait object tail, the size cannot be known without knowing the align, having  separate Align and Size strategies does not work.
Therefore this PR prepares for trait objects by allowing the alignment to be dynamic and does this while merging them into a new struct `LayoutStrategy`.