### PR TITLE
tree borrows + implicit writes: #[rustc_no_writable] support

### DIFF
--- a/spec/lang/step/expressions.md
+++ b/spec/lang/step/expressions.md
@@ -170,7 +170,7 @@ impl<M: Memory> Machine<M> {
         // Let the aliasing model know.
         let lookup = self.vtable_lookup();
         let ptr = self.mutate_cur_frame(|frame, mem| {
-            mem.retag_ptr(&mut frame.extra, place.ptr, ptr_ty, /* fn_entry */ false, lookup)
+            mem.retag_ptr(&mut frame.extra, place.ptr, ptr_ty, /* fn_entry */ false, /* fn_implicit_writes */ true, lookup)
         })?;
         
         ret((Value::Ptr(ptr), Type::Ptr(ptr_ty)))

--- a/spec/lang/step/statements.md
+++ b/spec/lang/step/statements.md
@@ -102,7 +102,7 @@ impl<M: Memory> Machine<M> {
             // base case
             (Value::Ptr(ptr), Type::Ptr(ptr_type)) => {
                 let lookup = self.vtable_lookup();
-                let val = self.mutate_cur_frame(|frame, mem| { mem.retag_ptr(&mut frame.extra, ptr, ptr_type, fn_entry, lookup) })?;
+                let val = self.mutate_cur_frame(|frame, mem| { mem.retag_ptr(&mut frame.extra, ptr, ptr_type, fn_entry, frame.func.implicit_writes, lookup) })?;
                 Value::Ptr(val)
             }
             // recurse into tuples/arrays/enums

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -487,6 +487,9 @@ pub struct Function {
     pub blocks: Map<BbName, BasicBlock>,
     /// The basic block where execution starts.
     pub start: BbName,
+
+    /// Whether implicit writes are enabled for this function.
+    pub implicit_writes: bool,
 }
 
 /// A basic block is a sequence of statements followed by a terminator.

--- a/spec/mem/concurrent.md
+++ b/spec/mem/concurrent.md
@@ -104,9 +104,10 @@ impl<M: Memory> ConcurrentMemory<M> {
         ptr: Pointer<M::Provenance>,
         ptr_type: PtrType,
         fn_entry: bool,
+        fn_implicit_writes: bool, // wether implicit_writes are enabled for the currently evaluated function, or not
         vtable_lookup: impl Fn(ThinPointer<M::Provenance>) -> crate::lang::VTable + 'static,
     ) -> Result<Pointer<M::Provenance>> {
-        self.memory.retag_ptr(frame_extra, ptr, ptr_type, fn_entry, vtable_lookup)
+        self.memory.retag_ptr(frame_extra, ptr, ptr_type, fn_entry, fn_implicit_writes, vtable_lookup)
     }
 
     /// Memory model hook invoked at the end of each function call.

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -142,6 +142,7 @@ pub trait Memory {
         ptr: Pointer<Self::Provenance>,
         _ptr_type: PtrType,
         _fn_entry: bool,
+        _fn_implicit_writes: bool,
         _vtable_lookup: impl Fn(ThinPointer<Self::Provenance>) -> crate::lang::VTable + 'static,
     ) -> Result<Pointer<Self::Provenance>> {
         ret(ptr)

--- a/spec/mem/tree_borrows/memory.md
+++ b/spec/mem/tree_borrows/memory.md
@@ -9,6 +9,7 @@ Similar to the [Basic Memory Model](../basic.md), we need to first define some b
 the core date structure managing the tree is defined in [tree.md](tree.md), and the core state machine can be found in [state_machine.md](state_machine.md).
 
 The model then tracks a tree for each allocation:
+
 ```rust
 struct TreeBorrowsAllocationExtra {
     root: Node,
@@ -17,6 +18,7 @@ struct TreeBorrowsAllocationExtra {
 
 We use a *path* to identify each node and track its location in the tree. A path is represented as a list of indices $[i_1, i_2, ..., i_k]$, where each index indicates which branch to take next.
 Below is an illustrated example:
+
 ```
 Consider the following tree
       A
@@ -242,9 +244,10 @@ impl<T: Target> Memory for TreeBorrowsMemory<T> {
         ptr: Pointer<Self::Provenance>,
         ptr_type: PtrType,
         fn_entry: bool,
+        fn_implicit_writes: bool, // wether implicit_writes are enabled for the currently evaluated function, or not
         vtable_lookup: impl Fn(ThinPointer<Self::Provenance>) -> crate::lang::VTable + 'static,
     ) -> Result<Pointer<Self::Provenance>> {
-        ret(if let Some(perms) = ReborrowSettings::new(ptr, ptr_type, fn_entry, self.params, vtable_lookup) {
+        ret(if let Some(perms) = ReborrowSettings::new(ptr, ptr_type, fn_entry, self.params, fn_implicit_writes, vtable_lookup) {
             self.reborrow(ptr.thin_pointer, perms, frame_extra)?.widen(ptr.metadata)
         } else {
             ptr

--- a/spec/mem/tree_borrows/reborrow_settings.md
+++ b/spec/mem/tree_borrows/reborrow_settings.md
@@ -94,6 +94,7 @@ impl ReborrowSettings {
         ptr_type: PtrType,
         fn_entry: bool,
         params: TreeBorrowsParams,
+        fn_implicit_writes: bool, // wether implicit_writes are enabled for the currently evaluated function, or not
         vtable_lookup: impl Fn(ThinPointer<TreeBorrowsProvenance>) -> crate::lang::VTable + 'static,
     ) -> Option<Self> {
         // Returns None for `Raw`, `FnPtr` and `VTablePtr`, so `ptr_type` can only be `Ref` and `Box` from here.
@@ -117,8 +118,9 @@ impl ReborrowSettings {
             Protected::No
         };
 
-        // Implicit writes are only performed for protected references, and only if globally enabled.
-        let implicit_writes_enabled = protected.yes() && params.implicit_writes;
+        // Implicit writes are performed for protected references, only if globally enabled (`params.implicit_writes`),
+        // and only if the function has not opted out via the `#[rustc_no_writable]` attribute (`fn_implicit_writes`).
+        let implicit_writes_enabled = protected.yes() && params.implicit_writes && fn_implicit_writes;
 
         // Helper to compute the permission, given whether it is inside the pointee and whether it is frozen.
         let perm = |inside: bool, frozen: bool| {

--- a/tooling/minimize/src/function.rs
+++ b/tooling/minimize/src/function.rs
@@ -27,6 +27,9 @@ pub struct FnCtxt<'cx, 'tcx> {
 
     pub locals: Map<LocalName, Type>,
     pub blocks: Map<BbName, BasicBlock>,
+
+    /// Whether implicit writes are enabled. Set to false if the function has `#[rustc_no_writable]`.
+    implicit_writes: bool,
 }
 
 impl<'cx, 'tcx> std::ops::Deref for FnCtxt<'cx, 'tcx> {
@@ -46,6 +49,7 @@ impl<'cx, 'tcx> std::ops::DerefMut for FnCtxt<'cx, 'tcx> {
 impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
     pub fn new(instance: rs::Instance<'tcx>, cx: &'cx mut Ctxt<'tcx>) -> Self {
         let body = cx.tcx.instance_mir(instance.def);
+        let implicit_writes = !rustc_hir::find_attr!(cx.tcx, instance.def_id(), RustcNoWritable);
         // We eagerly instantiate everything upfront once.
         // Then nothing else has to worry about generics.
         let body = cx.tcx.instantiate_and_normalize_erasing_regions(
@@ -70,6 +74,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             locals_smir,
             next_bb: 0,
             next_local: 0,
+            implicit_writes,
         }
     }
 
@@ -197,6 +202,7 @@ impl<'cx, 'tcx> FnCtxt<'cx, 'tcx> {
             blocks: self.blocks,
             start: init_bb,
             calling_convention: translate_calling_convention(self.abi.conv),
+            implicit_writes: self.implicit_writes,
         };
 
         f

--- a/tooling/minimize/src/program.rs
+++ b/tooling/minimize/src/program.rs
@@ -235,5 +235,6 @@ fn mk_start_fn(entry: u32) -> Function {
         blocks,
         start: b0_name,
         calling_convention: CallingConvention::C,
+        implicit_writes: true,
     }
 }

--- a/tooling/minimize/tests/pass/tree_borrows/rustc_no_writable_on_as_mut_ptr.rs
+++ b/tooling/minimize/tests/pass/tree_borrows/rustc_no_writable_on_as_mut_ptr.rs
@@ -1,0 +1,23 @@
+//@ compile-flags: --minirust-tree-borrows --minirust-tree-borrows-implicit-writes
+#![allow(internal_features)]
+#![feature(rustc_attrs)]
+
+// Same code as `ub/tree_borrows/implicit_writes/as_mut_ptr.rs`, but with
+// `#[rustc_no_writable]` on `as_mut_ptr`. This disables implicit writes for
+// that function, so no UB occurs.
+
+fn main() {
+    let mut x: [u8; 3] = [1, 2, 3];
+
+    let ptr = std::ptr::from_mut(&mut x);
+    let a = unsafe { &mut *ptr };
+    let b = unsafe { &mut *ptr };
+
+    let _c = as_mut_ptr(a);
+    let _v = *b;
+}
+
+#[rustc_no_writable]
+pub fn as_mut_ptr(x: &mut [u8; 3]) -> *mut u8 {
+    x as *mut [u8] as *mut u8
+}

--- a/tooling/miniutil/src/build/function.rs
+++ b/tooling/miniutil/src/build/function.rs
@@ -82,6 +82,7 @@ pub fn function(ret: Ret, num_args: usize, locals: &[Type], bbs: &[BasicBlock]) 
         start,
         // For now we use the C ABI for everything since that's what `spawn` needs...
         calling_convention: CallingConvention::C,
+        implicit_writes: true,
     }
 }
 

--- a/tooling/miniutil/src/build/mod.rs
+++ b/tooling/miniutil/src/build/mod.rs
@@ -160,6 +160,7 @@ pub struct FunctionBuilder {
     start: BbName,
     ret: Option<LocalName>,
     conv: CallingConvention,
+    implicit_writes: bool,
 
     cur_block: Option<CurBlock>,
 
@@ -177,6 +178,7 @@ impl FunctionBuilder {
             start: BbName(Name::from_internal(0)),
             ret: None,
             conv: CallingConvention::Rust,
+            implicit_writes: true,
             cur_block: None,
             next_block: 0,
             next_local: 0,
@@ -232,6 +234,7 @@ impl FunctionBuilder {
             calling_convention: self.conv,
             blocks: self.blocks,
             start: self.start,
+            implicit_writes: self.implicit_writes,
         }
     }
 
@@ -282,6 +285,10 @@ impl FunctionBuilder {
     /// Change the calling convention of the current function.
     pub fn set_conv(&mut self, conv: CallingConvention) {
         self.conv = conv;
+    }
+
+    pub fn set_implicit_writes(&mut self, implicit_writes: bool) {
+        self.implicit_writes = implicit_writes;
     }
 
     /// Build one or multiple cleanup blocks. The name of the first block is returned.


### PR DESCRIPTION
This PR adds support for `#[rustc_no_writable]` for implicit writes under Tree Borrows.
It depends on, and is blocked by https://github.com/minirust/minirust/pull/290 and https://github.com/minirust/minirust/pull/297.

The `#[rustc_no_writable]` attribute disables the passing of the `writable` LLVM flag in rustc, and disables the checking for implicit writes in Miri. The same is now done for MiniRust. A test has been added to demonstrate this behaviour (`tooling/minimize/tests/pass/tree_borrows/no_implicit_writes_attribute.rs`). If the attribute is set, implicit-write checking is disabled for the function it belongs to.