### PR TITLE
Add unwind payload

### DIFF
--- a/spec/lang/step/intrinsics.md
+++ b/spec/lang/step/intrinsics.md
@@ -588,3 +588,34 @@ impl<M: Memory> Machine<M> {
     }
 }
 ```
+## GetPayload
+
+```rust
+impl<M: Memory> Machine<M> {
+    fn eval_intrinsic(
+        &mut self,
+        IntrinsicOp::GetUnwindPayload: IntrinsicOp,
+        arguments: List<(Value<M>, Type)>,
+        ret_ty: Type,
+    ) -> NdResult<Value<M>> {
+        if arguments.len() != 0 {
+            throw_ub!("invalid number of arguments for `GetUnwindPayload` intrinsic");
+        }
+
+        let Type::Ptr(ret_ptr_ty) = ret_ty else {
+            throw_ub!("invalid return type for `GetUnwindPayload` intrinsic");
+        };
+        if ret_ptr_ty.meta_kind() != PointerMetaKind::None {
+            throw_ub!("invalid return type for `GetUnwindPayload` intrinsic");
+        }
+
+        let Some(thin_pointer) = self.active_thread().unwind_payloads.last() else {
+            throw_ub!("GetUnwindPayload: the payload stack is empty");
+        };
+
+        let payload_pointer = Value::Ptr(Pointer { thin_pointer, metadata: None });
+
+        ret(payload_pointer)
+    }
+}
+```

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -370,8 +370,15 @@ pub enum Terminator {
     /// Return from the current function.
     Return,
     /// Starts unwinding, jump to the indicated cleanup block.
-    StartUnwind(BbName),
+    StartUnwind {
+        /// The unwinding payload. This should evaluate to a thin pointer.
+        unwind_payload:  ValueExpr,
+        /// The cleanup or catch block the execution jumps to.
+        unwind_block: BbName,
+    },
     /// Stops unwinding, jump to the indicated regular block.
+    /// This also removes the topmost unwinding payload.
+    /// UB if not currently unwinding.
     StopUnwind(BbName),
     /// Ends this function call. The unwinding should continue at the caller's stack frame.
     ResumeUnwind,
@@ -430,6 +437,8 @@ pub enum IntrinsicOp {
     PointerExposeProvenance,
     /// Create a new pointer from the given address with some previously exposed provenance.
     PointerWithExposedProvenance,
+    /// Access the current unwinding payload. UB if not currently unwinding.
+    GetUnwindPayload,
 }
 ```
 

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -746,8 +746,17 @@ impl Terminator {
             Return => {
                 ensure_wf(block_kind == BbKind::Regular, "Terminator::Return has to be called in a regular block")?;
             }
-            StartUnwind(unwind_block) => {
-                ensure_wf(block_kind == BbKind::Regular, "Terminator::StartUnwind has to be called in a regular block")?;
+            StartUnwind { unwind_payload, unwind_block } => {
+                let payload_type = unwind_payload.check_wf::<T>(func.locals, prog)?;
+                ensure_wf(
+                    payload_type == Type::Ptr(PtrType::Raw { meta_kind: PointerMetaKind::None }),
+                    "Terminator::StartUnwind: the unwind payload should be a raw pointer",
+                )?;
+                
+                ensure_wf(
+                    block_kind == BbKind::Regular,
+                    "Terminator::StartUnwind has to be called in a regular block",
+                )?;
                 func.check_unwind_block(block_kind, unwind_block)?;
             }
             StopUnwind(next_block) => {

--- a/tooling/minitest/src/tests/blocks.rs
+++ b/tooling/minitest/src/tests/blocks.rs
@@ -88,7 +88,7 @@ fn call_unwindblock_wrong_kind() {
 /// This test checks that using `StartUnwind` to jump to a regular block results in an ill-formed program.
 #[test]
 fn start_unwind_wrong_nextblock() {
-    let bb0 = block!(start_unwind(BbName(Name::from_internal(1))));
+    let bb0 = block!(start_unwind(unit_ptr(), BbName(Name::from_internal(1))));
     let bb1 = block!(exit());
     let f = function(Ret::No, 0, &[], &[bb0, bb1]);
     let p = program(&[f]);
@@ -103,7 +103,7 @@ fn return_in_cleanup() {
     let f = {
         let mut f = p.declare_function();
         let c = f.cleanup_block(|f| f.return_());
-        f.start_unwind(c);
+        f.start_unwind(unit_ptr(), c);
         p.finish_function(f)
     };
 
@@ -130,9 +130,9 @@ fn start_unwind_in_cleanup() {
         let mut f = p.declare_function();
         let outer_cleanup = f.cleanup_block(|f| {
             let inner_cleanup = f.cleanup_block(|f| f.exit());
-            f.start_unwind(inner_cleanup);
+            f.start_unwind(unit_ptr(), inner_cleanup);
         });
-        f.start_unwind(outer_cleanup);
+        f.start_unwind(unit_ptr(), outer_cleanup);
         p.finish_function(f)
     };
     let p = p.finish_program(f);
@@ -218,7 +218,7 @@ fn unwind_in_catch_block() {
         let mut f = p.declare_function();
         f.print(const_int(2));
         let cleanup = f.cleanup_block(|f| f.resume_unwind());
-        f.start_unwind(cleanup);
+        f.start_unwind(unit_ptr(), cleanup);
         p.finish_function(f)
     };
 
@@ -250,7 +250,7 @@ fn unwind_in_catch_block() {
 fn goto_from_cleanup_to_catch() {
     let locals = [<()>::get_type()];
 
-    let b0 = block!(storage_live(0), Terminator::StartUnwind(BbName(Name::from_internal(1))));
+    let b0 = block!(storage_live(0), start_unwind(unit_ptr(), BbName(Name::from_internal(1))));
     let b1 = block(&[], Terminator::Goto(BbName(Name::from_internal(2))), BbKind::Cleanup);
     let b2 = block(&[], exit(), BbKind::Catch);
 

--- a/tooling/minitest/src/tests/catch_unwind.rs
+++ b/tooling/minitest/src/tests/catch_unwind.rs
@@ -9,7 +9,7 @@ fn catch_unwind() {
         let mut f = p.declare_function();
         f.print(const_int(2));
         let cleanup = f.cleanup_block(|f| f.resume_unwind());
-        f.start_unwind(cleanup);
+        f.start_unwind(unit_ptr(), cleanup);
         p.finish_function(f)
     };
 

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -45,6 +45,7 @@ mod trait_object;
 mod uninit_read;
 mod unreachable;
 mod unsized_struct;
+mod unwind_payload;
 mod unwinding;
 mod wide_ptr;
 mod zst;

--- a/tooling/minitest/src/tests/unwind_payload.rs
+++ b/tooling/minitest/src/tests/unwind_payload.rs
@@ -1,0 +1,206 @@
+use crate::*;
+
+/// This tests the basic functionality of the panic payload.
+#[test]
+fn basic_test() {
+    let mut p = ProgramBuilder::new();
+    let f = {
+        // mut x : i32 = 5;
+        // x_ptr = &mut x as *mut u8
+        let mut f = p.declare_function();
+        let x = f.declare_local::<i32>();
+        let x_ptr = f.declare_local::<*mut u8>();
+        let ret = f.declare_local::<*mut u8>();
+        f.storage_live(x);
+        f.storage_live(x_ptr);
+        f.assign(x, const_int(5));
+        f.assign(x_ptr, addr_of(x, <*mut u8>::get_type()));
+
+        // StartUnwind(x_ptr);
+        // ret = get_unwind_payload();
+        // StopUnwind();
+        let cont = f.declare_block();
+        let catch_block = f.catch_block(|f| {
+            f.storage_live(ret);
+            f.get_unwind_payload(ret);
+            f.stop_unwind(cont);
+        });
+        f.start_unwind(load(x_ptr), catch_block);
+        f.set_cur_block(cont, BbKind::Regular);
+
+        // assume(x_ptr == ret)
+        f.assume(eq(load(x_ptr), load(ret)));
+        // assume(5 == *ret)
+        f.assume(eq(const_int(5), load(deref(load(ret), <i32>::get_type()))));
+        // *ret = 3;
+        f.assign(deref(load(ret), <i32>::get_type()), const_int(3));
+        // assume(x == 3);
+        f.assume(eq(load(x), const_int(3)));
+        f.exit();
+        p.finish_function(f)
+    };
+    let p = p.finish_program(f);
+    dump_program(p);
+    assert_stop::<BasicMem>(p);
+}
+
+/// Tests a recursive function that panics, recurses, and catches each panic.
+/// Verifies that `get_unwind_payload()` returns the correct payload for each panic.
+/// ```rust
+/// fn rec_fn(mut x: i32) {
+///     if x == 0 {
+///         return;
+///     }
+///     let x_ptr = &mut x as *mut u8
+///     StartUnwind(x_ptr)
+///     rec_fn(x-1);
+///     let payload = get_unwind_payload();
+///     assume(*payload == x);
+///     print(*payload);
+///     StopUnwind;
+///     return;
+/// }
+///
+/// fn main() {
+///     rec_fn(5);
+/// }
+/// ```
+#[test]
+fn recursive_payload_test() {
+    let mut p = ProgramBuilder::new();
+
+    let rec_fn = {
+        let mut f = p.declare_function();
+        let x = f.declare_arg::<i32>();
+        let x_ptr = f.declare_local::<*mut u8>();
+        let payload = f.declare_local::<*mut u8>();
+        let bb1 = f.declare_block();
+        let bb2 = f.declare_block();
+
+        f.if_(eq(load(x), const_int(0)), |f| f.return_(), |f| f.goto(bb1));
+        f.set_cur_block(bb1, BbKind::Regular);
+
+        f.storage_live(x_ptr);
+        f.assign(
+            x_ptr,
+            ValueExpr::AddrOf {
+                target: GcCow::new(x),
+                ptr_ty: PtrType::Raw { meta_kind: PointerMetaKind::None },
+            },
+        );
+        let cleanup = f.catch_block(|f| {
+            f.call_nounwind(
+                unit_place(),
+                fn_ptr(f.name()),
+                &[by_value(ValueExpr::BinOp {
+                    operator: BinOp::Int(IntBinOp::Sub),
+                    left: GcCow::new(load(x)),
+                    right: GcCow::new(const_int(1)),
+                })],
+            );
+            f.storage_live(payload);
+            f.get_unwind_payload(payload);
+            f.assume(eq(load(deref(load(payload), Type::Int(IntType::I32))), load(x)));
+            f.print(load(deref(load(payload), Type::Int(IntType::I32))));
+            f.stop_unwind(bb2);
+        });
+
+        f.start_unwind(load(x_ptr), cleanup);
+
+        f.set_cur_block(bb2, BbKind::Regular);
+        f.return_();
+        p.finish_function(f)
+    };
+
+    let main_fn = {
+        let mut f = p.declare_function();
+        f.call_nounwind(unit_place(), fn_ptr(rec_fn), &[by_value(const_int(5))]);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(main_fn);
+    dump_program(p);
+    assert_eq!(get_stdout::<BasicMem>(p).unwrap(), &["1", "2", "3", "4", "5"]);
+}
+
+/// Calls `get_unwind_payload()` with an empty payload stack. Results in ub.
+#[test]
+fn empty_stack() {
+    let mut p = ProgramBuilder::new();
+    let f = {
+        // mut x : i32 = 5;
+        // x_ptr = &mut x as *mut u8
+        let mut f = p.declare_function();
+        let x = f.declare_local::<i32>();
+        let x_ptr = f.declare_local::<*mut u8>();
+        let payload = f.declare_local::<*mut u8>();
+        f.storage_live(x);
+        f.storage_live(x_ptr);
+        f.assign(x, const_int(5));
+        f.assign(x_ptr, addr_of(x, <*mut u8>::get_type()));
+
+        let cont = f.declare_block();
+        let catch_block = f.catch_block(|f| f.stop_unwind(cont));
+
+        f.start_unwind(load(x_ptr), catch_block);
+
+        f.set_cur_block(cont, BbKind::Regular);
+        f.storage_live(payload);
+        f.get_unwind_payload(payload);
+        f.exit();
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    dump_program(p);
+    assert_ub::<BasicMem>(p, "GetUnwindPayload: the payload stack is empty");
+}
+
+/// In this test the return place of `get_unwind_payload()` has the wrong type. Results in ub.
+#[test]
+fn wrong_ret_ty() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let cleanup = f.cleanup_block(|f| {
+            let x = f.declare_local::<i32>();
+            f.storage_live(x);
+            f.get_unwind_payload(x);
+            f.abort();
+        });
+        f.start_unwind(unit_ptr(), cleanup);
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    dump_program(p);
+    assert_ub::<BasicMem>(p, "invalid return type for `GetUnwindPayload` intrinsic");
+}
+
+/// In this test the unwind payload has the wrong type. Results in ub.
+#[test]
+fn payload_wrong_ty() {
+    let mut p = ProgramBuilder::new();
+
+    let f = {
+        let mut f = p.declare_function();
+        let cleanup = f.cleanup_block(|f| {
+            f.abort();
+        });
+
+        let x = f.declare_local::<i32>();
+        f.storage_live(x);
+        f.assign(x, const_int(0));
+        f.start_unwind(load(x), cleanup);
+        p.finish_function(f)
+    };
+
+    let p = p.finish_program(f);
+    dump_program(p);
+    assert_ill_formed::<BasicMem>(
+        p,
+        "Terminator::StartUnwind: the unwind payload should be a raw pointer",
+    );
+}

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -331,11 +331,13 @@ pub fn downcast(root: PlaceExpr, discriminant: impl Into<Int>) -> PlaceExpr {
     PlaceExpr::Downcast { root: GcCow::new(root), discriminant: discriminant.into() }
 }
 
+/// A pointer suited for 1-aligned zero-sized accesses.
+pub fn unit_ptr() -> ValueExpr {
+    ValueExpr::Constant(Constant::PointerWithoutProvenance(1.into()), <*const ()>::get_type())
+}
 /// A place suited for 1-aligned zero-sized accesses.
 pub fn unit_place() -> PlaceExpr {
-    let ptr =
-        ValueExpr::Constant(Constant::PointerWithoutProvenance(1.into()), <*const ()>::get_type());
-    PlaceExpr::Deref { operand: GcCow::new(ptr), ty: <()>::get_type() }
+    PlaceExpr::Deref { operand: GcCow::new(unit_ptr()), ty: <()>::get_type() }
 }
 
 pub fn by_value(val: ValueExpr) -> ArgumentExpr {

--- a/tooling/miniutil/src/fmt/function.rs
+++ b/tooling/miniutil/src/fmt/function.rs
@@ -219,9 +219,10 @@ fn fmt_terminator(t: Terminator, comptypes: &mut Vec<CompType>) -> String {
         Terminator::Return => {
             format!("    return;")
         }
-        Terminator::StartUnwind(block_name) => {
-            let bb_name = fmt_bb_name(block_name);
-            format!("    start unwind -> unwind: {bb_name} ")
+        Terminator::StartUnwind { unwind_payload, unwind_block } => {
+            let bb_name = fmt_bb_name(unwind_block);
+            let unwind_payload = fmt_value_expr(unwind_payload, comptypes).to_string();
+            format!("    start unwind({unwind_payload}) -> unwind: {bb_name} ")
         }
         Terminator::StopUnwind(block_name) => {
             let bb_name = fmt_bb_name(block_name);
@@ -251,6 +252,7 @@ fn fmt_terminator(t: Terminator, comptypes: &mut Vec<CompType>) -> String {
                 IntrinsicOp::Lock(IntrinsicLockOp::Release) => "lock_release",
                 IntrinsicOp::PointerExposeProvenance => "pointer_expose_provenance",
                 IntrinsicOp::PointerWithExposedProvenance => "pointer_with_exposed_provenance",
+                IntrinsicOp::GetUnwindPayload => "get_unwind_payload",
             };
             let args: Vec<_> =
                 arguments.iter().map(|arg| fmt_value_expr(arg, comptypes).to_string()).collect();


### PR DESCRIPTION
- `StartUnwind` now takes a payload pointer as an argument and pushes  it onto the payload stack.
- `StopUnwind` pops the payload pointer from the payload stack.
- Add `GetPayload` intrinsic to access the panic payload.