### PR TITLE
tree borrows: implicit writes

### DIFF
--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -126,10 +126,10 @@ The transition function simply dispatches to evaluating the next statement/termi
 
 ```rust
 impl<M: Memory> Machine<M> {
-    pub fn new(prog: Program, stdout: DynWrite, stderr: DynWrite) -> NdResult<Machine<M>> {
+    pub fn new(prog: Program, mem_params: M::Params, stdout: DynWrite, stderr: DynWrite) -> NdResult<Machine<M>> {
         prog.check_wf::<M::T>()?;
 
-        let mut mem = ConcurrentMemory::<M>::new();
+        let mut mem = ConcurrentMemory::<M>::new(mem_params);
         let mut global_ptrs = Map::new();
         let mut fn_ptrs = Map::new();
         let mut vtable_ptrs = Map::new();

--- a/spec/mem/basic.md
+++ b/spec/mem/basic.md
@@ -311,8 +311,10 @@ impl<T: Target> Memory for BasicMemory<T> {
     /// The basic memory model does not need any per-frame data,
     /// so we set `FrameExtra` to the unit type.
     type FrameExtra = ();
+    /// The basic memory model does not have any configuration parameters.
+    type Params = ();
 
-    fn new() -> Self {
+    fn new(_params: ()) -> Self {
         Self::new()
     }
 

--- a/spec/mem/concurrent.md
+++ b/spec/mem/concurrent.md
@@ -42,9 +42,9 @@ It differs in both store and load where we also take the `Atomicity` of an opera
 
 ```rust
 impl<M: Memory> ConcurrentMemory<M> {
-    pub fn new() -> Self {
+    pub fn new(params: M::Params) -> Self {
         Self {
-            memory: M::new(),
+            memory: M::new(params),
             accesses: list![],
         }
     }

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -51,7 +51,9 @@ impl<Provenance> AbstractByte<Provenance> {
 
 ## Memory interface
 
-The MiniRust memory interface is described by the following (not-yet-complete) trait definition:
+The MiniRust memory interface is described by the following (not-yet-complete) trait definition.
+A memory model can be configured through parameters that toggle specific or experimental behavior, such as enabling implicit writes in the Tree Borrows memory model.
+These parameters are bundled into the `Params` associated type and passed to the `new` function at construction time:
 
 ```rust
 /// The "kind" of an allocation is used to distinguish, for instance, stack from heap memory.
@@ -84,7 +86,11 @@ pub trait Memory {
     /// Extra information for each stack frame.
     type FrameExtra;
 
-    fn new() -> Self;
+    /// Parameters controlling memory model behavior, passed at construction time.
+    type Params: Default;
+
+    /// Create a new instance of the memory model with the given parameters.
+    fn new(params: Self::Params) -> Self;
 
     /// Create a new allocation.
     /// The initial contents of the allocation are `AbstractByte::Uninit`.

--- a/spec/mem/tree_borrows/memory.md
+++ b/spec/mem/tree_borrows/memory.md
@@ -48,7 +48,17 @@ type TreeBorrowsProvenance = (AllocId, Path);
 The memory itself largely reuses the basic memory infrastructure, with the tree as extra state.
 
 ```rust
+/// Global parameters controlling Tree Borrows behavior.
+#[derive(Default)]
+pub struct TreeBorrowsParams {
+    /// Whether implicit writes are enabled or not.
+    pub implicit_writes: bool,
+}
+```
+
+```rust
 pub struct TreeBorrowsMemory<T: Target> {
+    params: TreeBorrowsParams,
     mem: BasicMemory<T, Path, TreeBorrowsAllocationExtra>,
 }
 
@@ -113,7 +123,7 @@ impl<T: Target> TreeBorrowsMemory<T> {
             // Add the new node to the tree
             let child_path = allocation.extra.root.add_node(parent_path, child_node);
 
-            // Perform a read access on all bytes inside the pointee whose permission requires such an access.
+            // Perform a read or write access on all bytes inside the pointee whose permission requires such an access.
             for (idx, perm) in settings.inside.iter().enumerate() {
                 let idx = Int::from(idx); // FIXME: we need a version of `enumerate` that yields `Int`s.
                 let idx = Size::from_bytes(idx).unwrap();
@@ -173,9 +183,10 @@ impl<T: Target> Memory for TreeBorrowsMemory<T> {
     type Provenance = TreeBorrowsProvenance;
     type FrameExtra = TreeBorrowsFrameExtra;
     type T = T;
+    type Params = TreeBorrowsParams;
 
-    fn new() -> Self {
-        Self { mem: BasicMemory::new() }
+    fn new(params: TreeBorrowsParams) -> Self {
+        Self { mem: BasicMemory::new(), params }
     }
 
     fn allocate(&mut self, kind: AllocationKind, size: Size, align: Align) -> NdResult<ThinPointer<Self::Provenance>>  {
@@ -233,7 +244,7 @@ impl<T: Target> Memory for TreeBorrowsMemory<T> {
         fn_entry: bool,
         vtable_lookup: impl Fn(ThinPointer<Self::Provenance>) -> crate::lang::VTable + 'static,
     ) -> Result<Pointer<Self::Provenance>> {
-        ret(if let Some(perms) = ReborrowSettings::new(ptr, ptr_type, fn_entry, vtable_lookup) {
+        ret(if let Some(perms) = ReborrowSettings::new(ptr, ptr_type, fn_entry, self.params, vtable_lookup) {
             self.reborrow(ptr.thin_pointer, perms, frame_extra)?.widen(ptr.metadata)
         } else {
             ptr

--- a/spec/mem/tree_borrows/reborrow_settings.md
+++ b/spec/mem/tree_borrows/reborrow_settings.md
@@ -93,8 +93,10 @@ impl ReborrowSettings {
         ptr: Pointer<TreeBorrowsProvenance>,
         ptr_type: PtrType,
         fn_entry: bool,
+        params: TreeBorrowsParams,
         vtable_lookup: impl Fn(ThinPointer<TreeBorrowsProvenance>) -> crate::lang::VTable + 'static,
     ) -> Option<Self> {
+        // Returns None for `Raw`, `FnPtr` and `VTablePtr`, so `ptr_type` can only be `Ref` and `Box` from here.
         let Some(pointee_info) = ptr_type.safe_pointee() else {
             return None;
         };
@@ -115,26 +117,45 @@ impl ReborrowSettings {
             Protected::No
         };
 
-        // Helper to choose the correct permission, based on protection.
-        let mk_perm = |unprot, prot| if protected.yes() { Permission::Prot(prot) } else { Permission::Unprot(unprot) };
+        // Implicit writes are only performed for protected references, and only if globally enabled.
+        let implicit_writes_enabled = protected.yes() && params.implicit_writes;
 
-        // Determine permissions.
-        let no_cell_perm = match ptr_type {
-            // Shared references are frozen.
-            PtrType::Ref { mutbl: Mutability::Immutable, .. } => mk_perm(PermissionUnprot::Frozen, PermissionProt::Frozen { had_local_read: false }),
-            // Mutable references and Boxes are reserved.
-            _ => mk_perm(PermissionUnprot::Reserved, PermissionProt::Reserved { had_local_read: false, had_foreign_read: false }),
+        // Helper to compute the permission, given whether it is inside the pointee and whether it is frozen.
+        let perm = |inside: bool, frozen: bool| {
+            // Helper to choose the correct permission, based on protection.
+            let mk_perm = |unprot, prot| if protected.yes() { Permission::Prot(prot) } else { Permission::Unprot(unprot) };
+
+            match ptr_type {
+                // Shared references
+                PtrType::Ref { mutbl: Mutability::Immutable, .. } =>
+                    if frozen {
+                        mk_perm(PermissionUnprot::Frozen, PermissionProt::Frozen { had_local_read: false })
+                    } else {
+                        mk_perm(PermissionUnprot::Cell, PermissionProt::Cell)
+                    },
+                // Mutable references and Boxes (Boxes are treated the same as mutable references)
+                PtrType::Ref { mutbl: Mutability::Mutable, .. } | PtrType::Box { .. } =>
+                    if implicit_writes_enabled && inside {
+                        // The implicit write only happens on the inside.
+                        // `implicit_writes_enabled` implies `protected.yes()`, so this case is always protected.
+                        assert!(protected.yes());
+                        Permission::Prot(PermissionProt::Unique)
+                    } else {
+                        // Unprotected interior-mutable references and boxes start in `ReservedIm`, but if they are protected we ignore the `Im`
+                        mk_perm(
+                          if frozen { PermissionUnprot::Reserved } else { PermissionUnprot::ReservedIm },
+                          PermissionProt::Reserved { had_local_read: false, had_foreign_read: false }
+                        )
+                    },
+                // Cannot occur: `safe_pointee()` returns `None` for these variants.
+                PtrType::Raw { .. } | PtrType::FnPtr | PtrType::VTablePtr(_) => unreachable!("safe_pointee() returns None for Raw, FnPtr, and VTablePtr; should have returned early on function entry"),
+            }
         };
-        let cell_perm = match ptr_type {
-            // Shared references to UnsafeCell use the "transparent" Cell permission.
-            PtrType::Ref { mutbl: Mutability::Immutable, .. } => mk_perm(PermissionUnprot::Cell, PermissionProt::Cell),
-            // Unprotected mutable references and boxes start in `ReservedIm`, but if they are protected we ignore the `Im`
-            _ => mk_perm(PermissionUnprot::ReservedIm, PermissionProt::Reserved { had_local_read: false, had_foreign_read: false }),
-        };
+
         let inside = pointee_info.unsafe_cells.freeze_mask(pointee_info.layout, ptr.metadata, vtable_lookup).map(|freeze|
-            if freeze { no_cell_perm } else { cell_perm }
+            perm(/* inside */ true, freeze)
         );
-        let outside = if pointee_info.freeze { no_cell_perm } else { cell_perm };
+        let outside = perm(/* inside */ false, pointee_info.freeze);
 
         Some(ReborrowSettings { protected, inside, outside })
     }

--- a/spec/mem/tree_borrows/state_machine.md
+++ b/spec/mem/tree_borrows/state_machine.md
@@ -31,17 +31,10 @@ impl Permission {
         Ok(())
     }
 
-    fn init_access(self) -> Option<AccessKind> {
-        match self {
-            Permission::Unprot(p) => p.init_access(),
-            Permission::Prot(p) => p.init_access()
-        }
-    }
-
     /// When a protector is released, we transition to the unprotected state machine.
     /// Additionally, we might emit a _protector end access_, depending on our current state.
     /// The second state indicates that access, or is `None` when no access should happen.
-    /// 
+    ///
     /// This method may only be called when a protector is present.
     fn unprotect(self) -> (Permission, Option<AccessKind>) {
         match self {
@@ -73,6 +66,22 @@ impl Permission {
             matches!(self, Permission::Prot(_))
         } else {
             matches!(self, Permission::Unprot(_))
+        }
+    }
+}
+```
+
+When a new node is created, it may cause an implicit (read or write) access.
+This is so the optimizer can insert reads / writes as soon as a reference is created.
+The presence and type of the access depends on the permission.
+The details are defined by the `init_access` function.
+
+```rust
+impl Permission {
+    fn init_access(self) -> Option<AccessKind> {
+        match self {
+            Permission::Unprot(p) => p.init_access(),
+            Permission::Prot(p) => p.init_access()
         }
     }
 }

--- a/spec/mem/tree_borrows/state_machine_protected.md
+++ b/spec/mem/tree_borrows/state_machine_protected.md
@@ -89,8 +89,10 @@ impl PermissionProt {
 
     fn init_access(self) -> Option<AccessKind> {
         // Everything except for `Cell` gets an initial read access.
+        // `Unique` gets an initial write.
         match self {
             PermissionProt::Cell => None,
+            PermissionProt::Unique => Some(AccessKind::Write),
             _ => Some(AccessKind::Read)
         }
     }

--- a/spec/mem/tree_borrows/state_machine_unprotected.md
+++ b/spec/mem/tree_borrows/state_machine_unprotected.md
@@ -83,23 +83,14 @@ impl PermissionUnprot {
         // references, since unprotected references never trigger UB for foreign accesses.
         false
     }
-}
-```
 
-When a new node is created, it causes an implicit access, usually an implicit read.
-This is so the optimizer can insert reads as soon as a reference is created.
-Note that the implicit read is not universal, and depends on the permission.
-The details are defined by the `init_access` function.
-
-```rust
-impl PermissionUnprot {
     fn init_access(self) -> Option<AccessKind> {
         // Everything except for `Cell` gets an initial read access.
+        // We never perform implicit writes for unprotected references.
         match self {
             PermissionUnprot::Cell => None,
             _ => Some(AccessKind::Read)
         }
     }
 }
-
 ```

--- a/tooling/minimize/tests/pass/tree_borrows/no_implicit_writes.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/no_implicit_writes.rs
@@ -1,0 +1,63 @@
+//@ compile-flags: --minirust-tree-borrows
+
+// Copied from the Miri test suite and modified for MiniRust.
+// Shows that without implicit writes, `ptr_write.rs`, `ptr_write_unsafe_cell.rs`,
+// `ptr_write_box.rs`, `as_mut_ptr.rs` would pass.
+
+use std::cell::UnsafeCell;
+
+fn main() {
+    normal();
+    unsafe_cell();
+    box_test();
+    as_mut_ptr_test()
+}
+
+/// passing version of: tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write.rs
+fn normal() {
+    let mut x = 0u8;
+    let ptr = &raw mut x;
+    let res = dereference(&mut x, ptr);
+    let _ = *res;
+}
+
+/// passing version of: tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_unsafe_cell.rs
+fn unsafe_cell() {
+    let mut x: UnsafeCell<u8> = 0u8.into();
+    let ptr = x.get();
+    let res = dereference(&mut x, ptr);
+    let _ = *res.get_mut();
+}
+
+/// passing version of: tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_box.rs
+fn box_test() {
+    let mut x = 0u8;
+    let ptr = &raw mut x;
+    // Use transmute to create a Box without going through Box::new.
+    let b = unsafe { std::mem::transmute::<*mut u8, Box<u8>>(ptr) };
+    let res = dereference(b, ptr);
+    std::mem::forget(res);
+}
+
+fn dereference<T>(x: T, y: *mut u8) -> T {
+    let _ = unsafe { *y };
+    x
+}
+
+/// passing version of: tooling/minimize/tests/ub/tree_borrows/implicit_writes/as_mut_ptr.rs
+fn as_mut_ptr_test() {
+    let mut x: [u8; 3] = [1, 2, 3];
+
+    let ptr = std::ptr::from_mut(&mut x);
+    let a = unsafe { &mut *ptr };
+    let b = unsafe { &mut *ptr };
+
+    let _c = as_mut_ptr(a);
+    let _v = *b;
+}
+
+// This should be the same as the implementation for slice, as this is known to cause errors
+// with implicit writes and we want to test that behavior here.
+pub fn as_mut_ptr(x: &mut [u8; 3]) -> *mut u8 {
+    x as *mut [u8] as *mut u8
+}

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/as_mut_ptr.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/as_mut_ptr.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: --minirust-tree-borrows --minirust-tree-borrows-implicit-writes
+
+// Copied from the Miri test suite and modified for MiniRust.
+// This code no longer works using implicit writes in tree borrows.
+
+fn main() {
+    let mut x: [u8; 3] = [1, 2, 3];
+
+    let ptr = std::ptr::from_mut(&mut x);
+    let a = unsafe { &mut *ptr };
+    let b = unsafe { &mut *ptr };
+
+    let _c = as_mut_ptr(a);
+    let _v = *b;
+}
+
+pub fn as_mut_ptr(x: &mut [u8; 3]) -> *mut u8 {
+    x as *mut [u8] as *mut u8
+}

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/as_mut_ptr.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/as_mut_ptr.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: local read of Disabled reference

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/fnentry_invalidation.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/fnentry_invalidation.rs
@@ -1,0 +1,22 @@
+//@ compile-flags: --minirust-tree-borrows --minirust-tree-borrows-implicit-writes
+
+// Copied from the Miri test suite and modified for MiniRust.
+// This test shows that when implicit writes are enabled, Tree Borrows behaves more like Stacked
+// Borrows, and no additional explicit write is needed to detect UB.
+
+fn main() {
+    let mut x = 0i32;
+    let z = &mut x as *mut i32;
+    x.do_bad();
+    unsafe {
+        let _oof = *z;
+    }
+}
+
+trait Bad {
+    fn do_bad(&mut self) {
+        // who knows
+    }
+}
+
+impl Bad for i32 {}

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/fnentry_invalidation.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/fnentry_invalidation.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: local read of Disabled reference

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: --minirust-tree-borrows --minirust-tree-borrows-implicit-writes
+
+// Copied from the Miri test suite and modified for MiniRust.
+// Tests that UB is detected for reading from a mutable reference by another pointer
+// (as there could be a write on that mutable reference now).
+
+fn main() {
+    let mut x = 0u8;
+    let ptr = &raw mut x;
+    let res = dereference(&mut x, ptr);
+    let _ = *res;
+}
+
+fn dereference<T>(x: T, y: *mut u8) -> T {
+    let _ = unsafe { *y };
+    x
+}

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: foreign read of protected Unique reference

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_box.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_box.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: --minirust-tree-borrows --minirust-tree-borrows-implicit-writes
+
+// Copied from the Miri test suite and modified for MiniRust.
+// Same test as `ptr_write.rs` but with `Box`.
+
+fn main() {
+    let mut x = 0u8;
+    let ptr = &raw mut x;
+    // Use transmute to create a Box without going through Box::new.
+    let b = unsafe { std::mem::transmute::<*mut u8, Box<u8>>(ptr) };
+    let res = dereference(b, ptr);
+    std::mem::forget(res);
+}
+
+fn dereference<T>(x: T, y: *mut u8) -> T {
+    let _ = unsafe { *y };
+    x
+}

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_box.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_box.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: foreign read of protected Unique reference

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_unsafe_cell.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_unsafe_cell.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: --minirust-tree-borrows --minirust-tree-borrows-implicit-writes
+
+// Copied from the Miri test suite and modified for MiniRust.
+// Same test as `ptr_write.rs` but with `UnsafeCell`.
+
+use std::cell::UnsafeCell;
+
+fn main() {
+    let mut x: UnsafeCell<u8> = 0u8.into();
+    let ptr = x.get();
+    let res = dereference(&mut x, ptr);
+    let _ = *res.get_mut();
+}
+
+fn dereference<T>(x: T, y: *mut u8) -> T {
+    let _ = unsafe { *y };
+    x
+}

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_unsafe_cell.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/ptr_write_unsafe_cell.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: foreign read of protected Unique reference

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/static_memory_modification.rs
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/static_memory_modification.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: --minirust-tree-borrows --minirust-tree-borrows-implicit-writes
+
+// Copied from the Miri test suite and modified for MiniRust.
+// Tests that inserting an implicit write to a read-only allocation generates the correct error message.
+
+static X: usize = 5;
+
+#[allow(mutable_transmutes)]
+fn main() {
+    let x = unsafe { std::mem::transmute::<&usize, &mut usize>(&X) };
+    foo(x);
+}
+
+fn foo(_x: &mut usize) {}

--- a/tooling/minimize/tests/ub/tree_borrows/implicit_writes/static_memory_modification.stderr
+++ b/tooling/minimize/tests/ub/tree_borrows/implicit_writes/static_memory_modification.stderr
@@ -1,0 +1,1 @@
+fatal error: UB: Tree Borrows: local write of Frozen reference

--- a/tooling/miniutil/src/cli.rs
+++ b/tooling/miniutil/src/cli.rs
@@ -1,9 +1,12 @@
 //! This module provides utilities for the terminal user-interface.
 //! That is, it bundles common command line argument parsing and error message rendering.
 
-use minirust_rs::{lang::Program, prelude::TerminationInfo};
+use minirust_rs::{lang::Program, mem::TreeBorrowsParams, prelude::TerminationInfo};
 
-use crate::{BasicMem, TreeBorrowMem, run::run_program};
+use crate::{
+    BasicMem, TreeBorrowMem,
+    run::{run_program, run_program_with_config},
+};
 
 pub fn show_error(msg: &impl std::fmt::Display) -> ! {
     eprintln!("fatal error: {msg}");
@@ -15,14 +18,9 @@ macro_rules! show_error {
     ($($tt:tt)*) => {$crate::cli::show_error(&format_args!($($tt)*)) };
 }
 
+#[derive(Default)]
 pub struct MinirustMachineConfig {
-    tree_borrows: bool,
-}
-
-impl Default for MinirustMachineConfig {
-    fn default() -> Self {
-        Self { tree_borrows: false }
-    }
+    tree_borrows: Option<TreeBorrowsParams>,
 }
 
 impl MinirustMachineConfig {
@@ -32,7 +30,16 @@ impl MinirustMachineConfig {
             return false;
         };
         match arg {
-            "tree-borrows" => self.tree_borrows = true,
+            "tree-borrows" => self.tree_borrows = Some(Default::default()),
+            "tree-borrows-implicit-writes" =>
+                self.tree_borrows
+                    .as_mut()
+                    .unwrap_or_else(|| {
+                        show_error!(
+                            "--minirust-tree-borrows must be set before --minirust-tree-borrows-implicit-writes"
+                        )
+                    })
+                    .implicit_writes = true,
             _ => show_error!("Unknown argument --minirust-{arg}!"),
         }
         true
@@ -40,8 +47,8 @@ impl MinirustMachineConfig {
 
     /// Runs the program using [`run_program`]. The memory model/machine is constructed according to this config.
     pub fn run_prog(&self, prog: Program) -> TerminationInfo {
-        if self.tree_borrows {
-            run_program::<TreeBorrowMem>(prog)
+        if let Some(params) = self.tree_borrows {
+            run_program_with_config::<TreeBorrowMem>(prog, params)
         } else {
             run_program::<BasicMem>(prog)
         }

--- a/tooling/miniutil/src/run.rs
+++ b/tooling/miniutil/src/run.rs
@@ -1,25 +1,31 @@
 use crate::{mock_write::MockWrite, *};
 
-/// Run the program and return its TerminationInfo.
+/// Run the program and return its TerminationInfo, using default memory params.
 /// Stdout/stderr are just forwarded to the host.
 pub fn run_program<M: Memory>(prog: Program) -> TerminationInfo {
+    run_program_with_config::<M>(prog, Default::default())
+}
+
+/// Like [`run_program`], but accepts explicit memory parameters.
+/// Stdout/stderr are just forwarded to the host.
+pub fn run_program_with_config<M: Memory>(prog: Program, params: M::Params) -> TerminationInfo {
     let out = std::io::stdout();
     let err = std::io::stderr();
 
-    let res: Result<!, TerminationInfo> = run::<M>(prog, out, err);
+    let res: Result<!, TerminationInfo> = run::<M>(prog, params, out, err);
     match res {
         Ok(never) => never,
         Err(t) => t,
     }
 }
 
-/// Run the program and return stdout as a `Vec<String>`  or a termination info
-/// if it did not terminate correctly. Stderr is just forwarded to the host.
+/// Run the program and return stdout as a `Vec<String>`, using default memory params,
+/// or a termination info if it did not terminate correctly. Stderr is just forwarded to the host.
 pub fn get_stdout<M: Memory>(prog: Program) -> Result<Vec<String>, TerminationInfo> {
     let out = MockWrite::new();
     let err = std::io::stderr();
 
-    let res = run::<M>(prog, out.clone(), err);
+    let res = run::<M>(prog, M::Params::default(), out.clone(), err);
     match res {
         Ok(never) => never,
         Err(TerminationInfo::MachineStop) => Ok(out.into_strings()),
@@ -32,11 +38,13 @@ pub fn get_stdout<M: Memory>(prog: Program) -> Result<Vec<String>, TerminationIn
 /// We fix `BasicMemory` as a memory for now.
 fn run<M: Memory>(
     prog: Program,
+    params: M::Params,
     stdout: impl GcWrite,
     stderr: impl GcWrite,
 ) -> Result<!, TerminationInfo> {
     let res: NdResult<!> = try {
-        let mut machine = Machine::<M>::new(prog, DynWrite::new(stdout), DynWrite::new(stderr))?;
+        let mut machine =
+            Machine::<M>::new(prog, params, DynWrite::new(stdout), DynWrite::new(stderr))?;
 
         loop {
             machine.step()?;


### PR DESCRIPTION
This PR adds support for implicit writes in the tree borrows memory model. It mirrors the changes done in Miri here: https://github.com/rust-lang/miri/pull/4947.

Implicit writes are disabled by default, but can be enabled using a new argument: `--minirust-tree-borrows-implicit-writes`, same as in Miri.
For this some functions had to be changed to enable the passing of parameters.
Most tests for implicit writes were also copied from Miri and modified to work for minirust.