### PR TITLE
Fix wide pointer ABI compatibility

### DIFF
--- a/spec/lang/step/terminators.md
+++ b/spec/lang/step/terminators.md
@@ -82,9 +82,10 @@ fn check_abi_compatibility(
             caller_ty == callee_ty,
         (Type::Bool, Type::Bool) =>
             true,
-        (Type::Ptr(_), Type::Ptr(_)) =>
-            // The kind of pointer and pointee details do not matter for ABI.
-            true,
+        (Type::Ptr(caller_ty), Type::Ptr(callee_ty)) =>
+            // The kind of pointer and pointee details do not matter for ABI,
+            // however, the metadata kind does.
+            caller_ty.meta_kind() == callee_ty.meta_kind(),
         (Type::Tuple { fields: caller_fields, size: caller_size, align: caller_align },
          Type::Tuple { fields: callee_fields, size: callee_size, align: callee_align }) =>
             caller_fields.len() == callee_fields.len() &&

--- a/tooling/minitest/src/tests/wide_ptr.rs
+++ b/tooling/minitest/src/tests/wide_ptr.rs
@@ -15,7 +15,8 @@ fn ub_wide_thin_abi_incompatible() {
         let mut f = p.declare_function();
         let x = f.declare_local::<u32>();
         f.storage_live(x);
-        // UB: &u32 and &[u32] are different size and thus certainly not abi compatible.
+        // UB: `*const u32` and `*const [u32]` are different size and thus certainly
+        // not ABI compatible.
         f.call_ignoreret(fn_ptr(foo), &[by_value(addr_of(x, <*const u32>::get_type()))]);
         f.exit();
         p.finish_function(f)

--- a/tooling/minitest/src/tests/wide_ptr.rs
+++ b/tooling/minitest/src/tests/wide_ptr.rs
@@ -1,6 +1,31 @@
 use crate::*;
 
 #[test]
+fn ub_wide_thin_abi_incompatible() {
+    let mut p = ProgramBuilder::new();
+
+    let foo = {
+        let mut f = p.declare_function();
+        let _arg = f.declare_arg::<*const [u32]>();
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let main = {
+        let mut f = p.declare_function();
+        let x = f.declare_local::<u32>();
+        f.storage_live(x);
+        // UB: &u32 and &[u32] are different size and thus certainly not abi compatible.
+        f.call_ignoreret(fn_ptr(foo), &[by_value(addr_of(x, <*const u32>::get_type()))]);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(main);
+    assert_ub::<BasicMem>(p, "call ABI violation: argument types are not compatible");
+}
+
+#[test]
 fn get_metadata_non_ptr_ill_formed() {
     let mut p = ProgramBuilder::new();
 


### PR DESCRIPTION
Fixes a bug introduced in #225, where wide and thin pointers are still considered ABI compatible.
Now the `PointerMetaKind` must match.