### PR TITLE
Bump rust

### DIFF
--- a/mini
+++ b/mini
@@ -9,7 +9,7 @@ set -e
 ## The part that is always needed
 
 # Fixed specr-transpile version
-SPECR_VERSION="0.1.40"
+SPECR_VERSION="0.1.41"
 
 # Stricter checks on CI
 if [ -n "$CI" ]; then

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-04-01"
+channel = "nightly-2026-05-01"
 components = [ "rustfmt", "rust-src", "rustc-dev", "llvm-tools-preview" ]

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "libspecr"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbcdd154754d8773b3711e76364ff46b61c672ec6f25a758eb7da47d9ba04c0"
+checksum = "a3c0c46f39513f6c4b533ec6bea7d623f6761fd0a610b1152db7f2e4dd385a61"
 dependencies = [
  "gccompat-derive",
  "im",

--- a/tooling/minimize/src/ty.rs
+++ b/tooling/minimize/src/ty.rs
@@ -1,3 +1,5 @@
+use rustc_middle::ty::Unnormalized;
+
 use crate::*;
 
 impl<'tcx> Ctxt<'tcx> {
@@ -153,6 +155,8 @@ impl<'tcx> Ctxt<'tcx> {
                     Vec::new()
                 }
             }
+            // pattern types do not affect the UnsafeCell positions
+            rs::TyKind::Pat(ty, _) => self.cells_in_sized_ty(*ty, span),
             x => rs::span_bug!(span, "cells_in_sized_ty: TyKind not supported: {x:?}"),
         }
     }
@@ -277,7 +281,9 @@ impl<'tcx> Ctxt<'tcx> {
                 let ty = field.ty(self.tcx, sref);
                 // Field types can be non-normalized even if the ADT type was normalized
                 // (due to associated types on the fields).
-                let ty = self.tcx.normalize_erasing_regions(self.typing_env(), ty);
+                let ty = self
+                    .tcx
+                    .normalize_erasing_regions(self.typing_env(), Unnormalized::new_wip(ty));
                 let ty = self.translate_ty(ty, span);
                 let offset = match shape {
                     Some(shape) => shape.offset(i.into()),


### PR DESCRIPTION
This bumps the rust version used to `nightly-2026-05-01`.
This is needed as a future PR will use features that have only been introduced then.
For the version increase to work, the specr version also needed to be updated.