### PR TITLE
fix edge-cases around TB protectors

### DIFF
--- a/spec/mem/tree_borrows/memory.md
+++ b/spec/mem/tree_borrows/memory.md
@@ -142,7 +142,7 @@ impl<T: Target> TreeBorrowsMemory<T> {
             assert_ne!(protected_node.protected, Protected::No);
 
             if !allocation.live {
-                // Looks like the protected memory got deallocated anyways. This is fine,
+                // Looks like the protected memory got deallocated already. This is fine,
                 // and expected for weak allocations. For strong allocations, this can only
                 // happen if the protector was zero-sized or entirely on interior mutable
                 // data, but nonetheless it can happen.

--- a/spec/mem/tree_borrows/tree.md
+++ b/spec/mem/tree_borrows/tree.md
@@ -235,11 +235,21 @@ impl Node {
 
     /// Recusively check whether there is a strongly protected node in `self` and all its descendants.
     /// This is used to reject deallocation as long as there's a strong protector anywhere.
+    /// Note that not all strongly protected nodes prevent deallocation. Specifically, if all offsets in
+    /// the allocation fulfill the following property, the strong protector is not considered:
+    /// * the offset has `Cell` permission, i.e. is interior mutable.
+    /// * the offset was not accessed yet, i.e. the protector is not active at this offset.
     ///
-    /// Return true if there is a strongly protected node.
-    fn contains_strong_protector(&self) -> bool {
-        // FIXME: probably needs adjustment to ignore `Cell` nodes.
-        self.protected == Protected::Strong || self.children.any(|child| child.contains_strong_protector())
+    /// Return true if there is a strongly protected node preventing deallocation.
+    fn contains_strong_protector_preventing_deallocation(&self) -> bool {
+        // This node must have a protector...
+        (self.protected == Protected::Strong
+            // which is applicable to at least one offset.
+            && self
+                .location_states
+                .any(|st| st.permission != Permission::Cell && st.accessed == Accessed::Yes))
+            // if this node has has no such protector, we recurse.
+            || self.children.any(|child| child.contains_strong_protector_preventing_deallocation())
     }
 }
 ```

--- a/spec/mem/tree_borrows/tree.md
+++ b/spec/mem/tree_borrows/tree.md
@@ -240,7 +240,7 @@ impl Node {
     /// This is used to reject deallocation as long as there's a strong protector anywhere.
     /// Note that not all strongly protected nodes prevent deallocation. Specifically, if all offsets in
     /// the allocation fulfill the following property, the strong protector is not considered:
-    /// * the offset has `Cell` permission, i.e. is interior mutable.
+    /// * the offset has `Cell` permission, i.e. is interior mutable, or
     /// * the offset was not accessed yet, i.e. the protector is not active at this offset.
     ///
     /// Return true if there is a strongly protected node preventing deallocation.

--- a/spec/mem/tree_borrows/tree.md
+++ b/spec/mem/tree_borrows/tree.md
@@ -210,6 +210,9 @@ impl Node {
             // a foreign read/write of an Unique location should be UB.
             // This condition is hence equivalent to checking whether there was a (local) write to this location.
             let access_kind = match permission {
+                // As a special case, we do not perform any access on interior mutable data,
+                // because the protector does not really apply there.
+                Permission::Cell => continue,
                 Permission::Unique => AccessKind::Write,
                 _ => AccessKind::Read,
             };

--- a/tooling/minimize/tests/pass/tree_borrows/deallocate_interior_mut_protector.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/deallocate_interior_mut_protector.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// Check that deallocating an allocation is allowed even in the presence of a strong protector only covering interior mutable data.
+
+extern crate intrinsics;
+use intrinsics::*;
+use std::cell::Cell;
+
+// `x` is strongly protected but covers only `Cell` bytes.
+fn foo(_x: &Cell<u8>, ptr: *mut u8) {
+    unsafe { deallocate(ptr, 1, 1) };
+}
+
+fn main() {
+    let raw = unsafe { allocate(1, 1) };
+    let x = unsafe { &mut *(raw as *mut Cell<u8>) };
+
+    foo(x, raw);
+}

--- a/tooling/minimize/tests/pass/tree_borrows/deallocate_zero_sized_protector.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/deallocate_zero_sized_protector.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: --minimize-tree-borrows
 
-// Check that deallocating a zero-sized allocation containing a strongly protected node is UB.
+// Check that deallocating an allocation is allowed even in the presence of a zero-sized strong protector.
 
 extern crate intrinsics;
 use intrinsics::*;
@@ -11,7 +11,7 @@ fn foo(_x: &mut (), ptr: *mut u8) {
 }
 
 fn main() {
-    let raw = unsafe { allocate(1, 1) } ;
+    let raw = unsafe { allocate(1, 1) };
     let x = unsafe { &mut *(raw as *mut ()) };
 
     foo(x, raw);

--- a/tooling/minimize/tests/pass/tree_borrows/protector_end_access_special_cases.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/protector_end_access_special_cases.rs
@@ -3,18 +3,18 @@
 // test that protector end writes don't trigger for non-accessed or `Cell` bytes.
 use std::cell::Cell;
 
-fn other_function_zero_sized(ref_to_fst_elem: &mut (), ptr_to_vec: *mut u8) -> *mut u8 {
-    // ref_to_fst_elem is zero-sized so really nothing should happen at the protector end write.
-    *ref_to_fst_elem = ();
-    // this creates a reference that is Reserved Lazy on the first element (offset 0).
-    // It does so by doing a proper retag on the second element (offset 1), which is fine
-    // since nothing else happens at that offset, but the lazy init mechanism means it's
-    // also reserved at offset 0, but not initialized.
-    let funky_ptr_lazy_on_fst_elem = unsafe { ((&mut *(ptr_to_vec.add(1))) as *mut u8).sub(1) };
-    return funky_ptr_lazy_on_fst_elem;
-}
-
 fn check_zero_sized() {
+    fn other_function_zero_sized(ref_to_fst_elem: &mut (), ptr_to_vec: *mut u8) -> *mut u8 {
+        // ref_to_fst_elem is zero-sized so really nothing should happen at the protector end write.
+        *ref_to_fst_elem = ();
+        // this creates a reference that is Reserved Lazy on the first element (offset 0).
+        // It does so by doing a proper retag on the second element (offset 1), which is fine
+        // since nothing else happens at that offset, but the lazy init mechanism means it's
+        // also reserved at offset 0, but not initialized.
+        let funky_ptr_lazy_on_fst_elem = unsafe { ((&mut *(ptr_to_vec.add(1))) as *mut u8).sub(1) };
+        return funky_ptr_lazy_on_fst_elem;
+    }
+
     let mut v = [42u8, 1];
     // get a pointer to the root of the allocation
     // note that it's not important it's the actual root, what matters is that it's a parent
@@ -29,19 +29,18 @@ fn check_zero_sized() {
     }
 }
 
-fn other_function_cell(ref_to_fst_elem: &Cell<u8>, ptr_to_vec: *mut u8) -> *mut u8 {
-    // ref_to_fst_elem is `Cell` so the protector does not actually apply to it.
-    // Even if we write to it, no protector end actions should be triggered.
-    ref_to_fst_elem.set(42u8);
-    // this creates a reference that is Reserved Lazy on the first element (offset 0).
-    // It does so by doing a proper retag on the second element (offset 1), which is fine
-    // since nothing else happens at that offset, but the lazy init mechanism means it's
-    // also reserved at offset 0, but not initialized.
-    let funky_ptr_lazy_on_fst_elem = unsafe { ((&mut *(ptr_to_vec.add(1))) as *mut u8).sub(1) };
-    return funky_ptr_lazy_on_fst_elem;
-}
-
 fn check_cell() {
+    fn other_function_cell(ref_to_fst_elem: &Cell<u8>, ptr_to_vec: *mut u8) -> *mut u8 {
+        // ref_to_fst_elem is `Cell` so the protector does not actually apply to it.
+        // Even if we write to it, no protector end actions should be triggered.
+        ref_to_fst_elem.set(42u8);
+        // this creates a reference that is Reserved Lazy on the first element (offset 0).
+        // It does so by doing a proper retag on the second element (offset 1), which is fine
+        // since nothing else happens at that offset, but the lazy init mechanism means it's
+        // also reserved at offset 0, but not initialized.
+        let funky_ptr_lazy_on_fst_elem = unsafe { ((&mut *(ptr_to_vec.add(1))) as *mut u8).sub(1) };
+        return funky_ptr_lazy_on_fst_elem;
+    }
     let mut v = [0u8, 1];
     // get a pointer to the root of the allocation
     // note that it's not important it's the actual root, what matters is that it's a parent

--- a/tooling/minimize/tests/pass/tree_borrows/protector_end_access_special_cases.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/protector_end_access_special_cases.rs
@@ -1,0 +1,62 @@
+//@ compile-flags: --minimize-tree-borrows
+
+// test that protector end writes don't trigger for non-accessed or `Cell` bytes.
+use std::cell::Cell;
+
+fn other_function_zero_sized(ref_to_fst_elem: &mut (), ptr_to_vec: *mut u8) -> *mut u8 {
+    // ref_to_fst_elem is zero-sized so really nothing should happen at the protector end write.
+    *ref_to_fst_elem = ();
+    // this creates a reference that is Reserved Lazy on the first element (offset 0).
+    // It does so by doing a proper retag on the second element (offset 1), which is fine
+    // since nothing else happens at that offset, but the lazy init mechanism means it's
+    // also reserved at offset 0, but not initialized.
+    let funky_ptr_lazy_on_fst_elem = unsafe { ((&mut *(ptr_to_vec.add(1))) as *mut u8).sub(1) };
+    return funky_ptr_lazy_on_fst_elem;
+}
+
+fn check_zero_sized() {
+    let mut v = [42u8, 1];
+    // get a pointer to the root of the allocation
+    // note that it's not important it's the actual root, what matters is that it's a parent
+    // of both references that will be created
+    let ptr_to_vec = &mut v[0] as *mut u8;
+    let ref_to_fst_elem: &mut () = unsafe { &mut *(ptr_to_vec as *mut ()) };
+    let funky_ptr_lazy_on_fst_elem = other_function_zero_sized(ref_to_fst_elem, ptr_to_vec);
+    // now we try to use the funky lazy pointer.
+    // It should be allowed, since no protector end write invalidated it.
+    unsafe {
+        assert!(*funky_ptr_lazy_on_fst_elem == 42);
+    }
+}
+
+fn other_function_cell(ref_to_fst_elem: &Cell<u8>, ptr_to_vec: *mut u8) -> *mut u8 {
+    // ref_to_fst_elem is `Cell` so the protector does not actually apply to it.
+    // Even if we write to it, no protector end actions should be triggered.
+    ref_to_fst_elem.set(42u8);
+    // this creates a reference that is Reserved Lazy on the first element (offset 0).
+    // It does so by doing a proper retag on the second element (offset 1), which is fine
+    // since nothing else happens at that offset, but the lazy init mechanism means it's
+    // also reserved at offset 0, but not initialized.
+    let funky_ptr_lazy_on_fst_elem = unsafe { ((&mut *(ptr_to_vec.add(1))) as *mut u8).sub(1) };
+    return funky_ptr_lazy_on_fst_elem;
+}
+
+fn check_cell() {
+    let mut v = [0u8, 1];
+    // get a pointer to the root of the allocation
+    // note that it's not important it's the actual root, what matters is that it's a parent
+    // of both references that will be created
+    let ptr_to_vec = &mut v[0] as *mut u8;
+    let ref_to_fst_elem: &Cell<u8> = Cell::from_mut(unsafe { &mut *ptr_to_vec });
+    let funky_ptr_lazy_on_fst_elem = other_function_cell(ref_to_fst_elem, ptr_to_vec);
+    // now we try to use the funky lazy pointer.
+    // It should be allowed, since no protector end write invalidated it.
+    unsafe {
+        assert!(*funky_ptr_lazy_on_fst_elem == 42);
+    }
+}
+
+fn main() {
+    check_zero_sized();
+    check_cell();
+}

--- a/tooling/minimize/tests/ub/tree_borrows/protector/deallocate_zero_sized_protector.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/protector/deallocate_zero_sized_protector.stderr
@@ -1,1 +1,0 @@
-fatal error: UB: Tree Borrows: deallocating strongly protected allocation


### PR DESCRIPTION
This implements the behavior of https://github.com/rust-lang/miri/pull/4580, and similarly allows deallocation when the protector is entirely on `Cell`s, [similar to miri](https://github.com/rust-lang/miri/blob/14dc656410abc0c9bf018e2e263297b591c58c4f/src/borrow_tracker/tree_borrows/tree.rs#L758).

It also makes sure that there are no protector end accesses to `Cell` bytes, which was also yet missing but [is done in Miri](https://github.com/rust-lang/miri/blob/fc9c59b2e5d0e745d862852df30a20ea0f7699e9/src/borrow_tracker/tree_borrows/perms.rs#L311).