### PR TITLE
Add comparasion of wide pointers

### DIFF
--- a/spec/lang/step/operators.md
+++ b/spec/lang/step/operators.md
@@ -321,52 +321,59 @@ impl<M: Memory> Machine<M> {
 
 ```rust
 impl<M: Memory> Machine<M> {
-    fn eval_rel_op(rel: RelOp, left: Int, right: Int) -> (Value<M>, Type) {
+    /// Turns the ordering from the comparasion result into a value, depending on the operation.
+    fn eval_rel_op(rel: RelOp, ord: std::cmp::Ordering) -> (Value<M>, Type) {
         use RelOp::*;
-        let b = match rel {
-            Lt => left < right,
-            Gt => left > right,
-            Le => left <= right,
-            Ge => left >= right,
-            Eq => left == right,
-            Ne => left != right,
+        match rel {
+            Lt => (Value::Bool(ord.is_lt()), Type::Bool),
+            Gt => (Value::Bool(ord.is_gt()), Type::Bool),
+            Le => (Value::Bool(ord.is_le()), Type::Bool),
+            Ge => (Value::Bool(ord.is_ge()), Type::Bool),
+            Eq => (Value::Bool(ord.is_eq()), Type::Bool),
+            Ne => (Value::Bool(ord.is_ne()), Type::Bool),
             Cmp => {
-                // 3-way comparison.
-                let result = if left < right {
-                    Int::from(-1)
-                } else if left == right {
-                    Int::from(0)
-                } else {
-                    Int::from(1)
+                let val = match ord {
+                    std::cmp::Ordering::Less => -1,
+                    std::cmp::Ordering::Equal => 0,
+                    std::cmp::Ordering::Greater => 1,
                 };
-
-                // FIXME avoid using early return
-                return (Value::Int(result), Type::Int(IntType::I8));
+                (Value::Int(Int::from(val)), Type::Int(IntType::I8))
             }
-        };
-        (Value::Bool(b), Type::Bool)
-    }
-    /// Prepare a value for being compared with a `RelOp`. This involves turning it into an `Int`.
-    fn prepare_for_rel_op(val: Value<M>) -> Int {
-        match val {
-            Value::Int(i) => i,
-            Value::Bool(b) => if b { Int::from(1) } else { Int::from(0) },
-            Value::Ptr(p) if p.metadata.is_none() => p.thin_pointer.addr,
-            // TODO(UnsizedTypes): Prepare wide pointer for rel op: `addr * (MAX_META_VALUE+1) + meta_value`
-            Value::Ptr(_) => unimplemented!("comparing pointer with metadata"),
-            _ => panic!("invalid value for relational operator"),
         }
     }
+    /// Compares two pointers including their metadata, but ignoring provenance.
+    fn compare_ptr(left: Pointer<M::Provenance>, right: Pointer<M::Provenance>) -> std::cmp::Ordering {
+        let thin_cmp = left.thin_pointer.addr.cmp(&right.thin_pointer.addr);
+        let meta_cmp = match (left.metadata, right.metadata) {
+            (None, None) => std::cmp::Ordering::Equal,
+            (Some(PointerMeta::ElementCount(l)), Some(PointerMeta::ElementCount(r))) => l.cmp(&r),
+            (Some(PointerMeta::VTablePointer(l)), Some(PointerMeta::VTablePointer(r))) => l.addr.cmp(&r.addr),
+            _ => panic!("unmatching metadata in wide pointer comparasion"),
+        };
+        // Lexicographically compare on first the thin pointer and then the metadata
+        thin_cmp.then(meta_cmp)
+    }
+
     fn eval_bin_op(
         &self,
         BinOp::Rel(rel_op): BinOp,
         (left, l_ty): (Value<M>, Type),
         (right, _r_ty): (Value<M>, Type)
     ) -> Result<(Value<M>, Type)> {
-        let left = Self::prepare_for_rel_op(left);
-        let right = Self::prepare_for_rel_op(right);
+        let ord = match (l_ty, left, right) {
+            (Type::Int(_), Value::Int(left), Value::Int(right)) => {
+                left.cmp(&right)
+            }
+            (Type::Bool, Value::Bool(left), Value::Bool(right)) => {
+                left.cmp(&right)
+            }
+            (Type::Ptr(_), Value::Ptr(left), Value::Ptr(right)) => {
+                Self::compare_ptr(left, right)
+            }
+            _ => panic!("relational operator on incomparable type or value-type mismatch"),
+        };
 
-        ret(Self::eval_rel_op(rel_op, left, right))
+        ret(Self::eval_rel_op(rel_op, ord))
     }
 }
 ```

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -453,10 +453,6 @@ impl ValueExpr {
                     Rel(rel_op) => {
                         ensure_wf(matches!(left, Type::Int(_) | Type::Bool | Type::Ptr(_)), "BinOp::Rel: invalid left type")?;
                         ensure_wf(right == left, "BinOp::Rel: invalid right type")?;
-                        if let Type::Ptr(ptr_ty) = left {
-                            // TODO(UnsizedTypes): add support for this
-                            ensure_wf(ptr_ty.meta_kind() == PointerMetaKind::None, "BinOp::Rel: cannot compare wide pointers (yet)")?;
-                        }
                         match rel_op {
                             RelOp::Cmp => Type::Int(IntType::I8),
                             _ => Type::Bool,


### PR DESCRIPTION
The TODO was left open to support RelOp on wide pointers. This PR introduces this by using lexicographic ordering and ignoring provenance.
For vtable this uses the address in the pointer metadata, meaning also wide pointers with identical underlying vtables, but differing allocations will not be considered equal.
As far as I know this is the current state in rustc.