### PR TITLE
Bump specr to 0.1.31

### DIFF
--- a/mini
+++ b/mini
@@ -9,7 +9,7 @@ set -e
 ## The part that is always needed
 
 # Fixed specr-transpile version
-SPECR_VERSION="0.1.30"
+SPECR_VERSION="0.1.31"
 
 # Stricter checks on CI
 if [ -n "$CI" ]; then

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -359,9 +359,9 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libspecr"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70d0ae6675beecfaa140b8c4a5450926c1f9daa8bbf7be8eeb9768d2f5f2ad6"
+checksum = "7737a4e4f3dc9274cfaf927a17ce29053aed6fc8dffb42c1cf650016540714e3"
 dependencies = [
  "gccompat-derive",
  "im",


### PR DESCRIPTION
Necessary for #246 to have https://github.com/minirust/specr/pull/13