### PR TITLE
use env bash for NixOS compatibility

### DIFF
--- a/mini
+++ b/mini
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Helper script for working with MiniRust.
 # Usage:
 # - `./mini test`: run the test suite

--- a/tooling/minimize/cov.sh
+++ b/tooling/minimize/cov.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUSTFLAGS="-C instrument-coverage" cargo t
 llvm-profdata merge -sparse $(find -name "*.profraw") -o out.profdata

--- a/tooling/minimize/tests/rust.sh
+++ b/tooling/minimize/tests/rust.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is used run a test using `rustc` instead of `minimize`.
 

--- a/tooling/minitest/cov.sh
+++ b/tooling/minitest/cov.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUSTFLAGS="-C instrument-coverage" cargo test --tests
 llvm-profdata merge -sparse $(find -name "*.profraw") -o out.profdata


### PR DESCRIPTION
I modified all script files to use `#!/usr/bin/env bash` instead of `#!/bin/bash`. This has the same behaviour on most systems, but `#!/bin/bash` doesn't work on NixOS, while the new version does.