### PR TITLE
Fix #251: check VTablePtr

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -156,12 +156,9 @@ impl<M: Memory> Machine<M> {
         };
         // It is checked in check_value that the vtable is always valid.
         let vtable = self.vtable_lookup()(ptr.thin_pointer);
-        let Some(fn_name) = vtable.methods.get(method) else {
-            // This would be a type error, but since we don't store the trait in the VTablePtr type,
-            // we do not type check this.
-            // FIXME: Store the TraitName in VTablePtr and have this be a program well-formedness requirement.
-            throw_ub!("the referenced vtable does not have an entry for the invoked method");
-        };
+        // Well-formedness of values ensures `ptr` points to a vtable of the right trait,
+        // and hence the method exists.
+        let fn_name = vtable.methods[method];
         let fn_ptr = Value::Ptr(self.fn_ptrs[fn_name].widen(None));
         ret((fn_ptr, Type::Ptr(PtrType::FnPtr)))
     }

--- a/spec/mem/pointer.md
+++ b/spec/mem/pointer.md
@@ -142,7 +142,8 @@ pub enum PtrType {
         meta_kind: PointerMetaKind,
     },
     FnPtr,
-    VTablePtr,
+    /// This is a "stand-alone" vtable pointer, something that does not exist in surface Rust.
+    VTablePtr(TraitName),
 }
 ```
 
@@ -152,7 +153,7 @@ impl PtrType {
     pub fn safe_pointee(self) -> Option<PointeeInfo> {
         match self {
             PtrType::Ref { pointee, .. } | PtrType::Box { pointee, .. } => Some(pointee),
-            PtrType::Raw { .. } | PtrType::FnPtr | PtrType::VTablePtr => None,
+            PtrType::Raw { .. } | PtrType::FnPtr | PtrType::VTablePtr(_) => None,
         }
     }
 
@@ -160,7 +161,7 @@ impl PtrType {
         match self {
             PtrType::Ref { pointee, .. } | PtrType::Box { pointee, .. } => pointee.layout.meta_kind(),
             PtrType::Raw { meta_kind, .. } => meta_kind,
-            PtrType::FnPtr | PtrType::VTablePtr => PointerMetaKind::None,
+            PtrType::FnPtr | PtrType::VTablePtr(_) => PointerMetaKind::None,
         }
     }
 }

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -326,9 +326,10 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
                             (_, rs::TyKind::Dynamic(_, _, rs::Dyn)) => {
                                 let vtable =
                                     self.cx.get_vtable(old_pointee_rs_ty, new_pointee_rs_ty);
+                                let trait_name = self.cx.get_trait_name(new_pointee_rs_ty);
                                 build::construct_wide_pointer(
                                     operand,
-                                    build::const_vtable(vtable),
+                                    build::const_vtable(vtable, trait_name),
                                     Type::Ptr(new_ptr_ty),
                                 )
                             }

--- a/tooling/minitest/src/tests/slice.rs
+++ b/tooling/minitest/src/tests/slice.rs
@@ -103,7 +103,7 @@ fn local_not_wf() {
     let f = {
         let mut f = p.declare_function();
         // ill formed:
-        f.declare_local_with_ty(slice_ty(<u32>::get_type()));
+        f.declare_local_with_ty(<[u32]>::get_type());
         f.exit();
         p.finish_function(f)
     };

--- a/tooling/minitest/src/tests/unsized_struct.rs
+++ b/tooling/minitest/src/tests/unsized_struct.rs
@@ -76,7 +76,7 @@ fn unsized_tail() {
         let g = main.declare_local_with_ty(ref_ty_default_markers_for(g_ty));
         let g_val = construct_wide_pointer(
             addr_of(f, ref_ty_default_markers_for(f_ty)),
-            const_vtable(usize_bar_vtable),
+            const_vtable(usize_bar_vtable, trait_bar),
             ref_ty_default_markers_for(g_ty),
         );
         main.storage_live(g);
@@ -182,7 +182,7 @@ fn packed_tail() {
         let q = f.declare_local_with_ty(ref_ty_default_markers_for(q_ty));
         let q_val = construct_wide_pointer(
             load(p),
-            const_vtable(usize_send_vtable),
+            const_vtable(usize_send_vtable, trait_send),
             ref_ty_default_markers_for(q_ty),
         );
         f.storage_live(q);

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -303,8 +303,11 @@ pub fn global<T: TypeConv>(x: u32) -> PlaceExpr {
     global_by_name::<T>(GlobalName(Name::from_internal(x)))
 }
 
-pub fn const_vtable(vtable_name: VTableName) -> ValueExpr {
-    ValueExpr::Constant(Constant::VTablePointer(vtable_name), Type::Ptr(PtrType::VTablePtr))
+pub fn const_vtable(vtable_name: VTableName, trait_name: TraitName) -> ValueExpr {
+    ValueExpr::Constant(
+        Constant::VTablePointer(vtable_name),
+        Type::Ptr(PtrType::VTablePtr(trait_name)),
+    )
 }
 
 pub fn vtable_method_lookup(operand: ValueExpr, method: TraitMethodName) -> ValueExpr {

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -52,7 +52,7 @@ pub(super) fn fmt_ptr_type(ptr_ty: PtrType) -> FmtExpr {
             FmtExpr::NonAtomic(format!("*raw({meta_kind_str})"))
         }
         PtrType::FnPtr => FmtExpr::Atomic(format!("fn()")),
-        PtrType::VTablePtr => FmtExpr::Atomic("{vtable}".into()),
+        PtrType::VTablePtr(_) => FmtExpr::Atomic("{vtable}".into()),
     }
 }
 


### PR DESCRIPTION
My fix for #251 was to do as the comment said, and make sure all VTablePtr must point to an allocated vtable in the language invariant check. Previously this was only done for the metadata, not the pointers themselves.
Additionally, this PR adds trait information for vtablePtr pointer types.